### PR TITLE
add predefined shortcuts to certain menu items in git, bookmarks and custom commands

### DIFF
--- a/internal/ui/common/list.go
+++ b/internal/ui/common/list.go
@@ -1,0 +1,131 @@
+package common
+
+import (
+	"github.com/charmbracelet/bubbles/key"
+	"github.com/charmbracelet/bubbles/list"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/idursun/jjui/internal/config"
+)
+
+type FilterableList struct {
+	List          list.Model
+	Items         []list.Item
+	Filter        string
+	KeyMap        config.KeyMappings[key.Binding]
+	Width         int
+	Height        int
+	FilterMatches func(item list.Item, filter string) bool
+	Title         string
+}
+
+type FilterMatchFunc func(list.Item, string) bool
+
+func DefaultFilterMatch(item list.Item, filter string) bool {
+	return true
+}
+
+func NewFilterableList(items []list.Item, width int, height int, keyMap config.KeyMappings[key.Binding]) FilterableList {
+	l := list.New(items, ListItemDelegate{}, width, height)
+	l.SetShowTitle(false)
+	l.SetShowStatusBar(false)
+	l.SetShowFilter(true)
+	l.SetShowPagination(true)
+	l.SetFilteringEnabled(true)
+	l.SetShowHelp(false)
+	l.DisableQuitKeybindings()
+	l.Styles.NoItems = DefaultPalette.Dimmed
+
+	m := FilterableList{
+		List:          l,
+		Items:         items,
+		KeyMap:        keyMap,
+		Width:         width,
+		Height:        height,
+		FilterMatches: DefaultFilterMatch,
+	}
+
+	return m
+}
+
+func (m *FilterableList) SetWidth(w int) {
+	m.Width = w
+	m.List.SetWidth(w)
+}
+
+func (m *FilterableList) SetHeight(h int) {
+	maxHeight, minHeight := 30, 10
+	m.Height = max(min(maxHeight, h-4), minHeight)
+	m.List.SetHeight(m.Height - 6)
+}
+
+func (m *FilterableList) ShowShortcuts(show bool) {
+	m.List.SetDelegate(ListItemDelegate{ShowShortcuts: show})
+}
+
+func (m *FilterableList) Filtered(filter string) tea.Cmd {
+	m.Filter = filter
+	if m.Filter == "" {
+		m.List.SetDelegate(ListItemDelegate{ShowShortcuts: false})
+		return m.List.SetItems(m.Items)
+	}
+
+	m.List.SetDelegate(ListItemDelegate{ShowShortcuts: true})
+	var filtered []list.Item
+	for _, i := range m.Items {
+		if m.FilterMatches(i, m.Filter) {
+			filtered = append(filtered, i)
+		}
+	}
+	m.List.ResetSelected()
+	return m.List.SetItems(filtered)
+}
+
+func (m *FilterableList) RenderFilterView() string {
+	filterStyle := DefaultPalette.Shortcut.PaddingLeft(1)
+	filterValueStyle := DefaultPalette.Normal.Bold(true)
+
+	filterView := lipgloss.JoinHorizontal(0, filterStyle.Render("Showing "), filterValueStyle.Render("all"))
+	if m.Filter != "" {
+		filterView = lipgloss.JoinHorizontal(0, filterStyle.Render("Showing only "), filterValueStyle.Render(m.Filter))
+	}
+	return filterView
+}
+
+func (m *FilterableList) RenderHelpView(helpKeys []key.Binding) string {
+	if m.List.SettingFilter() {
+		return ""
+	}
+
+	bindings := make([]string, 0, len(helpKeys)+1)
+	for _, k := range helpKeys {
+		if renderedKey := RenderKey(k); renderedKey != "" {
+			bindings = append(bindings, renderedKey)
+		}
+	}
+
+	if m.List.IsFiltered() {
+		bindings = append(bindings, RenderKey(m.KeyMap.Cancel))
+	} else {
+		bindings = append(bindings, RenderKey(m.List.KeyMap.Filter))
+	}
+
+	return " " + lipgloss.JoinHorizontal(0, bindings...)
+}
+
+func RenderKey(k key.Binding) string {
+	if !k.Enabled() {
+		return ""
+	}
+	return lipgloss.JoinHorizontal(0, DefaultPalette.Shortcut.Render(k.Help().Key, ""), DefaultPalette.Dimmed.Render(k.Help().Desc, ""))
+}
+
+func (m *FilterableList) View(helpKeys []key.Binding) string {
+	titleView := m.List.Styles.Title.Render(m.Title)
+	filterView := m.RenderFilterView()
+	listView := m.List.View()
+	helpView := m.RenderHelpView(helpKeys)
+	content := lipgloss.JoinVertical(0, titleView, "", filterView, listView, "", helpView)
+	content = lipgloss.Place(m.Width, m.Height, 0, 0, content)
+	return lipgloss.NewStyle().Border(lipgloss.NormalBorder()).Render(content)
+}

