### PR TITLE
feat(leader): Allow leader entries to specify context requirements.

### DIFF
--- a/internal/ui/context/leader.go
+++ b/internal/ui/context/leader.go
@@ -10,15 +10,17 @@ import (
 type LeaderMap = map[string]*Leader
 
 type Leader struct {
-	Bind *key.Binding
-	Send []string
-	Nest LeaderMap
+	Bind    *key.Binding
+	Send    []string
+	Context []string
+	Nest    LeaderMap
 }
 
 func LoadLeader(content string) (LeaderMap, error) {
 	type leaderTomlEntry struct {
-		Help string
-		Send []string
+		Help    string
+		Send    []string
+		Context []string
 	}
 	type leaderToml struct {
 		Leader map[string]leaderTomlEntry
@@ -35,9 +37,8 @@ func LoadLeader(content string) (LeaderMap, error) {
 		for i, k := range ks {
 			m := checkExists(at, k)
 			if i == len(ks)-1 {
-				if len(v.Send) > 0 {
-					m.Send = v.Send
-				}
+				m.Send = v.Send
+				m.Context = v.Context
 				if len(v.Help) > 0 {
 					m.Bind.SetHelp(k, v.Help)
 				}
@@ -58,7 +59,6 @@ func checkExists(at LeaderMap, k string) *Leader {
 		)
 		m = &Leader{
 			Bind: &b,
-			Send: nil,
 			Nest: LeaderMap{},
 		}
 		at[k] = m

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -78,13 +78,13 @@ func (m Model) handleFocusInputMessage(msg tea.Msg) (tea.Model, tea.Cmd, bool) {
 		return m, nil, false
 	}
 
+	if m.leader != nil {
+		m.leader, cmd = m.leader.Update(msg)
+		return m, cmd, true
+	}
+
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
-		if m.leader != nil {
-			m.leader, cmd = m.leader.Update(msg)
-			return m, cmd, true
-		}
-
 		if m.diff != nil {
 			m.diff, cmd = m.diff.Update(msg)
 			return m, cmd, true
@@ -164,8 +164,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.stacked = customcommands.NewModel(m.context, 80, 30)
 			cmds = append(cmds, m.stacked.Init())
 		case key.Matches(msg, m.keyMap.Leader):
-			m.leader = leader.New(m.context.Leader)
-			cmds = append(cmds, m.leader.Init())
+			m.leader = leader.New(m.context)
+			cmds = append(cmds, leader.InitCmd)
 		case key.Matches(msg, m.keyMap.QuickSearch) && m.oplog != nil:
 			// HACK: prevents quick search from activating in op log view
 			return m, nil


### PR DESCRIPTION
This change allow Leader entries to also have an optional `context` (`[]string`) attribute. When present, it specifies the required context keys that MUST be available for the key to be shown.

This is useful for example for keys or submenus that must be shown only under certain contextual conditions.

The following example restricts the `e` key to be available ONLY when both `$file` and `$change_id` are available in context. That is, when the cursor is on change details over a file.

```toml
[leader.e]
context = [ "$file", "$change_id" ]
help = "Edit current file"
send = [ "$", "jj edit $change_id && $EDITOR $file", "enter" ]
```