### PR TITLE
fix: Add missing abandon keymap help to short help row

### DIFF
--- a/internal/ui/revisions/keymap.go
+++ b/internal/ui/revisions/keymap.go
@@ -104,7 +104,7 @@ func (k *keymap) resetMode() {
 func (k *keymap) ShortHelp() []key.Binding {
 	switch b := k.bindings[k.current].(type) {
 	case baseLayer:
-		return []key.Binding{k.up, k.down, b.revset, b.new, b.edit, b.diffedit, b.diff, b.description, b.split, b.rebaseMode, b.gitMode, b.bookmarkMode, b.quit}
+		return []key.Binding{k.up, k.down, b.revset, b.new, b.edit, b.diffedit, b.diff, b.abandon, b.description, b.split, b.rebaseMode, b.gitMode, b.bookmarkMode, b.quit}
 	case rebaseLayer:
 		return []key.Binding{b.revision, b.branch}
 	case gitLayer:


### PR DESCRIPTION
This PR adds the missing keymap short help for the abandon operation. The remaining operations should already be present in the short help row.