### PR TITLE
fix: refresh SelectedFile on ToggleSelect

### DIFF
--- a/internal/ui/operations/details/details.go
+++ b/internal/ui/operations/details/details.go
@@ -185,11 +185,13 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.confirmation = &model
 			return m, m.confirmation.Init()
 		case key.Matches(msg, m.keyMap.Details.ToggleSelect):
-			if item, ok := m.files.SelectedItem().(item); ok {
-				item.selected = !item.selected
+			if oldItem, ok := m.files.SelectedItem().(item); ok {
+				oldItem.selected = !oldItem.selected
 				oldIndex := m.files.Index()
 				m.files.CursorDown()
-				return m, m.files.SetItem(oldIndex, item)
+
+				curItem := m.files.SelectedItem().(item)
+				return m, tea.Batch(m.files.SetItem(oldIndex, oldItem), m.context.SetSelectedItem(context.SelectedFile{ChangeId: m.revision, File: curItem.fileName}))
 			}
 			return m, nil
 		case key.Matches(msg, m.keyMap.Details.RevisionsChangingFile):


### PR DESCRIPTION
When the preview panel is open alongside the details view for a single revision, it displays the currently selected file. Navigating through the file list using up and down arrows changes the preview accordingly. However, pressing the ToggleSelect key moves the cursor in the file list, but it doesn't update the preview panel.

I'm not familiar with the bubbletea library so I mostly followed existing patterns. I tested that the change works in the repo I noticed the issue in.