### PR TITLE
rename modules to allow remote go install

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,12 @@ You can build `jjui` from source.
 ```
 git clone https://github.com/idursun/jjui.git
 cd jjui
-go install cmd/jjui.go
+go install cmd/jjui/main.go
+```
+
+### From go install
+```
+go install github.com/idursun/jjui/cmd/jjui@latest
 ```
 
 ### From pre-built binaries

--- a/cmd/jjui/main.go
+++ b/cmd/jjui/main.go
@@ -2,10 +2,11 @@ package main
 
 import (
 	"fmt"
-	tea "github.com/charmbracelet/bubbletea"
-	"jjui/internal/jj"
-	"jjui/internal/ui"
 	"os"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/idursun/jjui/internal/jj"
+	"github.com/idursun/jjui/internal/ui"
 )
 
 var Version = "unknown"

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module jjui
+module github.com/idursun/jjui
 
 go 1.22
 

--- a/internal/ui/abandon/abandon.go
+++ b/internal/ui/abandon/abandon.go
@@ -1,8 +1,8 @@
 package abandon
 
 import (
-	"jjui/internal/ui/common"
-	"jjui/internal/ui/confirmation"
+	"github.com/idursun/jjui/internal/ui/common"
+	"github.com/idursun/jjui/internal/ui/confirmation"
 
 	tea "github.com/charmbracelet/bubbletea"
 )

