### PR TITLE
feat: add --period/-p CLI option

### DIFF
--- a/cmd/jjui/main.go
+++ b/cmd/jjui/main.go
@@ -33,6 +33,7 @@ func getVersion() string {
 
 var (
 	revset     string
+	period     int
 	version    bool
 	editConfig bool
 	help       bool
@@ -41,6 +42,8 @@ var (
 func init() {
 	flag.StringVar(&revset, "revset", "", "Set default revset")
 	flag.StringVar(&revset, "r", "", "Set default revset (same as --revset)")
+	flag.IntVar(&period, "period", -1, "Override auto-refresh interval (seconds, set to 0 to disable)")
+	flag.IntVar(&period, "p", -1, "Override auto-refresh interval (alias for --period)")
 	flag.BoolVar(&version, "version", false, "Show version information")
 	flag.BoolVar(&editConfig, "config", false, "Open configuration file in $EDITOR")
 	flag.BoolVar(&help, "help", false, "Show help information")
@@ -118,6 +121,10 @@ func main() {
 	} else {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
+	}
+
+	if period >= 0 {
+		config.Current.UI.AutoRefreshInterval = period
 	}
 
 	p := tea.NewProgram(ui.New(appContext, revset), tea.WithAltScreen())

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,13 +2,14 @@ package config
 
 import (
 	"fmt"
-	"github.com/idursun/jjui/internal/jj"
 	"log"
 	"os"
 	"os/exec"
 	"path"
 	"path/filepath"
 	"runtime"
+
+	"github.com/idursun/jjui/internal/jj"
 )
 
 var Current = &Config{
@@ -57,10 +58,12 @@ type colors struct {
 }
 
 type UIConfig struct {
-	HighlightLight      string `toml:"highlight_light"`
-	HighlightDark       string `toml:"highlight_dark"`
-	Colors              colors `toml:"colors"`
-	AutoRefreshInterval int    `toml:"auto_refresh_interval"`
+	HighlightLight string `toml:"highlight_light"`
+	HighlightDark  string `toml:"highlight_dark"`
+	Colors         colors `toml:"colors"`
+	// TODO(ilyagr): It might make sense to rename this to `auto_refresh_period` to match `--period` option
+	// once we have a mechanism to deprecate the old name softly.
+	AutoRefreshInterval int `toml:"auto_refresh_interval"`
 }
 
 type PreviewConfig struct {


### PR DESCRIPTION
I think `--period` is better than `--interval`, because `-i` sounds more like "interactive". 

Fixes #148

-----

We could still go with `--interval`, or something else if we can come up with something better.