### PR TITLE
perf: make the preview pane more responsive when switching commit

### DIFF
--- a/internal/ui/preview/preview.go
+++ b/internal/ui/preview/preview.go
@@ -32,7 +32,7 @@ type Model struct {
 	keyMap           config.KeyMappings[key.Binding]
 }
 
-const DebounceTime = 200 * time.Millisecond
+const DebounceTime = 50 * time.Millisecond
 
 var border = lipgloss.NewStyle().Border(lipgloss.NormalBorder())
 


### PR DESCRIPTION
the debounce of 200ms made it feel a bit laggy. I tried 100ms, and while it was significantly better, it still didn't felt as responsive as expected. 50ms feels just right, and it doesn't seem to overload my system.