### PR TITLE
Adding nix flake.

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,13 @@ You can install `jjui` using nix from the unstable channel.
 
 ```shell
 nix-env -iA nixpkgs.jjui
+
+If you need to use a particular branch/revision that
+has not yet landed into nixpkgs. You can install it via
+our provided flake.
+
+```shell
+nix profile install github:idursun/jjui/main
 ```
 
 ### From go install

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,77 @@
+{
+  "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1743550720,
+        "narHash": "sha256-hIshGgKZCgWh6AYJpJmRgFdR3WUbkY04o82X05xqQiY=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "c621e8422220273271f52058f618c94e405bb0f5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1743938762,
+        "narHash": "sha256-UgFYn8sGv9B8PoFpUfCa43CjMZBl1x/ShQhRDHBFQdI=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "74a40410369a1c35ee09b8a1abee6f4acbedc059",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1743296961,
+        "narHash": "sha256-b1EdN3cULCqtorQ4QeWgLMrd5ZGOjLSLemfa00heasc=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "e4822aea2a6d1cdd36653c134cacfd64c97ff4fa",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs",
+        "systems": "systems"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,9 @@
+{
+  inputs = {
+    systems.url = "github:nix-systems/default";
+    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+    flake-parts.url = "github:hercules-ci/flake-parts";
+  };
+
+  outputs = inputs: inputs.flake-parts.lib.mkFlake { inherit inputs; } ./nix;
+}

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,0 +1,31 @@
+{ inputs, ... }:
+{
+  systems = import inputs.systems;
+
+  flake.overlays.default = final: _prev: {
+    jjui = inputs.self.packages.${final.system}.jjui;
+  };
+
+  perSystem =
+    { pkgs, ... }:
+    let
+      jjui = pkgs.buildGoModule rec {
+        name = "jjui";
+        src = ./..;
+        vendorHash = builtins.readFile ./vendor-hash;
+        meta.mainProgram = "jjui";
+      };
+
+    in
+    {
+      packages.default = jjui;
+      packages.jjui = jjui;
+
+      devShells.default = pkgs.mkShell {
+        nativeBuildInputs = [
+          pkgs.go
+          pkgs.gopls
+        ];
+      };
+    };
+}

--- a/nix/vendor-hash
+++ b/nix/vendor-hash
@@ -1,0 +1,1 @@
+sha256-YlOK+NvyH/3uvvFcCZixv2+Y2m26TP8+ohUSdl3ppro=


### PR DESCRIPTION
jjui is already on nixpkgs. However as jjui evolves, it might be possible that people might want to try a fresh release without having to wait on it being available on nixpkgs. We now provide a simple flake for just that.

jjui can be run directly with:

```shell
nix run github:idursun/jjui
```

or added as an input on their flakes.


We also provide a minimal development shell for those wanting to contribute back to jjui.