### PR TITLE
feat(exec): Exec key `:` one-shot interactive jj commands.

### DIFF
--- a/internal/config/keys.go
+++ b/internal/config/keys.go
@@ -29,6 +29,8 @@ var DefaultKeyMappings = KeyMappings[keys]{
 	Evolog:            []string{"v"},
 	Help:              []string{"?"},
 	Revset:            []string{"L"},
+	ExecJJ:            []string{":"},
+	ExecShell:         []string{"$"},
 	QuickSearch:       []string{"/"},
 	QuickSearchCycle:  []string{"'"},
 	CustomCommands:    []string{"x"},
@@ -127,6 +129,8 @@ func Convert(m KeyMappings[keys]) KeyMappings[key.Binding] {
 		CustomCommands:    key.NewBinding(key.WithKeys(m.CustomCommands...), key.WithHelp(JoinKeys(m.CustomCommands), "custom commands menu")),
 		Leader:            key.NewBinding(key.WithKeys(m.Leader...), key.WithHelp(JoinKeys(m.Leader), "leader")),
 		Suspend:           key.NewBinding(key.WithKeys(m.Suspend...), key.WithHelp(JoinKeys(m.Suspend), "suspend")),
+		ExecJJ:            key.NewBinding(key.WithKeys(m.ExecJJ...), key.WithHelp(JoinKeys(m.ExecJJ), "interactive jj")),
+		ExecShell:         key.NewBinding(key.WithKeys(m.ExecShell...), key.WithHelp(JoinKeys(m.ExecShell), "interactive shell command")),
 		Rebase: rebaseModeKeys[key.Binding]{
 			Mode:     key.NewBinding(key.WithKeys(m.Rebase.Mode...), key.WithHelp(JoinKeys(m.Rebase.Mode), "rebase")),
 			Revision: key.NewBinding(key.WithKeys(m.Rebase.Revision...), key.WithHelp(JoinKeys(m.Rebase.Revision), "revision")),
@@ -238,6 +242,8 @@ type KeyMappings[T any] struct {
 	Undo              T                         `toml:"undo"`
 	Evolog            T                         `toml:"evolog"`
 	Revset            T                         `toml:"revset"`
+	ExecJJ            T                         `toml:"exec_jj"`
+	ExecShell         T                         `toml:"exec_shell"`
 	QuickSearch       T                         `toml:"quick_search"`
 	QuickSearchCycle  T                         `toml:"quick_search_cycle"`
 	CustomCommands    T                         `toml:"custom_commands"`

--- a/internal/jj/commands.go
+++ b/internal/jj/commands.go
@@ -221,6 +221,15 @@ func Args(args ...string) CommandArgs {
 	return args
 }
 
+// Works by replacing placeholders on a single line, being given to `sh -c`.
+// It does not prefixes files with `file:` like TemplatedArgs does.
+func ShellTemplatedLine(shellLine string, replacements map[string]string) string {
+	for k, v := range replacements {
+		shellLine = strings.ReplaceAll(shellLine, k, v)
+	}
+	return shellLine
+}
+
 func TemplatedArgs(templatedArgs []string, replacements map[string]string) CommandArgs {
 	var args []string
 	if fileReplacement, exists := replacements[FilePlaceholder]; exists {

--- a/internal/ui/common/msgs.go
+++ b/internal/ui/common/msgs.go
@@ -1,8 +1,9 @@
 package common
 
 import (
-	tea "github.com/charmbracelet/bubbletea"
 	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
 )
 
 type (
@@ -31,6 +32,10 @@ type (
 	SelectionChangedMsg struct{}
 	QuickSearchMsg      string
 	UpdateRevSetMsg     string
+	ExecMsg             struct {
+		Line string
+		Mode ExecMode
+	}
 )
 
 type State int
@@ -78,4 +83,19 @@ func UpdateRevSet(revset string) tea.Cmd {
 	return func() tea.Msg {
 		return UpdateRevSetMsg(revset)
 	}
+}
+
+type ExecMode struct {
+	Mode   string
+	Prompt string
+}
+
+var ExecJJ ExecMode = ExecMode{
+	Mode:   "jj",
+	Prompt: ": ",
+}
+
+var ExecShell ExecMode = ExecMode{
+	Mode:   "sh",
+	Prompt: "$ ",
 }

--- a/internal/ui/context/custom_run_command.go
+++ b/internal/ui/context/custom_run_command.go
@@ -38,12 +38,12 @@ func (c CustomRunCommand) IsApplicableTo(item SelectedItem) bool {
 }
 
 func (c CustomRunCommand) Description(ctx *MainContext) string {
-	args := jj.TemplatedArgs(c.Args, c.createReplacements(ctx))
+	args := jj.TemplatedArgs(c.Args, ctx.CreateReplacements())
 	return fmt.Sprintf("jj %s", strings.Join(args, " "))
 }
 
 func (c CustomRunCommand) Prepare(ctx *MainContext) tea.Cmd {
-	replacements := c.createReplacements(ctx)
+	replacements := ctx.CreateReplacements()
 	switch {
 	case c.Show == config.ShowOptionDiff:
 		return func() tea.Msg {
@@ -55,22 +55,4 @@ func (c CustomRunCommand) Prepare(ctx *MainContext) tea.Cmd {
 	default:
 		return ctx.RunCommand(jj.TemplatedArgs(c.Args, replacements), common.Refresh)
 	}
-}
-
-func (c CustomRunCommand) createReplacements(ctx *MainContext) map[string]string {
-	selectedItem := ctx.SelectedItem
-	replacements := make(map[string]string)
-	replacements[jj.RevsetPlaceholder] = ctx.CurrentRevset
-
-	switch selectedItem := selectedItem.(type) {
-	case SelectedRevision:
-		replacements[jj.ChangeIdPlaceholder] = selectedItem.ChangeId
-	case SelectedFile:
-		replacements[jj.ChangeIdPlaceholder] = selectedItem.ChangeId
-		replacements[jj.FilePlaceholder] = selectedItem.File
-	case SelectedOperation:
-		replacements[jj.OperationIdPlaceholder] = selectedItem.OperationId
-	}
-
-	return replacements
 }

--- a/internal/ui/context/main_context.go
+++ b/internal/ui/context/main_context.go
@@ -83,3 +83,22 @@ func NewAppContext(location string) *MainContext {
 	}
 	return m
 }
+
+// context aware replacements for custom commands and exec input.
+func (ctx *MainContext) CreateReplacements() map[string]string {
+	selectedItem := ctx.SelectedItem
+	replacements := make(map[string]string)
+	replacements[jj.RevsetPlaceholder] = ctx.CurrentRevset
+
+	switch selectedItem := selectedItem.(type) {
+	case SelectedRevision:
+		replacements[jj.ChangeIdPlaceholder] = selectedItem.ChangeId
+	case SelectedFile:
+		replacements[jj.ChangeIdPlaceholder] = selectedItem.ChangeId
+		replacements[jj.FilePlaceholder] = selectedItem.File
+	case SelectedOperation:
+		replacements[jj.OperationIdPlaceholder] = selectedItem.OperationId
+	}
+
+	return replacements
+}

--- a/internal/ui/exec_process/exec_process.go
+++ b/internal/ui/exec_process/exec_process.go
@@ -1,0 +1,117 @@
+package exec_process
+
+import (
+	"bufio"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/idursun/jjui/internal/jj"
+	"github.com/idursun/jjui/internal/ui/common"
+	"github.com/idursun/jjui/internal/ui/context"
+)
+
+func ExecMsgFromLine(prompt string, line string) common.ExecMsg {
+	line = strings.TrimSpace(line)
+	switch prompt {
+	case common.ExecShell.Prompt:
+		return common.ExecMsg{
+			Line: line,
+			Mode: common.ExecShell,
+		}
+	default:
+		return common.ExecMsg{
+			Line: line,
+			Mode: common.ExecJJ,
+		}
+	}
+}
+
+func ExecLine(ctx *context.MainContext, msg common.ExecMsg) tea.Cmd {
+	replacements := ctx.CreateReplacements()
+	switch msg.Mode {
+	case common.ExecJJ:
+		args := strings.Fields(msg.Line)
+		args = jj.TemplatedArgs(args, replacements)
+		return exec_program("jj", args)
+	case common.ExecShell:
+		// user input is run via `$SHELL -c` to support user specifying command lines
+		// that have pipes (eg, to a pager) or redirection.
+		program := os.Getenv("SHELL")
+		if len(program) == 0 {
+			program = "sh"
+		}
+		args := []string{
+			"-c",
+			jj.ShellTemplatedLine(msg.Line, replacements),
+		}
+		return exec_program(program, args)
+	}
+	return nil
+}
+
+// This is different from command_runner.RunInteractiveCommand.
+// This function does not capture any IO. We want all IO to be given to the program.
+//
+// If program terminates in less than 5-secs we ask to press a key to return to JJUI.
+// This is useful for programs that would otherwise terminate quickly and just flash.
+//
+// Since programs are run interactively (without capturing stdio) users have
+// already seen output on the terminal, and we don't use the usual CommandRunning or
+// CommandCompleted machinery we use for background jj processes.
+// However if the program fails we ask the user for confirmation before closing
+// and returning stdio back to jjui.
+func exec_program(program string, args []string) tea.Cmd {
+	p := &process{program: program, args: args}
+	return tea.Exec(p, func(err error) tea.Msg {
+		return common.RefreshMsg{}
+	})
+}
+
+type process struct {
+	program string
+	args    []string
+	stdin   io.Reader
+	stdout  io.Writer
+	stderr  io.Writer
+}
+
+// This is a blocking call.
+func (p *process) Run() error {
+	cmd := exec.Command(p.program, p.args...)
+	cmd.Stdin = p.stdin
+	cmd.Stdout = p.stdout
+	cmd.Stderr = p.stderr
+
+	// If program terminates quickly (most likely non interactive commands),
+	// we ask the user to press a key, so they can at least see the output.
+	askUserClose := true
+	go func() {
+		time.Sleep(5 * time.Second)
+		askUserClose = false
+	}()
+
+	err := cmd.Run()
+	// Dont auto-close on error.
+	if askUserClose || err != nil {
+		p.stderr.Write([]byte("\njjui: press enter to continue... "))
+		reader := bufio.NewReader(p.stdin)
+		reader.ReadByte()
+	}
+	return err
+}
+
+func (p *process) SetStdin(stdin io.Reader) {
+	p.stdin = stdin
+
+}
+func (p *process) SetStdout(stdout io.Writer) {
+	p.stdout = stdout
+
+}
+func (p *process) SetStderr(stderr io.Writer) {
+	p.stderr = stderr
+}

--- a/internal/ui/helppage/help.go
+++ b/internal/ui/helppage/help.go
@@ -2,6 +2,7 @@ package helppage
 
 import (
 	"fmt"
+
 	"github.com/charmbracelet/bubbles/key"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
@@ -95,6 +96,9 @@ func (h *Model) View() string {
 		h.printHelp(h.keyMap.Quit),
 		h.printHelp(h.keyMap.Suspend),
 		h.printHelp(h.keyMap.Revset),
+		h.printHeader("Exec"),
+		h.printHelp(h.keyMap.ExecJJ),
+		h.printHelp(h.keyMap.ExecShell),
 		h.printHeader("Revisions"),
 		h.printHelp(h.keyMap.JumpToParent),
 		h.printHelp(h.keyMap.JumpToWorkingCopy),

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -14,6 +14,7 @@ import (
 	"github.com/idursun/jjui/internal/ui/context"
 	customcommands "github.com/idursun/jjui/internal/ui/custom_commands"
 	"github.com/idursun/jjui/internal/ui/diff"
+	"github.com/idursun/jjui/internal/ui/exec_process"
 	"github.com/idursun/jjui/internal/ui/git"
 	"github.com/idursun/jjui/internal/ui/helppage"
 	"github.com/idursun/jjui/internal/ui/leader"
@@ -180,6 +181,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				}
 			}
 		}
+	case common.ExecMsg:
+		return m, exec_process.ExecLine(m.context, msg)
 	case common.ToggleHelpMsg:
 		if m.stacked == nil {
 			m.stacked = helppage.New(m.context)


### PR DESCRIPTION
This feature is inspired by Vim's `:` key and uses the footer line-editor to obtain input just like we have for `/` (search).

For example, using `: restore -i` will run `jj restore -i` command in interactive mode. jj will use the terminal to show its TUI.

## Context aware placeholders.

We use the same facilities that allow CustomCommands to replace pleaceholders like `$file`, `$change_id`, `$operation_id`.

If the user specifies any of these as arguments to their commands they will be replaced with the context value.

## Exec keys shown in help screen

We have two different exec keys: `:`, `$`.

- `:` 
    As described above, allows running jj interactive commands. These commands can make use of the terminal for TUIs.
   Examples: `: help`, `: squash -i`, etc.

- `$`
  Run interactive shell commands via `$SHELL -c "<input>"`.
  Examples: `$ man jj`, `$ jq . $file | bat --paging always`, `$ htop`

Programs are run interactively with full control of stdio, so users can see all output and errors on the terminal as they'd normally do.  Because of this we don't use status spinner nor error notification on the main UI. However, if the program terminates quickly (less than 5 secs) we assume the program was non interactive (eg, `: version` or `$ ls -la`) and we ask the user for confirmation before closing the terminal and returning back to the main UI.

---

## Try this branch.

To try this branch changes, use:

```shell
nix run github:vic/jjui/exec --refresh
```

----

Closes #87