### PR TITLE
build(nix): allow building flake when `self.dirtyRev` is not defined

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -10,7 +10,13 @@
     { pkgs, lib, ... }:
     let
       self = inputs.self;
-      version = if (self ? rev) then self.rev else "dirty-${self.dirtyRev}";
+      version =
+        if (self ? rev) then
+          self.rev
+        else if (self ? dirtyRev) then
+          "dirty-${self.dirtyRev}"
+        else
+          "(devel)";
       jjui = pkgs.buildGoModule {
         name = "jjui";
         src = lib.cleanSource ./..;


### PR DESCRIPTION
Fixes up 7a6b379.

This seems to matter if I `nix build /path/to/jjui?ref=main`, for example.