--- a/internal/ui/common/list_item_delegate.go
+++ b/internal/ui/common/list_item_delegate.go
@@ -1,0 +1,102 @@
+package common
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/charmbracelet/bubbles/list"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/idursun/jjui/internal/config"
+)
+
+type ListItem interface {
+	list.DefaultItem
+	ShortCut() string
+}
+
+type ListItemDelegate struct {
+	ShowShortcuts bool
+}
+
+func (l ListItemDelegate) Render(w io.Writer, m list.Model, index int, item list.Item) {
+	var (
+		title    string
+		desc     string
+		shortcut string
+	)
+	if item, ok := item.(ListItem); ok {
+		title = item.Title()
+		desc = item.Description()
+		shortcut = item.ShortCut()
+	} else {
+		return
+	}
+	if m.Width() <= 0 {
+		// short-circuit
+		return
+	}
+
+	if !l.ShowShortcuts {
+		shortcut = ""
+	}
+
+	titleWidth := m.Width()
+	if shortcut != "" {
+		titleWidth -= lipgloss.Width(shortcut) + 1
+	}
+
+	if len(title) > titleWidth {
+		title = title[:titleWidth-3] + "..."
+	}
+
+	if len(desc) > m.Width() {
+		desc = desc[:m.Width()-3] + "..."
+	}
+
+	var (
+		titleStyle    = DefaultPalette.Normal
+		descStyle     = DefaultPalette.Dimmed
+		shortcutStyle = DefaultPalette.Shortcut
+	)
+
+	highlightColor := lipgloss.AdaptiveColor{
+		Light: config.Current.UI.HighlightLight,
+		Dark:  config.Current.UI.HighlightDark,
+	}
+
+	if index == m.Index() {
+		titleStyle = DefaultPalette.CompletionMatched.
+			Bold(true).
+			Background(highlightColor)
+		descStyle = DefaultPalette.CompletionSelected.
+			Background(highlightColor)
+		shortcutStyle = shortcutStyle.Background(highlightColor)
+	}
+
+	titleStyle = titleStyle.Width(titleWidth)
+	descStyle = descStyle.Width(m.Width())
+
+	_, _ = fmt.Fprint(w, " ")
+	if shortcut != "" {
+		_, _ = fmt.Fprint(w, lipgloss.JoinHorizontal(0, shortcutStyle.Render(shortcut, ""), titleStyle.Render(title)))
+	} else {
+		_, _ = fmt.Fprint(w, titleStyle.Render(title))
+	}
+	_, _ = fmt.Fprintln(w)
+	_, _ = fmt.Fprint(w, " ")
+	_, _ = fmt.Fprintf(w, descStyle.Render(desc))
+	_, _ = fmt.Fprint(w, " ")
+}
+
+func (l ListItemDelegate) Height() int {
+	return 1
+}
+
+func (l ListItemDelegate) Spacing() int {
+	return 1
+}
+
+func (l ListItemDelegate) Update(msg tea.Msg, m *list.Model) tea.Cmd {
+	return nil
+}

