### PR TITLE
chore(nix): Add flake check GH action.

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,0 +1,15 @@
+name: nix flake check
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  flake-check:
+    name: nix flake check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cachix/install-nix-action@v30
+      - run: nix flake check


### PR DESCRIPTION
Just to make sure that jjui is buildable with nix.

Previously, if we added a new Go dependency, we
wont notice the vendored-hash mismatch, since CI was not testing with nix.

Now we make sure that the package builds correctly under nix.