### PR TITLE
fix(revisions): Using `J` should work on uppercase templated change_id

### DIFF
--- a/internal/ui/revisions/revisions.go
+++ b/internal/ui/revisions/revisions.go
@@ -3,10 +3,11 @@ package revisions
 import (
 	"bytes"
 	"fmt"
-	"github.com/idursun/jjui/internal/ui/operations/duplicate"
 	"log"
 	"slices"
 	"strings"
+
+	"github.com/idursun/jjui/internal/ui/operations/duplicate"
 
 	"github.com/idursun/jjui/internal/parser"
 	"github.com/idursun/jjui/internal/ui/operations/describe"
@@ -470,11 +471,15 @@ func (m *Model) requestMoreRows(tag uint64) tea.Cmd {
 }
 
 func (m *Model) selectRevision(revision string) int {
+	eqFold := func(other string) bool {
+		return strings.EqualFold(other, revision)
+	}
+
 	idx := slices.IndexFunc(m.rows, func(row parser.Row) bool {
 		if revision == "@" {
 			return row.Commit.IsWorkingCopy
 		}
-		return row.Commit.GetChangeId() == revision || row.Commit.ChangeId == revision || row.Commit.CommitId == revision
+		return eqFold(row.Commit.GetChangeId()) || eqFold(row.Commit.ChangeId) || eqFold(row.Commit.CommitId)
 	})
 	return idx
 }


### PR DESCRIPTION
This change fixes the `J` move to parent when change_id is not lowercase. 


Having the following graph, and starting the top, moving with `J` repeatedly should work like this:

`W`, `78` (change_id), `K`, `M`, `N`, `YPQP` ...


```
○  W vborja@apache.org 1 minute ago C
│  (no description set)
│ ○  R?? vborja@apache.org 1 minute ago A
├─╯  CONFIG_HOME
○  P?? vborja@apache.org 1 minute ago 78
│  (empty) (no description set)
│ ○  R?? vborja@apache.org 1 minute ago E9
│ │  CONFIG_HOME
│ ○  P?? vborja@apache.org 1 minute ago E6
├─╯  (no description set)
○  K vborja@apache.org 1 minute ago context* 5
│  feat(leader): Allow leader entries to specify context requirements.
@  M vborja@apache.org 1 minute ago 77
│  (no description set)
◆  N ibrahim@dursun.cc 21 hours ago main@idursun git_head() 2
│  refactor: unify jj and jjui color unmarshalling logic
◆  YPQP ibrahim@dursun.cc 22 hours ago 462
│  refactor: change batched command order
◆  YSZ vborja@apache.org 22 hours ago DA7
│  fix(exec_shell): Dont replace context values but set env.
```

Closes #191 