### PR TITLE
feat(leader): add Leader (vim/spacemacs) like commands.

### DIFF
--- a/cmd/jjui/main.go
+++ b/cmd/jjui/main.go
@@ -127,6 +127,12 @@ func main() {
 		} else {
 			appContext.CustomCommands = registry
 		}
+		if registry, err := context.LoadLeader(string(output)); err != nil {
+			fmt.Fprintf(os.Stderr, "Error loading leader keys: %v\n", err)
+			os.Exit(1)
+		} else {
+			appContext.Leader = registry
+		}
 	} else if !errors.Is(err, fs.ErrNotExist) {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)

--- a/internal/config/keys.go
+++ b/internal/config/keys.go
@@ -32,6 +32,7 @@ var DefaultKeyMappings = KeyMappings[keys]{
 	QuickSearch:       []string{"/"},
 	QuickSearchCycle:  []string{"'"},
 	CustomCommands:    []string{"x"},
+	Leader:            []string{"\\"},
 	Suspend:           []string{"ctrl+z"},
 	Rebase: rebaseModeKeys[keys]{
 		Mode:     []string{"r"},
@@ -124,6 +125,7 @@ func Convert(m KeyMappings[keys]) KeyMappings[key.Binding] {
 		QuickSearch:       key.NewBinding(key.WithKeys(m.QuickSearch...), key.WithHelp(JoinKeys(m.QuickSearch), "quick search")),
 		QuickSearchCycle:  key.NewBinding(key.WithKeys(m.QuickSearchCycle...), key.WithHelp(JoinKeys(m.QuickSearchCycle), "locate next match")),
 		CustomCommands:    key.NewBinding(key.WithKeys(m.CustomCommands...), key.WithHelp(JoinKeys(m.CustomCommands), "custom commands menu")),
+		Leader:            key.NewBinding(key.WithKeys(m.Leader...), key.WithHelp(JoinKeys(m.Leader), "leader")),
 		Suspend:           key.NewBinding(key.WithKeys(m.Suspend...), key.WithHelp(JoinKeys(m.Suspend), "suspend")),
 		Rebase: rebaseModeKeys[key.Binding]{
 			Mode:     key.NewBinding(key.WithKeys(m.Rebase.Mode...), key.WithHelp(JoinKeys(m.Rebase.Mode), "rebase")),
@@ -239,6 +241,7 @@ type KeyMappings[T any] struct {
 	QuickSearch       T                         `toml:"quick_search"`
 	QuickSearchCycle  T                         `toml:"quick_search_cycle"`
 	CustomCommands    T                         `toml:"custom_commands"`
+	Leader            T                         `toml:"leader"`
 	Suspend           T                         `toml:"suspend"`
 	Rebase            rebaseModeKeys[T]         `toml:"rebase"`
 	Duplicate         duplicateModeKeys[T]      `toml:"duplicate"`

--- a/internal/ui/context/leader.go
+++ b/internal/ui/context/leader.go
@@ -1,0 +1,67 @@
+package context
+
+import (
+	"strings"
+
+	"github.com/BurntSushi/toml"
+	"github.com/charmbracelet/bubbles/key"
+)
+
+type LeaderMap = map[string]*Leader
+
+type Leader struct {
+	Bind *key.Binding
+	Send []string
+	Nest LeaderMap
+}
+
+func LoadLeader(content string) (LeaderMap, error) {
+	type leaderTomlEntry struct {
+		Help string
+		Send []string
+	}
+	type leaderToml struct {
+		Leader map[string]leaderTomlEntry
+	}
+	dec := leaderToml{}
+	_, err := toml.Decode(content, &dec)
+	if err != nil {
+		return nil, err
+	}
+	res := LeaderMap{}
+	for name, v := range dec.Leader {
+		ks := strings.Split(name, "")
+		at := res
+		for i, k := range ks {
+			m := checkExists(at, k)
+			if i == len(ks)-1 {
+				if len(v.Send) > 0 {
+					m.Send = v.Send
+				}
+				if len(v.Help) > 0 {
+					m.Bind.SetHelp(k, v.Help)
+				}
+			}
+			at = m.Nest
+		}
+	}
+	return res, nil
+}
+
+func checkExists(at LeaderMap, k string) *Leader {
+	if m, ok := at[k]; ok {
+		return m
+	} else {
+		b := key.NewBinding(
+			key.WithKeys(k),
+			key.WithHelp(k, ""),
+		)
+		m = &Leader{
+			Bind: &b,
+			Send: nil,
+			Nest: LeaderMap{},
+		}
+		at[k] = m
+		return m
+	}
+}

--- a/internal/ui/context/leader_test.go
+++ b/internal/ui/context/leader_test.go
@@ -1,0 +1,81 @@
+package context
+
+import (
+	"testing"
+)
+
+const exampleLeaderToml = `
+[leader.M]
+help = "Set bookmark main and push"
+send = ["b/move main", "down", "enter", "gp", "enter"]
+
+[leader.g]
+help = "Git"
+
+[leader.gff]
+help = "Git Fetch"
+send = ["gf", "enter"]
+
+[leader.gfa]
+help = "Git Fetch All"
+send = ["g/fetch --all", "down", "enter"]
+`
+
+func TestLoadLeader(t *testing.T) {
+	lm, err := LoadLeader(exampleLeaderToml)
+	if err != nil {
+		t.Fatalf("LoadLeader failed: %v", err)
+	}
+
+	// Test leader.M
+	m := lm["M"]
+	if m == nil {
+		t.Error("leader.M not found")
+	} else {
+		if m.Bind == nil || m.Bind.Help().Desc != "Set bookmark main and push" {
+			t.Errorf("leader.M help mismatch: got %q", m.Bind.Help().Desc)
+		}
+		if len(m.Send) != 5 || m.Send[0] != "b/move main" || m.Send[4] != "enter" {
+			t.Errorf("leader.M send mismatch: got %v", m.Send)
+		}
+	}
+
+	// Test leader.g
+	g := lm["g"]
+	if g == nil {
+		t.Error("leader.g not found")
+	} else {
+		if g.Bind == nil || g.Bind.Help().Desc != "Git" {
+			t.Errorf("leader.g help mismatch: got %q", g.Bind.Help().Desc)
+		}
+		if len(g.Send) != 0 {
+			t.Errorf("leader.g send should be empty: got %v", g.Send)
+		}
+	}
+
+	// Test leader.gff
+	gff := lm["g"].Nest["f"].Nest["f"]
+	if gff == nil {
+		t.Error("leader.gff not found")
+	} else {
+		if gff.Bind == nil || gff.Bind.Help().Desc != "Git Fetch" {
+			t.Errorf("leader.gff help mismatch: got %q", gff.Bind.Help().Desc)
+		}
+		if len(gff.Send) != 2 || gff.Send[0] != "gf" || gff.Send[1] != "enter" {
+			t.Errorf("leader.gff send mismatch: got %v", gff.Send)
+		}
+	}
+
+	// Test leader.gf
+	h := lm["g"].Nest["f"]
+	if h == nil {
+		t.Error("leader.gf not found")
+	} else {
+		if h.Bind == nil || h.Bind.Help().Desc != "" {
+			t.Errorf("leader.gf help mismatch: got %q", h.Bind.Help().Desc)
+		}
+		if len(h.Send) != 0 {
+			t.Errorf("leader.gf send mismatch: got %v", h.Send)
+		}
+	}
+}

--- a/internal/ui/context/main_context.go
+++ b/internal/ui/context/main_context.go
@@ -50,6 +50,7 @@ type MainContext struct {
 	SelectedItem   SelectedItem
 	Location       string
 	CustomCommands map[string]CustomCommand
+	Leader         LeaderMap
 	JJConfig       *config.JJConfig
 	DefaultRevset  string
 	CurrentRevset  string

--- a/internal/ui/helppage/help.go
+++ b/internal/ui/helppage/help.go
@@ -161,6 +161,7 @@ func (h *Model) View() string {
 		printHelp(h.keyMap.Diff),
 		printHelp(h.keyMap.OpLog.Restore),
 		printMode(h.keyMap.CustomCommands, "Custom Commands"),
+		printMode(h.keyMap.Leader, "Leader"),
 	)
 
 	var customCommands []string

--- a/internal/ui/leader/leader.go
+++ b/internal/ui/leader/leader.go
@@ -1,0 +1,231 @@
+package leader
+
+import (
+	"maps"
+	"slices"
+
+	"github.com/charmbracelet/bubbles/key"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/idursun/jjui/internal/config"
+	"github.com/idursun/jjui/internal/ui/common"
+	"github.com/idursun/jjui/internal/ui/context"
+)
+
+type Model struct {
+	cancel key.Binding
+	root   context.LeaderMap
+	shown  context.LeaderMap
+}
+
+func New(root context.LeaderMap) *Model {
+	keyMap := config.Current.GetKeyMap()
+	m := &Model{
+		cancel: keyMap.Cancel,
+		root:   root,
+		shown:  root,
+	}
+	return m
+}
+
+func (m *Model) ShortHelp() []key.Binding {
+	bindings := []key.Binding{m.cancel}
+	for m := range maps.Values(m.shown) {
+		bindings = append(bindings, *m.Bind)
+	}
+	return bindings
+}
+
+func (m *Model) FullHelp() [][]key.Binding {
+	bindings := slices.Collect(slices.Chunk(m.ShortHelp(), 6))
+	return bindings
+}
+
+type initMsg struct{}
+
+func initCmd() tea.Msg {
+	return initMsg{}
+}
+
+type PendingMsg struct {
+	cmds []tea.Cmd
+}
+
+func pendingCmd(cmds []tea.Cmd) tea.Cmd {
+	return func() tea.Msg {
+		return PendingMsg{cmds: cmds}
+	}
+}
+
+func TakePending(msg PendingMsg) tea.Cmd {
+	if len(msg.cmds) > 1 {
+		return tea.Batch(msg.cmds[0], pendingCmd(msg.cmds[1:]))
+	}
+	if len(msg.cmds) == 1 {
+		return msg.cmds[0]
+	}
+	return nil
+}
+
+func (m *Model) Init() tea.Cmd {
+	return initCmd
+}
+
+func (m *Model) Update(msg tea.Msg) (*Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case initMsg:
+		m.shown = m.root
+	case tea.KeyMsg:
+		switch {
+		case key.Matches(msg, m.cancel):
+			m.shown = nil
+			return m, common.Close
+		}
+		for c := range maps.Values(m.shown) {
+			if key.Matches(msg, *c.Bind) {
+				if len(c.Nest) > 0 {
+					m.shown = c.Nest
+					return m, nil
+				}
+				m.shown = nil
+				cmds := sendCmds(c.Send)
+				return m, tea.Batch(
+					common.Close,
+					pendingCmd(cmds),
+				)
+			}
+		}
+	}
+	return m, nil
+}
+
+func sendCmds(strings []string) []tea.Cmd {
+	cmds := []tea.Cmd{}
+	send := func(k tea.Key) {
+		cmds = append(cmds, func() tea.Msg {
+			return tea.KeyMsg(k)
+		})
+	}
+	for _, s := range strings {
+		if k, ok := keyNames[s]; ok {
+			send(k)
+		} else {
+			for _, r := range s {
+				send(tea.Key{
+					Type:  tea.KeyRunes,
+					Runes: []rune{r},
+				})
+			}
+		}
+	}
+	return cmds
+}
+
+// From bubbletea's key.go. So that we can identify by their string.
+// Notable Exception: tea.KeyRunes. Because we create them.
+var keyTypes = []tea.KeyType{
+	// Control keys.
+	tea.KeyTab,
+	tea.KeyEnter,
+	tea.KeyEsc,
+	tea.KeyBackspace,
+
+	tea.KeyCtrlAt,
+	tea.KeyCtrlA,
+	tea.KeyCtrlB,
+	tea.KeyCtrlC,
+	tea.KeyCtrlD,
+	tea.KeyCtrlE,
+	tea.KeyCtrlF,
+	tea.KeyCtrlG,
+	tea.KeyCtrlH,
+	tea.KeyCtrlJ,
+	tea.KeyCtrlK,
+	tea.KeyCtrlL,
+	tea.KeyCtrlN,
+	tea.KeyCtrlO,
+	tea.KeyCtrlP,
+	tea.KeyCtrlQ,
+	tea.KeyCtrlR,
+	tea.KeyCtrlS,
+	tea.KeyCtrlT,
+	tea.KeyCtrlU,
+	tea.KeyCtrlV,
+	tea.KeyCtrlW,
+	tea.KeyCtrlX,
+	tea.KeyCtrlY,
+	tea.KeyCtrlZ,
+
+	tea.KeyCtrlCloseBracket,
+	tea.KeyCtrlCaret,
+	tea.KeyCtrlUnderscore,
+	tea.KeyCtrlBackslash,
+
+	// Other keys.
+	tea.KeyUp,
+	tea.KeyDown,
+	tea.KeyRight,
+	tea.KeySpace,
+	tea.KeyLeft,
+	tea.KeyShiftTab,
+	tea.KeyHome,
+	tea.KeyEnd,
+	tea.KeyCtrlHome,
+	tea.KeyCtrlEnd,
+	tea.KeyShiftHome,
+	tea.KeyShiftEnd,
+	tea.KeyCtrlShiftHome,
+	tea.KeyCtrlShiftEnd,
+	tea.KeyPgUp,
+	tea.KeyPgDown,
+	tea.KeyCtrlPgUp,
+	tea.KeyCtrlPgDown,
+	tea.KeyDelete,
+	tea.KeyInsert,
+	tea.KeyCtrlUp,
+	tea.KeyCtrlDown,
+	tea.KeyCtrlRight,
+	tea.KeyCtrlLeft,
+	tea.KeyShiftUp,
+	tea.KeyShiftDown,
+	tea.KeyShiftRight,
+	tea.KeyShiftLeft,
+	tea.KeyCtrlShiftUp,
+	tea.KeyCtrlShiftDown,
+	tea.KeyCtrlShiftLeft,
+	tea.KeyCtrlShiftRight,
+	tea.KeyF1,
+	tea.KeyF2,
+	tea.KeyF3,
+	tea.KeyF4,
+	tea.KeyF5,
+	tea.KeyF6,
+	tea.KeyF7,
+	tea.KeyF8,
+	tea.KeyF9,
+	tea.KeyF10,
+	tea.KeyF11,
+	tea.KeyF12,
+	tea.KeyF13,
+	tea.KeyF14,
+	tea.KeyF15,
+	tea.KeyF16,
+	tea.KeyF17,
+	tea.KeyF18,
+	tea.KeyF19,
+	tea.KeyF20,
+}
+
+func keysFromTypes() map[string]tea.Key {
+	m := map[string]tea.Key{}
+	set := func(t tea.KeyType) {
+		m[t.String()] = tea.Key{
+			Type: t,
+		}
+	}
+	for _, t := range keyTypes {
+		set(t)
+	}
+	return m
+}
+
+var keyNames = keysFromTypes()

--- a/internal/ui/leader/leader_test.go
+++ b/internal/ui/leader/leader_test.go
@@ -1,0 +1,201 @@
+package leader
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/idursun/jjui/internal/ui/common"
+	"github.com/idursun/jjui/internal/ui/context"
+)
+
+func Test_sendCmds_detects_tea_keytypes(t *testing.T) {
+	cmds := sendCmds([]string{"enter", "ctrl+s"})
+	if len(cmds) != 2 {
+		t.Fatalf("expected 2 cmds, got %d", len(cmds))
+	}
+	msg1 := cmds[0]()
+	msg2 := cmds[1]()
+	key1, ok1 := msg1.(tea.KeyMsg)
+	key2, ok2 := msg2.(tea.KeyMsg)
+	if !ok1 || !ok2 {
+		t.Fatalf("expected tea.KeyMsg, got %T and %T", msg1, msg2)
+	}
+	if key1.Type != tea.KeyEnter {
+		t.Errorf("expected key1.Type == KeyEnter, got %v", key1.Type)
+	}
+	if key2.Type != tea.KeyCtrlS {
+		t.Errorf("expected key2.Type == KeyCtrlS, got %v", key2.Type)
+	}
+}
+
+func Test_sendCmds_produces_rune_keys_on_non_keytypes(t *testing.T) {
+	cmds := sendCmds([]string{"hi"})
+	if len(cmds) != 2 {
+		t.Fatalf("expected 2 cmds, got %d", len(cmds))
+	}
+	msg1 := cmds[0]()
+	msg2 := cmds[1]()
+	key1, ok1 := msg1.(tea.KeyMsg)
+	key2, ok2 := msg2.(tea.KeyMsg)
+	if !ok1 || !ok2 {
+		t.Fatalf("expected tea.KeyMsg, got %T and %T", msg1, msg2)
+	}
+	if key1.Type != tea.KeyRunes || string(key1.Runes) != "h" {
+		t.Errorf("expected key1 to be rune 'h', got type %v runes %q", key1.Type, string(key1.Runes))
+	}
+	if key2.Type != tea.KeyRunes || string(key2.Runes) != "i" {
+		t.Errorf("expected key2 to be rune 'i', got type %v runes %q", key2.Type, string(key2.Runes))
+	}
+}
+
+func TestUpdate_h_closes_leader_and_produces_pending_questionmark(t *testing.T) {
+	content := `[leader.h]
+help = "Help"
+send = ["?"]
+`
+	lm, err := context.LoadLeader(content)
+	if err != nil {
+		t.Fatalf("LoadLeader failed: %v", err)
+	}
+	model := New(lm)
+	if len(model.shown) == 0 {
+		t.Fatal("expected shown leader keys")
+	}
+	msg := tea.KeyMsg{
+		Type:  tea.KeyRunes,
+		Runes: []rune{'h'},
+	}
+	model, cmd := model.Update(msg)
+	if len(model.shown) != 0 {
+		t.Fatal("expected not to show leader keys after reaching leaf")
+	}
+	if cmd == nil {
+		t.Fatal("expected a command returned from Update")
+	}
+	msgOut := cmd()
+	batch, ok := msgOut.(tea.BatchMsg)
+	if !ok {
+		t.Fatalf("expected BatchMsg, got %T", msgOut)
+	}
+	if len(batch) != 2 {
+		t.Fatalf("expected 2 cmds in batch, got %d", len(batch))
+	}
+	closeMsg := batch[0]()
+	if _, ok := closeMsg.(common.CloseViewMsg); !ok {
+		t.Error("expected non-nil closeMsg")
+	}
+	pendingMsgRaw := batch[1]()
+	pendingMsg, ok := pendingMsgRaw.(PendingMsg)
+	if !ok {
+		t.Fatalf("expected PendingMsg, got %T", pendingMsgRaw)
+	}
+	if len(pendingMsg.cmds) != 1 {
+		t.Fatalf("expected 1 cmd in PendingMsg, got %d", len(pendingMsg.cmds))
+	}
+	msg2 := pendingMsg.cmds[0]()
+	keyMsg, ok := msg2.(tea.KeyMsg)
+	if !ok {
+		t.Fatalf("expected tea.KeyMsg, got %T", msg2)
+	}
+	if keyMsg.Type != tea.KeyRunes || string(keyMsg.Runes) != "?" {
+		t.Errorf("expected keyMsg to be rune '?', got type %v runes %q", keyMsg.Type, string(keyMsg.Runes))
+	}
+}
+
+func TestUpdate_gf_shows_git_fetch_submenu_and_returns_nil_cmd(t *testing.T) {
+	content := `[leader.g]
+help = "Git"
+
+[leader.gff]
+help = "Git Fetch"
+send = ["gf", "enter"]
+`
+	lm, err := context.LoadLeader(content)
+	if err != nil {
+		t.Fatalf("LoadLeader failed: %v", err)
+	}
+	model := New(lm)
+	// Press 'g' to enter the submenu
+	msgG := tea.KeyMsg{
+		Type:  tea.KeyRunes,
+		Runes: []rune{'g'},
+	}
+	model, cmd := model.Update(msgG)
+	if cmd != nil {
+		t.Errorf("expected nil cmd when entering submenu, got %v", cmd)
+	}
+	if model.shown == nil || len(model.shown) == 0 {
+		t.Fatal("expected submenu to be shown after pressing 'g'")
+	}
+	// Press 'f' to enter the next submenu
+	msgF := tea.KeyMsg{
+		Type:  tea.KeyRunes,
+		Runes: []rune{'f'},
+	}
+	model, cmd = model.Update(msgF)
+	if cmd != nil {
+		t.Errorf("expected nil cmd when entering nested submenu, got %v", cmd)
+	}
+	if len(model.shown) == 0 {
+		t.Fatal("expected nested submenu to be shown after pressing 'f'")
+	}
+}
+
+func TestUpdate_esc_closes_menu(t *testing.T) {
+	content := `[leader.h]
+help = "Help"
+send = ["?"]
+`
+	lm, err := context.LoadLeader(content)
+	if err != nil {
+		t.Fatalf("LoadLeader failed: %v", err)
+	}
+	model := New(lm)
+	msg := tea.KeyMsg{
+		Type: tea.KeyEsc,
+	}
+	model, cmd := model.Update(msg)
+	if len(model.shown) != 0 {
+		t.Fatal("expected menu to be closed after pressing esc")
+	}
+	if cmd == nil {
+		t.Fatal("expected a command returned from Update")
+	}
+	msgOut := cmd()
+	if _, ok := msgOut.(common.CloseViewMsg); !ok {
+		t.Errorf("expected CloseViewMsg, got %T", msgOut)
+	}
+}
+
+func TestTakePending_reduces_cmds_one_by_one(t *testing.T) {
+	cmds := sendCmds([]string{"ctrl+h", "b", "c"})
+	pending := PendingMsg{cmds: cmds}
+	if len(pending.cmds) != 3 {
+		t.Fatalf("Expected 3 cmds")
+	}
+
+	cmd := TakePending(pending)
+	if batch, ok := cmd().(tea.BatchMsg); !ok {
+		t.Fatalf("expected BatchMsg got %v", batch)
+	} else if len(batch) != 2 {
+		t.Fatalf("expected 2 cmds in batch, got %d", len(batch))
+	} else if k, ok := batch[0]().(tea.KeyMsg); !ok || k.String() != "ctrl+h" {
+		t.Fatalf("expected rune got %v", k)
+	} else if pending, ok = batch[1]().(PendingMsg); !ok || len(pending.cmds) != 2 {
+		t.Fatalf("expected two pending cmds got %v", pending)
+	}
+
+	cmds = sendCmds([]string{"c"})
+	pending = PendingMsg{cmds: cmds}
+	cmd = TakePending(pending)
+	if cmd().(tea.KeyMsg).String() != "c" {
+		t.Fatalf("expected single command to be returned")
+	}
+
+	cmds = sendCmds([]string{})
+	pending = PendingMsg{cmds: cmds}
+	cmd = TakePending(pending)
+	if cmd != nil {
+		t.Fatalf("expected nil command for empty send keys")
+	}
+}


### PR DESCRIPTION
The motivation for this changeset is trying to automate user workflows without having to add more keybindings or features on jjui main branch.

(an example is: Create a "TODO" change just bellow the current one, but it can be anything that is possible via current jjui key bindings)

For this we take inspiration on spacemacs/vim Leader-like key bindings.

Leader is a prefix key that allows navigating a tree of keymaps where leafs are actions to be performed in the UI as if the user typed them directly.

When Leader is activated, the user can navigate its defined keymap tree using single letter keystrokes. Actions are leafs on this tree and represent key sequences sent to the UI.

This allows creating mnemonic shortcuts (like those popularized by spacemacs and other vim editor frameworks) that ease repetitive tasks but most importantly: allow the user to have shortcuts for their particular workflows that fit their mental model.


---

To test this feature, add the toml example at the end of this message on your jjui configuration file. And run this branch:

```shell
nix run github:vic/jjui/leader --refresh
```

Then type the following key sequence (git fetch all): `\`, `g` `f` `a`

---

This change adds "Leader" key support, by default bound to (backslash) `\` as is popular to many vim users.


This change does the following:

- Added Leader key bound to backslash by default.
- Parsers leader entries as part of main context initialization.
- keymap-tree navigation in the UI footer when leader is activated.
- Once a leaf is invoked by the user, defined keys are sent into the UI.
- Detect tea.KeyType on `send` strings: ("enter", "down" "ctrl+s")
- For non tea.KeyType-s, a rune key is sent per each rune in the string.
- Keys are Sequenced properly since tea.Batch does not guarantees the order on which cmds were handled. So we implement sequencing.

---

Example leader configuration:

```toml
[leader.M]
help = "Set bookmark main and push"
send = ["b/move main", "down", "enter", "gp", "enter"]

[leader.g]
help = "Git"

[leader.gff]
help = "Git Fetch"
send = ["gf", "enter"]

[leader.gfa]
help = "Git Fetch All"
send = ["g/fetch --all", "down", "enter"]

[leader.gpc]
help = "Git Push Change"
send = ["g/push --change", "down", "enter"]

[leader.gpa]
help = "Git Push All"
send = ["g/fetch --all", "down", "enter"]


# These do not currently work since J has bugs.
#
# NOTE:: Looks like `J` (jump-to-parent) is not working in main branch.
#
#[leader.T]
#help = "New TODO"
#
#[leader.Ta]
#help = "New TODO After"
#send = ["n", "enter", "TODO", "ctrl+s", "rJa", "enter"]
#
#[leader.Tb]
#help = "New TODO Before"
#send = ["n", "enter", "TODO", "ctrl+s" ,"rJb", "enter"]

[leader.h]
help = "Help"
send = ["?"]
```
