### PR TITLE
Add --keep-emptied option for jj squash in TUI

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -29,6 +29,9 @@ var Current = &Config{
 	},
 	CustomCommands:                 map[string]CustomCommandDefinition{},
 	ExperimentalLogBatchingEnabled: false,
+	Jj: JjConfig{
+		SquashKeepEmptied: false,
+	},
 }
 
 type Config struct {
@@ -38,6 +41,12 @@ type Config struct {
 	OpLog                          OpLogConfig                        `toml:"oplog"`
 	CustomCommands                 map[string]CustomCommandDefinition `toml:"custom_commands"`
 	ExperimentalLogBatchingEnabled bool                               `toml:"experimental_log_batching_enabled"`
+	Jj                             JjConfig                           `toml:"jj"`
+}
+
+// JjConfig holds flags that tweak how underlying 'jj' commands are invoked.
+type JjConfig struct {
+	SquashKeepEmptied bool `toml:"squash_keep_emptied"`
 }
 
 type UIConfig struct {

--- a/internal/jj/commands.go
+++ b/internal/jj/commands.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"github.com/idursun/jjui/internal/config"
 )
 
 type CommandArgs []string
@@ -113,6 +114,9 @@ func BookmarkUntrack(name string) CommandArgs {
 
 func Squash(from SelectedRevisions, destination string) CommandArgs {
 	args := []string{"squash"}
+	if config.Current.Jj.SquashKeepEmptied {
+		args = append(args, "--keep-emptied")
+	}
 	args = append(args, from.AsPrefixedArgs("--from")...)
 	args = append(args, "--into", destination)
 	return args


### PR DESCRIPTION
👋 Thank you for building and maintaining jjui! It's been super nice to use.

## Summary
When following a multi-parent workflow e.g. steveklabnik.github.io/jujutsu-tutorial/advanced/simultaneous-edits.html , it's useful to keep a change that's the descendent of all of your concurrent work. I can run `jj squash -i --keep-emptied` to merge specific changes into one of the ancestors.

## Issue
Unfortunately, jjui's squash TUI command runs the default `jj squash` command. Without `--keep-emptied`, the "merge" change gets abandoned everytime. You then need to do something like `jj new <all your parents>` to get that restored. 

## Solution
To solve this, we can add jj-specific config options that can modify TUI behavior. The drawback of enabling this is that you now have to abandon changes manually after squashing. I've set this as `false` by default to prevent breaking changes

Alternatives we can consider:
- Support generic command overrides: `jj.squash_command = ["squash", "--keep-emptied"]` or `jj.commands.squash = ...`
- Support a flag that can be flipped during `jj squash` selection.