### PR TITLE
Add compilation instructions and add `/jjui` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
+/jjui
+
 .idea/
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -152,3 +152,5 @@ Minimum supported `jj` version is **v0.21**+.
 ## Contributing
 
 Feel free to submit a pull request.
+
+You can compile `jjui` by running `go build ./...` in the root of the repo.


### PR DESCRIPTION
After this, `go build ./...` will not result in `jj` trying to snapshot a binary file.

------

I have found it hard to get used to golang CLI idioms, so I'd have found these instructions useful.

If there's a better way, please let me know!

I'm guessing you're using Nix yourself, but it doesn't seem worth recommending it to people here unless they already know they want to use it.