### PR TITLE
Automatically add `--allow-new` argument to new local bookmarks

### DIFF
--- a/internal/jj/bookmark_parser_test.go
+++ b/internal/jj/bookmark_parser_test.go
@@ -24,13 +24,12 @@ func TestParseBookmarkListOutput(t *testing.T) {
 		{
 			name: "single",
 			args: args{
-				output: "feat-1;false;false;false;false;9",
+				output: "feat-1;.;false;false;false;9",
 			},
 			want: []Bookmark{
 				{
 					Name:      "feat-1",
-					Tracked:   false,
-					Remote:    false,
+					Remotes:   nil,
 					Conflict:  false,
 					Backwards: false,
 					CommitId:  "9",
@@ -40,13 +39,15 @@ func TestParseBookmarkListOutput(t *testing.T) {
 		{
 			name: "remote",
 			args: args{
-				output: "feature@origin;true;true;false;false;b",
+				output: `feature;.;false;false;false;b
+feature;origin;true;false;false;b`,
 			},
 			want: []Bookmark{
 				{
-					Name:      "feature@origin",
-					Tracked:   true,
-					Remote:    true,
+					Name: "feature",
+					Remotes: []BookmarkRemote{
+						{"origin", "b", true},
+					},
 					Conflict:  false,
 					Backwards: false,
 					CommitId:  "b",

--- a/internal/jj/bookmark_parser_test.go
+++ b/internal/jj/bookmark_parser_test.go
@@ -1,0 +1,62 @@
+package jj
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestParseBookmarkListOutput(t *testing.T) {
+	type args struct {
+		output string
+	}
+	tests := []struct {
+		name string
+		args args
+		want []Bookmark
+	}{
+		{
+			name: "empty",
+			args: args{
+				output: "",
+			},
+			want: nil,
+		},
+		{
+			name: "single",
+			args: args{
+				output: "feat-1;false;false;false;false;9",
+			},
+			want: []Bookmark{
+				{
+					Name:      "feat-1",
+					Tracked:   false,
+					Remote:    false,
+					Conflict:  false,
+					Backwards: false,
+					CommitId:  "9",
+				},
+			},
+		},
+		{
+			name: "remote",
+			args: args{
+				output: "feature@origin;true;true;false;false;b",
+			},
+			want: []Bookmark{
+				{
+					Name:      "feature@origin",
+					Tracked:   true,
+					Remote:    true,
+					Conflict:  false,
+					Backwards: false,
+					CommitId:  "b",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equalf(t, tt.want, ParseBookmarkListOutput(tt.args.output), "ParseBookmarkListOutput(%v)", tt.args.output)
+		})
+	}
+}

--- a/internal/jj/commands.go
+++ b/internal/jj/commands.go
@@ -115,7 +115,8 @@ func Squash(from string, destination string) CommandArgs {
 }
 
 func BookmarkList(revset string) CommandArgs {
-	return []string{"bookmark", "list", "-r", revset, "--template", allBookmarkTemplate, "--color", "never"}
+	const template = `separate(";", name, if(remote, remote, "."), tracked, conflict, 'false', normal_target.commit_id().shortest(1)) ++ "\n"`
+	return []string{"bookmark", "list", "-a", "-r", revset, "--template", template, "--color", "never"}
 }
 
 func BookmarkListMovable(revision string) CommandArgs {

--- a/internal/ui/git/git.go
+++ b/internal/ui/git/git.go
@@ -158,11 +158,17 @@ func NewModel(c context.AppContext, commit *jj.Commit, width int, height int) *M
 				continue
 			}
 			b.Name = strings.TrimSuffix(b.Name, "*")
-			items = append(items, item{
+			bookmarkItem := item{
 				name:    fmt.Sprintf("git push --bookmark %s", b.Name),
 				desc:    "Git push bookmark " + b.Name,
 				command: jj.GitPush("--bookmark", b.Name),
-			})
+			}
+			if b.Tracked == false {
+				bookmarkItem.name = fmt.Sprintf("git push --bookmark %s --allow-new", b.Name)
+				bookmarkItem.desc = "Git push new bookmark " + b.Name
+				bookmarkItem.command = append(bookmarkItem.command, "--allow-new")
+			}
+			items = append(items, bookmarkItem)
 		}
 	}
 	items = append(items,

--- a/internal/ui/git/git_test.go
+++ b/internal/ui/git/git_test.go
@@ -5,6 +5,7 @@ import (
 	"github.com/charmbracelet/x/exp/teatest"
 	"github.com/idursun/jjui/internal/jj"
 	"github.com/idursun/jjui/test"
+	"github.com/stretchr/testify/assert"
 	"testing"
 	"time"
 )
@@ -32,4 +33,20 @@ func Test_Fetch(t *testing.T) {
 	tm.Send(tea.KeyMsg{Type: tea.KeyEnter})
 	tm.Send(tea.KeyMsg{Type: tea.KeyEnter})
 	tm.WaitFinished(t, teatest.WithFinalTimeout(3*time.Second))
+}
+
+func Test_loadBookmarks(t *testing.T) {
+	const changeId = "changeid"
+	c := test.NewTestContext(t)
+	c.Expect(jj.BookmarkList(changeId)).SetOutput([]byte(`
+feat/allow-new-bookmarks;.;false;false;false;83
+feat/allow-new-bookmarks;origin;true;false;false;83
+main;.;false;false;false;86
+main;origin;true;false;false;86
+test;.;false;false;false;d0
+`))
+	defer c.Verify()
+
+	bookmarks := loadBookmarks(c, changeId)
+	assert.Len(t, bookmarks, 3)
 }


### PR DESCRIPTION
This PR adds `--allow-new` option to new local bookmarks. Previously this was not supported.