### PR TITLE
fix: highlight background colour seq calculation

### DIFF
--- a/internal/ui/graph/renderer.go
+++ b/internal/ui/graph/renderer.go
@@ -73,8 +73,11 @@ func RenderRow(r io.Writer, row Row, renderer DefaultRowDecorator) {
 			fmt.Fprintln(r, line)
 		}
 	}
-
-	highlightSeq := lipgloss.ColorProfile().FromColor(renderer.HighlightBackground).Sequence(true)
+	highlightColor := renderer.HighlightBackground.Light
+	if lipgloss.HasDarkBackground() {
+		highlightColor = renderer.HighlightBackground.Dark
+	}
+	highlightSeq := lipgloss.ColorProfile().Color(highlightColor).Sequence(true)
 	var lastLine *GraphRowLine
 	for segmentedLine := range row.RowLinesIter(Including(Highlightable)) {
 		lastLine = segmentedLine

--- a/internal/ui/operations/evolog/evolog_operation.go
+++ b/internal/ui/operations/evolog/evolog_operation.go
@@ -87,15 +87,20 @@ func (o Operation) Render() string {
 		return "loading"
 	}
 	h := min(o.height-5, len(o.rows)*2)
+	highlightBackground := lipgloss.AdaptiveColor{
+		Light: config.Current.UI.HighlightLight,
+		Dark:  config.Current.UI.HighlightDark,
+	}
 	var w graph.Renderer
 	selectedLineStart := -1
 	selectedLineEnd := -1
 	for i, row := range o.rows {
 		nodeRenderer := graph.DefaultRowDecorator{
-			Palette:       common.DefaultPalette,
-			Op:            &operations.Default{},
-			IsHighlighted: i == o.cursor,
-			Width:         o.width,
+			Palette:             common.DefaultPalette,
+			HighlightBackground: highlightBackground,
+			Op:                  &operations.Default{},
+			IsHighlighted:       i == o.cursor,
+			Width:               o.width,
 		}
 
 		if i == o.cursor {


### PR DESCRIPTION
Fixes an issue in the highlighted background colour sequence calculation where the previous code incorrectly used a deprecated method. 

Additionally, the evolog renderer highlight colour property was not set, which caused it to render the background incorrectly in some cases.

fixes #105 