--- a/internal/ui/git/git.go
+++ b/internal/ui/git/git.go
@@ -5,15 +5,11 @@ import (
 	"github.com/charmbracelet/bubbles/key"
 	"github.com/charmbracelet/bubbles/list"
 	tea "github.com/charmbracelet/bubbletea"
-	"github.com/charmbracelet/lipgloss"
 	"github.com/idursun/jjui/internal/config"
 	"github.com/idursun/jjui/internal/jj"
 	"github.com/idursun/jjui/internal/ui/common"
 	"github.com/idursun/jjui/internal/ui/context"
 )
-
-var filterStyle = common.DefaultPalette.Shortcut.PaddingLeft(2)
-var filterValueStyle = common.DefaultPalette.Normal.Bold(true)
 
 type itemCategory string
 
@@ -47,35 +43,25 @@ func (i item) Description() string {
 }
 
 type Model struct {
-	context *context.MainContext
-	keymap  config.KeyMappings[key.Binding]
-	list    list.Model
-	items   []list.Item
-	filter  itemCategory
-	width   int
-	height  int
+	context        *context.MainContext
+	keymap         config.KeyMappings[key.Binding]
+	filterableList common.FilterableList
 }
 
 func (m *Model) Width() int {
-	return m.width
+	return m.filterableList.Width
 }
 
 func (m *Model) Height() int {
-	return m.height
+	return m.filterableList.Height
 }
 
 func (m *Model) SetWidth(w int) {
-	//maxWidth, minWidth := 80, 40
-	//m.width = max(min(maxWidth, w-4), minWidth)
-	//m.list.SetWidth(m.width - 8)
-	m.width = w
-	m.list.SetWidth(w)
+	m.filterableList.SetWidth(w)
 }
 
 func (m *Model) SetHeight(h int) {
-	maxHeight, minHeight := 30, 10
-	m.height = max(min(maxHeight, h-4), minHeight)
-	m.list.SetHeight(m.height - 6)
+	m.filterableList.SetHeight(h)
 }
 
 func (m *Model) Init() tea.Cmd {
@@ -85,89 +71,47 @@ func (m *Model) Init() tea.Cmd {
 func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
-		if m.list.SettingFilter() {
+		if m.filterableList.List.SettingFilter() {
 			break
 		}
 		switch {
 		case key.Matches(msg, m.keymap.Apply):
-			action := m.list.SelectedItem().(item)
+			action := m.filterableList.List.SelectedItem().(item)
 			return m, m.context.RunCommand(jj.Args(action.command...), common.Refresh, common.Close)
 		case key.Matches(msg, m.keymap.Cancel):
-			if m.filter != "" || m.list.IsFiltered() {
-				m.list.ResetFilter()
+			if m.filterableList.Filter != "" || m.filterableList.List.IsFiltered() {
+				m.filterableList.List.ResetFilter()
 				return m.filtered("")
 			}
 			return m, common.Close
-		case key.Matches(msg, m.keymap.Git.Push) && m.filter != itemCategoryPush:
-			return m.filtered(itemCategoryPush)
-		case key.Matches(msg, m.keymap.Git.Fetch) && m.filter != itemCategoryFetch:
-			return m.filtered(itemCategoryFetch)
+		case key.Matches(msg, m.keymap.Git.Push) && m.filterableList.Filter != string(itemCategoryPush):
+			return m.filtered(string(itemCategoryPush))
+		case key.Matches(msg, m.keymap.Git.Fetch) && m.filterableList.Filter != string(itemCategoryFetch):
+			return m.filtered(string(itemCategoryFetch))
 		default:
-			for _, listItem := range m.list.Items() {
-				if item, ok := listItem.(item); ok && m.filter != "" && item.key == msg.String() {
+			for _, listItem := range m.filterableList.List.Items() {
+				if item, ok := listItem.(item); ok && m.filterableList.Filter != "" && item.key == msg.String() {
 					return m, m.context.RunCommand(jj.Args(item.command...), common.Refresh, common.Close)
 				}
 			}
 		}
 	}
 	var cmd tea.Cmd
-	m.list, cmd = m.list.Update(msg)
+	m.filterableList.List, cmd = m.filterableList.List.Update(msg)
 	return m, cmd
 }
 
+func (m *Model) filtered(filter string) (tea.Model, tea.Cmd) {
+	return m, m.filterableList.Filtered(filter)
+}
+
 func (m *Model) View() string {
-	title := m.list.Styles.Title.Render(m.list.Title)
-	filterView := lipgloss.JoinHorizontal(0, filterStyle.Render("Showing "), filterValueStyle.Render("all"))
-	if m.filter != "" {
-		filterView = lipgloss.JoinHorizontal(0, filterStyle.Render("Showing only "), filterValueStyle.Render(string(m.filter)))
-	}
-	listView := m.list.View()
-	helpView := m.helpView()
-	content := lipgloss.JoinVertical(0, title, "", filterView, listView, "", helpView)
-	content = lipgloss.Place(m.width, m.height, 0, 0, content)
-	return lipgloss.NewStyle().Border(lipgloss.NormalBorder()).Padding(0).Render(content)
-}
-
-func renderKey(k key.Binding) string {
-	if !k.Enabled() {
-		return ""
-	}
-	return lipgloss.JoinHorizontal(0, common.DefaultPalette.Shortcut.Render(k.Help().Key, ""), common.DefaultPalette.Dimmed.Render(k.Help().Desc, ""))
-}
-
-func (m *Model) helpView() string {
-	if m.list.SettingFilter() {
-		return ""
-	}
-	bindings := []string{
-		renderKey(m.keymap.Git.Push),
-		renderKey(m.keymap.Git.Fetch),
-	}
-	if m.list.IsFiltered() {
-		bindings = append(bindings, renderKey(m.keymap.Cancel))
-	} else {
-		bindings = append(bindings, renderKey(m.list.KeyMap.Filter))
+	helpKeys := []key.Binding{
+		m.keymap.Git.Push,
+		m.keymap.Git.Fetch,
 	}
 
-	return " " + lipgloss.JoinHorizontal(0, bindings...)
-}
-
-func (m *Model) filtered(filter itemCategory) (tea.Model, tea.Cmd) {
-	m.filter = filter
-	if m.filter == "" {
-		m.list.SetDelegate(common.ListItemDelegate{ShowShortcuts: false})
-		return m, m.list.SetItems(m.items)
-	}
-	m.list.SetDelegate(common.ListItemDelegate{ShowShortcuts: true})
-	var filtered []list.Item
-	for _, i := range m.items {
-		if item, ok := i.(item); !ok || item.category != m.filter {
-			continue
-		}
-		filtered = append(filtered, i)
-	}
-	m.list.ResetSelected()
-	return m, m.list.SetItems(filtered)
+	return m.filterableList.View(helpKeys)
 }
 
 func loadBookmarks(c context.CommandRunner, changeId string) []jj.Bookmark {
@@ -225,23 +169,20 @@ func NewModel(c *context.MainContext, commit *jj.Commit, width int, height int) 
 		item{name: "git fetch --all-remotes", desc: "Fetch from all remotes", command: jj.GitFetch("--all-remotes"), category: itemCategoryFetch, key: "a"},
 	)
 
-	l := list.New(items, common.ListItemDelegate{}, width, height)
-	l.SetShowTitle(true)
-	l.Title = "Git Operations"
-	l.SetShowTitle(false)
-	l.SetShowStatusBar(false)
-	l.SetShowFilter(true)
-	l.SetShowPagination(true)
-	l.SetFilteringEnabled(true)
-	l.SetShowHelp(false)
-	l.DisableQuitKeybindings()
-	l.Styles.NoItems = common.DefaultPalette.Dimmed
+	keymap := config.Current.GetKeyMap()
+	filterableList := common.NewFilterableList(items, width, height, keymap)
+	filterableList.Title = "Git Operations"
+	filterableList.FilterMatches = func(i list.Item, filter string) bool {
+		if gitItem, ok := i.(item); ok {
+			return gitItem.category == itemCategory(filter)
+		}
+		return false
+	}
 
 	m := &Model{
-		context: c,
-		list:    l,
-		items:   items,
-		keymap:  config.Current.GetKeyMap(),
+		context:        c,
+		filterableList: filterableList,
+		keymap:         keymap,
 	}
 	m.SetWidth(width)
 	m.SetHeight(height)

--- a/internal/ui/git/git.go
+++ b/internal/ui/git/git.go
@@ -225,9 +225,7 @@ func NewModel(c *context.MainContext, commit *jj.Commit, width int, height int) 
 		item{name: "git fetch --all-remotes", desc: "Fetch from all remotes", command: jj.GitFetch("--all-remotes"), category: itemCategoryFetch, key: "a"},
 	)
 
-	delegate := common.ListItemDelegate{}
-
-	l := list.New(items, delegate, width, height)
+	l := list.New(items, common.ListItemDelegate{}, width, height)
 	l.SetShowTitle(true)
 	l.Title = "Git Operations"
 	l.SetShowTitle(false)

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -130,7 +130,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			cmds = append(cmds, m.stacked.Init())
 		case key.Matches(msg, m.keyMap.Bookmark.Mode) && m.revisions.InNormalMode():
 			changeIds := m.revisions.GetCommitIds()
-			m.stacked = bookmarks.NewModel(m.context, m.revisions.SelectedRevision(), changeIds, m.width, m.height)
+			m.stacked = bookmarks.NewModel(m.context, m.revisions.SelectedRevision(), changeIds, 80, 30)
 			cmds = append(cmds, m.stacked.Init())
 		case key.Matches(msg, m.keyMap.Help):
 			cmds = append(cmds, common.ToggleHelp)
@@ -144,7 +144,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case key.Matches(msg, m.keyMap.Preview.Shrink):
 			m.previewWindowPercentage -= config.Current.Preview.WidthIncrementPercentage
 		case key.Matches(msg, m.keyMap.CustomCommands):
-			m.stacked = customcommands.NewModel(m.context, m.width, m.height)
+			m.stacked = customcommands.NewModel(m.context, 80, 30)
 			cmds = append(cmds, m.stacked.Init())
 		case key.Matches(msg, m.keyMap.QuickSearch) && m.oplog != nil:
 			// HACK: prevents quick search from activating in op log view

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -123,7 +123,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.revsetModel, _ = m.revsetModel.Update(revset.EditRevSetMsg{Clear: m.state != common.Error})
 			return m, nil
 		case key.Matches(msg, m.keyMap.Git.Mode) && m.revisions.InNormalMode():
-			m.stacked = git.NewModel(m.context, m.revisions.SelectedRevision(), m.width, m.height)
+			m.stacked = git.NewModel(m.context, m.revisions.SelectedRevision(), 80, 30)
 			return m, m.stacked.Init()
 		case key.Matches(msg, m.keyMap.Undo) && m.revisions.InNormalMode():
 			m.stacked = undo.NewModel(m.context)
@@ -202,6 +202,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			s.SetHeight(m.height - 2)
 		}
 		m.status.SetWidth(m.width)
+		m.revisions.SetHeight(m.height)
+		m.revisions.SetWidth(m.width)
 	}
 
 	if m.revsetModel.Editing {


### PR DESCRIPTION
Inline with what's asked in #102, these changes introduce predefined shortcuts to certain menu items so that they can be invoked without having to choose and press enter on them.

For example in git menu, _git push --all_ can be invoked by pressing `gpa`.
<img width="712" height="583" alt="image" src="https://github.com/user-attachments/assets/164aa36b-7f92-4317-8444-e33456f46c35" />

In bookmarks, the _main_ or the _master_ branch can be moved by pressing `bmm`.

<img width="712" height="511" alt="image" src="https://github.com/user-attachments/assets/e7bfbeb7-f15f-4a97-a054-2ffa162d060b" />

Additionally, custom commands window now shows the assigned keys of each custom command and invokes it when the key is pressed.

<img width="716" height="544" alt="image" src="https://github.com/user-attachments/assets/b9521e7d-7644-42f7-9ad7-baf74a3bd11c" />


closes #102 