--- a/internal/ui/bookmark/bookmarks.go
+++ b/internal/ui/bookmark/bookmarks.go
@@ -5,7 +5,7 @@ import (
 	"io"
 	"strings"
 
-	"jjui/internal/ui/common"
+	"github.com/idursun/jjui/internal/ui/common"
 
 	"github.com/charmbracelet/bubbles/list"
 	tea "github.com/charmbracelet/bubbletea"

--- a/internal/ui/bookmark/set.go
+++ b/internal/ui/bookmark/set.go
@@ -3,7 +3,7 @@ package bookmark
 import (
 	"github.com/charmbracelet/bubbles/textarea"
 	tea "github.com/charmbracelet/bubbletea"
-	"jjui/internal/ui/common"
+	"github.com/idursun/jjui/internal/ui/common"
 )
 
 type SetBookmarkModel struct {

--- a/internal/ui/bookmark/set_test.go
+++ b/internal/ui/bookmark/set_test.go
@@ -2,12 +2,14 @@ package bookmark
 
 import (
 	"bytes"
-	tea "github.com/charmbracelet/bubbletea"
-	"github.com/charmbracelet/x/exp/teatest"
-	"jjui/internal/ui/common"
-	"jjui/test"
 	"testing"
 	"time"
+
+	"github.com/idursun/jjui/test"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/x/exp/teatest"
+	"github.com/idursun/jjui/internal/ui/common"
 )
 
 func TestSetBookmarkModel_Update(t *testing.T) {

--- a/internal/ui/common/commands.go
+++ b/internal/ui/common/commands.go
@@ -1,9 +1,10 @@
 package common
 
 import (
-	"github.com/charmbracelet/bubbletea"
-	"jjui/internal/jj"
 	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/idursun/jjui/internal/jj"
 )
 
 type UICommands struct {
@@ -63,7 +64,7 @@ func (c UICommands) FetchRevisions(revset string) tea.Cmd {
 func (c UICommands) FetchBookmarks(revision string) tea.Cmd {
 	return func() tea.Msg {
 		cmd := c.jj.ListBookmark(revision)
-		//TODO: handle error
+		// TODO: handle error
 		output, _ := cmd.CombinedOutput()
 		var bookmarks []string
 		lines := strings.Split(string(output), "\n")

--- a/internal/ui/common/msgs.go
+++ b/internal/ui/common/msgs.go
@@ -1,9 +1,10 @@
 package common
 
 import (
-	tea "github.com/charmbracelet/bubbletea"
-	"jjui/internal/jj"
 	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/idursun/jjui/internal/jj"
 )
 
 type (
@@ -98,7 +99,7 @@ func RunCommand(c jj.Command, continuations ...tea.Cmd) tea.Cmd {
 		func() tea.Msg {
 			_, err := c.CombinedOutput()
 			return CommandCompletedMsg{
-				//Output: string(output),
+				// Output: string(output),
 				Err: err,
 			}
 		})

--- a/internal/ui/confirmation/confirmation.go
+++ b/internal/ui/confirmation/confirmation.go
@@ -1,10 +1,11 @@
 package confirmation
 
 import (
-	"github.com/charmbracelet/lipgloss"
 	"strings"
 
-	"jjui/internal/ui/common"
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/idursun/jjui/internal/ui/common"
 
 	tea "github.com/charmbracelet/bubbletea"
 )
@@ -22,11 +23,14 @@ type Model struct {
 	selected int
 }
 
-var textStyle = lipgloss.NewStyle().Bold(true).Foreground(common.Magenta)
-var normalStyle = lipgloss.NewStyle().
-	Foreground(common.White).
-	PaddingLeft(2).
-	PaddingRight(2)
+var (
+	textStyle   = lipgloss.NewStyle().Bold(true).Foreground(common.Magenta)
+	normalStyle = lipgloss.NewStyle().
+			Foreground(common.White).
+			PaddingLeft(2).
+			PaddingRight(2)
+)
+
 var selectedStyle = lipgloss.NewStyle().
 	Foreground(common.DarkWhite).
 	Background(common.Blue).

--- a/internal/ui/describe/describe.go
+++ b/internal/ui/describe/describe.go
@@ -3,7 +3,7 @@ package describe
 import (
 	"github.com/charmbracelet/bubbles/textarea"
 	tea "github.com/charmbracelet/bubbletea"
-	"jjui/internal/ui/common"
+	"github.com/idursun/jjui/internal/ui/common"
 )
 
 type Model struct {

--- a/internal/ui/describe/describe_test.go
+++ b/internal/ui/describe/describe_test.go
@@ -2,13 +2,15 @@ package describe
 
 import (
 	"bytes"
-	tea "github.com/charmbracelet/bubbletea"
-	"github.com/charmbracelet/x/exp/teatest"
-	"github.com/stretchr/testify/assert"
-	"jjui/internal/ui/common"
-	"jjui/test"
 	"testing"
 	"time"
+
+	"github.com/idursun/jjui/test"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/x/exp/teatest"
+	"github.com/idursun/jjui/internal/ui/common"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestCancel(t *testing.T) {

--- a/internal/ui/diff/diff.go
+++ b/internal/ui/diff/diff.go
@@ -1,7 +1,7 @@
 package diff
 
 import (
-	"jjui/internal/ui/common"
+	"github.com/idursun/jjui/internal/ui/common"
 
 	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"

--- a/internal/ui/revisions/details/details.go
+++ b/internal/ui/revisions/details/details.go
@@ -2,13 +2,14 @@ package details
 
 import (
 	"fmt"
+	"io"
+
 	"github.com/charmbracelet/bubbles/key"
 	"github.com/charmbracelet/bubbles/list"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
-	"io"
-	"jjui/internal/ui/common"
-	"jjui/internal/ui/confirmation"
+	"github.com/idursun/jjui/internal/ui/common"
+	"github.com/idursun/jjui/internal/ui/confirmation"
 )
 
 var (

--- a/internal/ui/revisions/details/details_test.go
+++ b/internal/ui/revisions/details/details_test.go
@@ -2,12 +2,14 @@ package details
 
 import (
 	"bytes"
-	tea "github.com/charmbracelet/bubbletea"
-	"github.com/charmbracelet/x/exp/teatest"
-	"jjui/internal/ui/common"
-	"jjui/test"
 	"testing"
 	"time"
+
+	"github.com/idursun/jjui/test"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/x/exp/teatest"
+	"github.com/idursun/jjui/internal/ui/common"
 )
 
 const (

--- a/internal/ui/revisions/renderer.go
+++ b/internal/ui/revisions/renderer.go
@@ -2,9 +2,10 @@ package revisions
 
 import (
 	"fmt"
-	"jjui/internal/jj"
-	"jjui/internal/ui/common"
 	"strings"
+
+	"github.com/idursun/jjui/internal/jj"
+	"github.com/idursun/jjui/internal/ui/common"
 
 	tea "github.com/charmbracelet/bubbletea"
 )

--- a/internal/ui/revisions/revisions.go
+++ b/internal/ui/revisions/revisions.go
@@ -2,16 +2,17 @@ package revisions
 
 import (
 	"fmt"
-	"jjui/internal/ui/confirmation"
 	"slices"
 
-	"jjui/internal/jj"
-	"jjui/internal/ui/abandon"
-	"jjui/internal/ui/bookmark"
-	"jjui/internal/ui/common"
-	"jjui/internal/ui/describe"
-	"jjui/internal/ui/revisions/details"
-	"jjui/internal/ui/revisions/revset"
+	"github.com/idursun/jjui/internal/ui/confirmation"
+
+	"github.com/idursun/jjui/internal/jj"
+	"github.com/idursun/jjui/internal/ui/abandon"
+	"github.com/idursun/jjui/internal/ui/bookmark"
+	"github.com/idursun/jjui/internal/ui/common"
+	"github.com/idursun/jjui/internal/ui/describe"
+	"github.com/idursun/jjui/internal/ui/revisions/details"
+	"github.com/idursun/jjui/internal/ui/revisions/revset"
 
 	"github.com/charmbracelet/bubbles/key"
 	tea "github.com/charmbracelet/bubbletea"

--- a/internal/ui/revisions/revset/revset.go
+++ b/internal/ui/revisions/revset/revset.go
@@ -2,14 +2,15 @@ package revset
 
 import (
 	"fmt"
+	"strings"
+	"unicode"
+
 	"github.com/charmbracelet/bubbles/help"
 	"github.com/charmbracelet/bubbles/key"
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
-	"jjui/internal/ui/common"
-	"strings"
-	"unicode"
+	"github.com/idursun/jjui/internal/ui/common"
 )
 
 var allowedFunctions = []string{
@@ -95,8 +96,10 @@ type Model struct {
 	keymap        keymap
 }
 
-var promptStyle = common.DefaultPalette.CommitShortStyle
-var cursorStyle = common.DefaultPalette.Empty
+var (
+	promptStyle = common.DefaultPalette.CommitShortStyle
+	cursorStyle = common.DefaultPalette.Empty
+)
 
 type keymap struct{}
 
@@ -109,6 +112,7 @@ func (k keymap) ShortHelp() []key.Binding {
 		key.NewBinding(key.WithKeys("esc"), key.WithHelp("esc", "quit")),
 	}
 }
+
 func (k keymap) FullHelp() [][]key.Binding {
 	return [][]key.Binding{k.ShortHelp()}
 }

--- a/internal/ui/revisions/revset/revset_test.go
+++ b/internal/ui/revisions/revset/revset_test.go
@@ -1,9 +1,10 @@
 package revset
 
 import (
+	"testing"
+
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestSignatureHelp(t *testing.T) {
@@ -21,7 +22,6 @@ func TestSignatureHelp(t *testing.T) {
 			model.textInput.SetValue(test.input)
 			m, _ := model.Update(tea.KeyLeft)
 			assert.Contains(t, m.signatureHelp, test.expected)
-
 		})
 	}
 }

--- a/internal/ui/status/status.go
+++ b/internal/ui/status/status.go
@@ -2,7 +2,7 @@ package status
 
 import (
 	"github.com/charmbracelet/lipgloss"
-	"jjui/internal/ui/common"
+	"github.com/idursun/jjui/internal/ui/common"
 
 	"github.com/charmbracelet/bubbles/spinner"
 	tea "github.com/charmbracelet/bubbletea"
@@ -16,8 +16,10 @@ type Model struct {
 	error   error
 }
 
-var successStyle = lipgloss.NewStyle().Foreground(common.Green)
-var errorStyle = lipgloss.NewStyle().Foreground(common.Red)
+var (
+	successStyle = lipgloss.NewStyle().Foreground(common.Green)
+	errorStyle   = lipgloss.NewStyle().Foreground(common.Red)
+)
 
 func (m Model) Init() tea.Cmd {
 	return nil
@@ -30,7 +32,7 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 		m.running = true
 		return m, m.spinner.Tick
 	case common.CommandCompletedMsg:
-		//m.command = ""
+		// m.command = ""
 		m.running = false
 		m.output = msg.Output
 		m.error = msg.Err

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -1,13 +1,14 @@
 package ui
 
 import (
-	"jjui/internal/jj"
 	"strings"
 
-	"jjui/internal/ui/common"
-	"jjui/internal/ui/diff"
-	"jjui/internal/ui/revisions"
-	"jjui/internal/ui/status"
+	"github.com/idursun/jjui/internal/jj"
+
+	"github.com/idursun/jjui/internal/ui/common"
+	"github.com/idursun/jjui/internal/ui/diff"
+	"github.com/idursun/jjui/internal/ui/revisions"
+	"github.com/idursun/jjui/internal/ui/status"
 
 	"github.com/charmbracelet/bubbles/help"
 	tea "github.com/charmbracelet/bubbletea"

--- a/test/parse_test.go
+++ b/test/parse_test.go
@@ -1,11 +1,12 @@
 package test
 
 import (
-	"github.com/stretchr/testify/assert"
-	"jjui/internal/jj"
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/idursun/jjui/internal/jj"
+	"github.com/stretchr/testify/assert"
 )
 
 func Test_Parse_Line(t *testing.T) {

--- a/test/shell.go
+++ b/test/shell.go
@@ -2,7 +2,7 @@ package test
 
 import (
 	tea "github.com/charmbracelet/bubbletea"
-	"jjui/internal/ui/common"
+	"github.com/idursun/jjui/internal/ui/common"
 )
 
 type model struct {

--- a/test/test_commands.go
+++ b/test/test_commands.go
@@ -1,10 +1,11 @@
 package test
 
 import (
-	"github.com/stretchr/testify/assert"
-	"jjui/internal/jj"
 	"os/exec"
 	"testing"
+
+	"github.com/idursun/jjui/internal/jj"
+	"github.com/stretchr/testify/assert"
 )
 
 type JJCommands struct {
@@ -35,17 +36,17 @@ func (m *MockedCommand) Args() []string {
 }
 
 func (t *JJCommands) GetConfig(key string) ([]byte, error) {
-	//TODO implement me
+	// TODO implement me
 	panic("implement me")
 }
 
 func (t *JJCommands) RebaseCommand(from string, to string) jj.Command {
-	//TODO implement me
+	// TODO implement me
 	panic("implement me")
 }
 
 func (t *JJCommands) RebaseBranchCommand(from string, to string) jj.Command {
-	//TODO implement me
+	// TODO implement me
 	panic("implement me")
 }
 
@@ -60,7 +61,7 @@ func (t *JJCommands) SetDescription(rev string, description string) jj.Command {
 }
 
 func (t *JJCommands) ListBookmark(revision string) jj.Command {
-	//TODO implement me
+	// TODO implement me
 	panic("implement me")
 }
 
@@ -74,52 +75,52 @@ func (t *JJCommands) SetBookmark(revision string, name string) jj.Command {
 }
 
 func (t *JJCommands) MoveBookmark(revision string, bookmark string) jj.Command {
-	//TODO implement me
+	// TODO implement me
 	panic("implement me")
 }
 
 func (t *JJCommands) DeleteBookmark(bookmark string) jj.Command {
-	//TODO implement me
+	// TODO implement me
 	panic("implement me")
 }
 
 func (t *JJCommands) GitFetch() jj.Command {
-	//TODO implement me
+	// TODO implement me
 	panic("implement me")
 }
 
 func (t *JJCommands) GitPush() jj.Command {
-	//TODO implement me
+	// TODO implement me
 	panic("implement me")
 }
 
 func (t *JJCommands) Diff(revision string, fineName string) jj.Command {
-	//TODO implement me
+	// TODO implement me
 	panic("implement me")
 }
 
 func (t *JJCommands) Edit(revision string) jj.Command {
-	//TODO implement me
+	// TODO implement me
 	panic("implement me")
 }
 
 func (t *JJCommands) DiffEdit(revision string) jj.Command {
-	//TODO implement me
+	// TODO implement me
 	panic("implement me")
 }
 
 func (t *JJCommands) Abandon(revision string) jj.Command {
-	//TODO implement me
+	// TODO implement me
 	panic("implement me")
 }
 
 func (t *JJCommands) New(from string) jj.Command {
-	//TODO implement me
+	// TODO implement me
 	panic("implement me")
 }
 
 func (t *JJCommands) Undo() jj.Command {
-	//TODO implement me
+	// TODO implement me
 	panic("implement me")
 }
 
@@ -142,12 +143,12 @@ func (t *JJCommands) ExpectSplit(tt *testing.T, revision string, files []string)
 }
 
 func (t *JJCommands) GetCommits(revset string) ([]jj.GraphRow, error) {
-	//TODO implement me
+	// TODO implement me
 	panic("implement me")
 }
 
 func (t *JJCommands) Squash(from string, destination string) jj.Command {
-	//TODO implement me
+	// TODO implement me
 	panic("implement me")
 }
 


### PR DESCRIPTION
I would like to install JJUI via `go install` (and, actually via [mise's Go backend](https://mise.jdx.dev/dev-tools/backends/go.html)https://[mise.jdx.dev/dev-tools/backends/go.html](https://mise.jdx.dev/dev-tools/backends/go.html)) but I cant because the module is named just `jjui` rather than `github.com/idursun/jjui`

This PR should allow for installing via either.