### PR TITLE
build(nix): add git version to --version

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -7,11 +7,15 @@
   };
 
   perSystem =
-    { pkgs, ... }:
+    { pkgs, lib, ... }:
     let
-      jjui = pkgs.buildGoModule rec {
+      self = inputs.self;
+      version = if (self ? rev) then self.rev else "dirty-${self.dirtyRev}";
+      jjui = pkgs.buildGoModule {
         name = "jjui";
-        src = ./..;
+        src = lib.cleanSource ./..;
+
+        ldflags = [ "-X main.Version=${version}" ];
         vendorHash = builtins.readFile ./vendor-hash;
         meta.mainProgram = "jjui";
       };


### PR DESCRIPTION
before:
```
➜ jjui --version     
(devel)
```

after
```
result/bin/jjui --version
0b5d3eb8e800989ed91845e131e49b8f3bacd21a
```

even better would be if I could retreive the next version to print `jjui 0.9-nightly+REV` or even the current version.