### PR TITLE
doc: Remove a duplicated maintainer mention

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,6 @@ yay -S jjui-bin
 ```
 
 ### Nix (maintained by [@Adda0](https://github.com/Adda0))
-Maintainer: @Adda0
 
 You can install `jjui` using nix from the unstable channel.
 


### PR DESCRIPTION
This PR removes one of the duplicated maintainer mentions, leaving the mention in the section title to correspond to other maintainer mentions.