### PR TITLE
Fixup build command from ebfae407b1

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,4 +153,4 @@ Minimum supported `jj` version is **v0.21**+.
 
 Feel free to submit a pull request.
 
-You can compile `jjui` by running `go build ./...` in the root of the repo.
+You can compile `jjui` by running `go build ./cmd/jjui in the root of the repo.


### PR DESCRIPTION
When I run `go build ./...`, something happens and no error is generated, but the binary does *not* get updated. `go build ./cmd/jjui` actually works.