### PR TITLE
fixed display of empty revsets (#151)

### DIFF
--- a/internal/ui/common/msgs.go
+++ b/internal/ui/common/msgs.go
@@ -18,6 +18,7 @@ type (
 		Output string
 		Err    error
 	}
+	UpdateRevisionsSuccessMsg struct{}
 	UpdateBookmarksMsg struct {
 		Bookmarks []string
 		Revision  string

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -168,6 +168,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.state = common.Error
 		m.output = msg.Output
 		m.error = msg.Err
+	case common.UpdateRevisionsSuccessMsg:
+		m.state = common.Ready
 	case triggerAutoRefreshMsg:
 		return m, tea.Batch(m.scheduleAutoRefresh(), func() tea.Msg {
 			return common.AutoRefreshMsg{}


### PR DESCRIPTION
just a quick fix for #151:

- `jjui -r 'none()'` now returns "(no matching revisions)"
- `jjui`, then hit 'L' and change the revset to none() now displays "(no matching revisions)"

<img width="892" alt="Screenshot 2025-07-02 at 1 21 22 PM" src="https://github.com/user-attachments/assets/092b8e76-5304-4618-9d07-fc795eb92303" />
