### PR TITLE
fix: allow build version to be set from ldflags

### DIFF
--- a/cmd/jjui/main.go
+++ b/cmd/jjui/main.go
@@ -15,13 +15,18 @@ import (
 	"github.com/idursun/jjui/internal/ui"
 )
 
-var Version = "unknown"
+var Version string
 
 func getVersion() string {
+	if Version != "" {
+		// set explicitly from build flags
+		return Version
+	}
 	if info, ok := debug.ReadBuildInfo(); ok && info.Main.Version != "" {
+		// obtained by go build, usually from VCS
 		return info.Main.Version
 	}
-	return Version
+	return "unknown"
 }
 
 var (


### PR DESCRIPTION
When building from a standalone VCS-free tarball of the repo, info.Main.Version is `(devel)`, not `""`.
This fix first check if main.Version has been set by the build options, then default to get the version info embedded by go.

This is necessary for  #72.