### PR TITLE
fix(exec_shell): Dont replace context values but set env.

### DIFF
--- a/internal/jj/commands.go
+++ b/internal/jj/commands.go
@@ -221,15 +221,6 @@ func Args(args ...string) CommandArgs {
 	return args
 }
 
-// Works by replacing placeholders on a single line, being given to `sh -c`.
-// It does not prefixes files with `file:` like TemplatedArgs does.
-func ShellTemplatedLine(shellLine string, replacements map[string]string) string {
-	for k, v := range replacements {
-		shellLine = strings.ReplaceAll(shellLine, k, v)
-	}
-	return shellLine
-}
-
 func TemplatedArgs(templatedArgs []string, replacements map[string]string) CommandArgs {
 	var args []string
 	if fileReplacement, exists := replacements[FilePlaceholder]; exists {


### PR DESCRIPTION
Instead of replacing context values on the command line string it is much better to expose them as environment variables for the process being run. This way if people use their own scripts they can access the contextual values as exposed on the env.