### PR TITLE
Update instruction on installation for archlinux-based linux distros

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,16 @@ The latest release of `jjui` is available on Homebrew core:
 brew install jjui
 ```
 
+### Archlinux
+
+The built `jjui` binary from latest release is available on the AUR:
+
+```shell
+paru -S jjui-bin
+# OR
+yay -S jjui-bin
+```
+
 ### Nix
 
 You can install `jjui` using nix from the unstable channel.


### PR DESCRIPTION
This PR updates the README to include installation instruction for archlinux-based distros.

Thank you for the great work of `jjui`. I just created an AUR package for `jjui` so that archlinux-based distro users can easily install it as well: https://aur.archlinux.org/packages/jjui-bin. I will maintain this package as long as needed.