### PR TITLE
fix: snapshot working copy less often

### DIFF
--- a/internal/jj/commands.go
+++ b/internal/jj/commands.go
@@ -78,8 +78,12 @@ func Undo() CommandArgs {
 	return []string{"undo"}
 }
 
+func Snapshot() CommandArgs {
+	return []string{"debug", "snapshot"}
+}
+
 func Status(revision string) CommandArgs {
-	return []string{"log", "-r", revision, "--summary", "--no-graph", "--color", "never", "--quiet", "--template", ""}
+	return []string{"log", "-r", revision, "--summary", "--no-graph", "--color", "never", "--quiet", "--template", "", "--ignore-working-copy"}
 }
 
 func BookmarkSet(revision string, name string) CommandArgs {
@@ -176,7 +180,7 @@ func Absorb(changeId string) CommandArgs {
 }
 
 func OpLog(limit int) CommandArgs {
-	args := []string{"op", "log", "--color", "always", "--quiet"}
+	args := []string{"op", "log", "--color", "always", "--quiet", "--ignore-working-copy"}
 	if limit > 0 {
 		args = append(args, "--limit", strconv.Itoa(limit))
 	}

--- a/internal/ui/operations/details/details.go
+++ b/internal/ui/operations/details/details.go
@@ -293,11 +293,14 @@ func (m Model) View() string {
 }
 
 func (m Model) load(revision string) tea.Cmd {
-	output, err := m.context.RunCommandImmediate(jj.Status(revision))
+	output, err := m.context.RunCommandImmediate(jj.Snapshot())
 	if err == nil {
-		return func() tea.Msg {
-			summary := strings.Split(strings.TrimSpace(string(output)), "\n")
-			return updateCommitStatusMsg(summary)
+		output, err = m.context.RunCommandImmediate(jj.Status(revision))
+		if err == nil {
+			return func() tea.Msg {
+				summary := strings.Split(strings.TrimSpace(string(output)), "\n")
+				return updateCommitStatusMsg(summary)
+			}
 		}
 	}
 	return func() tea.Msg {


### PR DESCRIPTION
I noticed that when working with repos with large files, there are some glitches and unneeded visual noise in jjui, e.g., when
viewing the details list:
<img width="523" alt="448634004-152dd117-0bb5-4848-ae3d-0136dc5f5752" src="https://github.com/user-attachments/assets/a6b7dc35-eb7d-437d-a300-11ccf761286d" />
viewing a diff:
<img width="844" alt="448634163-6f23408d-e8f6-4155-bcfc-301df81d2387" src="https://github.com/user-attachments/assets/5e227c4e-ccd3-4675-9889-31b13a6d7d9e" />
viewing an operation:
<img width="933" alt="448634061-9d1b8025-8e87-46a4-9dac-3f0d1e236b46" src="https://github.com/user-attachments/assets/cb6eb30d-ecf9-4a2e-bb90-1fe198baaf1e" />

This PR fixes these by avoiding snapshotting the working directory for the associated commands.
Even without snapshotting the working copy, viewing the details list still updates without the need for manually refreshing.
There are no tests..!
