### PR TITLE
feat(git): add UI and test support for 'git push --change <changeId>'

### DIFF
--- a/internal/ui/git/git.go
+++ b/internal/ui/git/git.go
@@ -183,6 +183,17 @@ func NewModel(c *context.MainContext, commit *jj.Commit, width int, height int) 
 	items = append(items,
 		item{name: "git push", desc: "Push tracking bookmarks in the current revset", command: jj.GitPush()},
 		item{name: "git push --all", desc: "Push all bookmarks (including new and deleted bookmarks)", command: jj.GitPush("--all")},
+	)
+	if commit != nil {
+		items = append(items,
+			item{
+				name:    fmt.Sprintf("git push --change %s", commit.GetChangeId()),
+				desc:    fmt.Sprintf("Push the current change (%s)", commit.GetChangeId()),
+				command: jj.GitPush("--change", commit.GetChangeId()),
+			},
+		)
+	}
+	items = append(items,
 		item{name: "git push --deleted", desc: "Push all deleted bookmarks", command: jj.GitPush("--deleted")},
 		item{name: "git push --tracked", desc: "Push all tracked bookmarks (including deleted bookmarks)", command: jj.GitPush("--tracked")},
 		item{name: "git push --allow-new", desc: "Allow pushing new bookmarks", command: jj.GitPush("--allow-new")},

--- a/internal/ui/git/git_test.go
+++ b/internal/ui/git/git_test.go
@@ -50,3 +50,21 @@ test;.;false;false;false;d0
 	bookmarks := loadBookmarks(commandRunner, changeId)
 	assert.Len(t, bookmarks, 3)
 }
+
+func Test_PushChange(t *testing.T) {
+	const changeId = "abc123"
+	commandRunner := test.NewTestCommandRunner(t)
+	// Expect bookmark list to be loaded since we have a changeId
+	commandRunner.Expect(jj.BookmarkList(changeId)).SetOutput([]byte(""))
+	commandRunner.Expect(jj.GitPush("--change", changeId))
+	defer commandRunner.Verify()
+
+	op := NewModel(test.NewTestContext(commandRunner), &jj.Commit{ChangeId: changeId}, 0, 0)
+	tm := teatest.NewTestModel(t, test.NewShell(op))
+	// Filter for the exact item and ensure selection is at index 0
+	tm.Type("/")
+	tm.Type("git push --change")
+	tm.Send(tea.KeyMsg{Type: tea.KeyDown}) // Ensure first item is selected
+	tm.Send(tea.KeyMsg{Type: tea.KeyEnter})
+	tm.WaitFinished(t, teatest.WithFinalTimeout(3*time.Second))
+}


### PR DESCRIPTION
- Added UI item for 'git push --change <changeId>' when a commit is present.
- Updated tests to verify filtering and selection triggers the correct command.
- Ensured bookmark list expectation is handled in tests.