### PR TITLE
CI and Nix: make `nix flake check` build the flake

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -20,6 +20,7 @@
     {
       packages.default = jjui;
       packages.jjui = jjui;
+      checks.default = jjui;
 
       devShells.default = pkgs.mkShell {
         nativeBuildInputs = [


### PR DESCRIPTION
Previously, it merely checked that the flake has correct syntax.

See also <https://github.com/idursun/jjui/issues/128>.

--------

This does slow down the CI, but only a little (the run for this PR took 1m8s, hopefully this will be somewhat consistent).

Instead of this PR, another option would be to rename the check to make it clear that it checks the flake syntax only (as it does without this PR).

I also don't know much about Nix, so there might be a better way of implementing this; this implementation was a guess based on `nix flake check` docs.