### PR TITLE
feat: add quick describe operation

### DIFF
--- a/internal/config/keys.go
+++ b/internal/config/keys.go
@@ -18,6 +18,7 @@ var DefaultKeyMappings = KeyMappings[keys]{
 	Quit:             []string{"q"},
 	Undo:             []string{"u"},
 	Describe:         []string{"D"},
+	QuickDescribe:    []string{"enter"},
 	Abandon:          []string{"a"},
 	Edit:             []string{"e"},
 	Diff:             []string{"d"},
@@ -92,6 +93,7 @@ func Convert(m KeyMappings[keys]) KeyMappings[key.Binding] {
 		Quit:             key.NewBinding(key.WithKeys(m.Quit...), key.WithHelp(JoinKeys(m.Quit), "quit")),
 		Diff:             key.NewBinding(key.WithKeys(m.Diff...), key.WithHelp(JoinKeys(m.Diff), "diff")),
 		Describe:         key.NewBinding(key.WithKeys(m.Describe...), key.WithHelp(JoinKeys(m.Describe), "describe")),
+		QuickDescribe:    key.NewBinding(key.WithKeys(m.QuickDescribe...), key.WithHelp(JoinKeys(m.QuickDescribe), "quick describe")),
 		Undo:             key.NewBinding(key.WithKeys(m.Undo...), key.WithHelp(JoinKeys(m.Undo), "undo")),
 		Abandon:          key.NewBinding(key.WithKeys(m.Abandon...), key.WithHelp(JoinKeys(m.Abandon), "abandon")),
 		Edit:             key.NewBinding(key.WithKeys(m.Edit...), key.WithHelp(JoinKeys(m.Edit), "edit")),
@@ -191,6 +193,7 @@ type KeyMappings[T any] struct {
 	Quit             T                   `toml:"quit"`
 	Help             T                   `toml:"help"`
 	Describe         T                   `toml:"describe"`
+	QuickDescribe    T                   `toml:"quick_describe"`
 	Edit             T                   `toml:"edit"`
 	Diffedit         T                   `toml:"diffedit"`
 	Absorb           T                   `toml:"absorb"`

--- a/internal/jj/commands.go
+++ b/internal/jj/commands.go
@@ -49,6 +49,10 @@ func Describe(revision string) CommandArgs {
 	return []string{"describe", "-r", revision, "--edit"}
 }
 
+func QuickDescribe(revision string, message string) CommandArgs {
+	return []string{"describe", "-r", revision, "--message", message}
+}
+
 func Abandon(revision ...string) CommandArgs {
 	args := []string{"abandon"}
 	for _, rev := range revision {

--- a/internal/ui/operations/quick_describe/quick_describe.go
+++ b/internal/ui/operations/quick_describe/quick_describe.go
@@ -1,0 +1,77 @@
+package quick_describe
+
+import (
+	"github.com/charmbracelet/bubbles/textarea"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/idursun/jjui/internal/jj"
+	"github.com/idursun/jjui/internal/ui/common"
+	"github.com/idursun/jjui/internal/ui/context"
+	"github.com/idursun/jjui/internal/ui/operations"
+)
+
+type QuickDescribeOperation struct {
+	context  context.AppContext
+	revision string
+	message  textarea.Model
+}
+
+func (s QuickDescribeOperation) Init() tea.Cmd {
+	return textarea.Blink
+}
+
+func (s QuickDescribeOperation) View() string {
+	return s.message.View()
+}
+
+func (s QuickDescribeOperation) IsFocused() bool {
+	return true
+}
+
+func (s QuickDescribeOperation) Update(msg tea.Msg) (operations.OperationWithOverlay, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "esc":
+			return s, common.Close
+		case "enter":
+			return s, s.context.RunCommand(jj.QuickDescribe(s.revision, s.message.Value()), common.Close, common.Refresh)
+		}
+	}
+	var cmd tea.Cmd
+	s.message, cmd = s.message.Update(msg)
+	return s, cmd
+}
+
+func (s QuickDescribeOperation) Render() string {
+	return s.message.View()
+}
+
+func (s QuickDescribeOperation) RenderPosition() operations.RenderPosition {
+	return operations.RenderPositionAfter
+}
+
+func (s QuickDescribeOperation) Name() string {
+	return "describe"
+}
+
+func NewQuickDescribeOperation(context context.AppContext, changeId string) (operations.Operation, tea.Cmd) {
+
+	description, _ := context.RunCommandImmediate(jj.Args(
+		"show", "-r", changeId, "--ignore-working-copy", "--no-patch", "--template", "description",
+	))
+
+	t := textarea.New()
+	t.CharLimit = 120
+	t.ShowLineNumbers = false
+	t.SetValue(string(description))
+	t.SetWidth(60)
+	t.SetHeight(1)
+	t.Focus()
+
+	op := QuickDescribeOperation{
+		message:  t,
+		revision: changeId,
+		context:  context,
+	}
+	return op, op.Init()
+}

--- a/internal/ui/revisions/revisions.go
+++ b/internal/ui/revisions/revisions.go
@@ -20,6 +20,7 @@ import (
 	"github.com/idursun/jjui/internal/ui/operations/bookmark"
 	"github.com/idursun/jjui/internal/ui/operations/details"
 	"github.com/idursun/jjui/internal/ui/operations/evolog"
+	"github.com/idursun/jjui/internal/ui/operations/quick_describe"
 	"github.com/idursun/jjui/internal/ui/operations/rebase"
 	"github.com/idursun/jjui/internal/ui/operations/squash"
 	"github.com/idursun/jjui/internal/ui/revset"
@@ -277,6 +278,8 @@ func (m *Model) Update(msg tea.Msg) (*Model, tea.Cmd) {
 			case key.Matches(msg, m.keymap.Describe):
 				currentRevision := m.SelectedRevision().GetChangeId()
 				return m, m.context.RunInteractiveCommand(jj.Describe(currentRevision), common.Refresh)
+			case key.Matches(msg, m.keymap.QuickDescribe):
+				m.op, cmd = quick_describe.NewQuickDescribeOperation(m.context, m.SelectedRevision().GetChangeId())
 			case key.Matches(msg, m.keymap.Evolog):
 				m.op, cmd = evolog.NewOperation(m.context, m.SelectedRevision().GetChangeId(), m.width, m.height)
 			case key.Matches(msg, m.keymap.Diff):


### PR DESCRIPTION
This is a feature request in the form of a minimal working example.

The inline text interface for setting bookmarks is unexpectedly cool. I thought it would be nice to have something similar for setting short descriptions, bound to `enter`. Of course, you can still use a text editor for longer messages, but this is also convenient!