### PR TITLE
Use os.Getwd for getting the current dir

### DIFF
--- a/cmd/jjui/main.go
+++ b/cmd/jjui/main.go
@@ -94,7 +94,12 @@ func main() {
 	}
 
 	if location == "" {
-		location = os.Getenv("PWD")
+		var err error
+		if location, err = os.Getwd(); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: couldn't determine the current directory: %v.\n", err)
+			fmt.Fprintf(os.Stderr, "Please pass the location of a `jj` repo as an argument to `jjui`.\n")
+			os.Exit(1)
+		}
 	}
 
 	rootLocation, err := getJJRootDir(location)


### PR DESCRIPTION
The current setup led to a confusing situation when I tried to debug `jjui` and told the debugger to use a different working dir when launching `jjui`. It did so, but since the debugger did not *also* change the PWD variable, `jjui` still used the directory I started the debugger from.

I am not sure whether it is a bug that the `dlv` debugger does not update PWD when run with the `-wd some_dir` argument. However, this commit does make `dlv debug ./cmd/jjui/  --headless --output /tmp/jjui-debug  -l 127.0.0.1:5566 --wd ~/dev/jj` work as expected. (If you try this command, note that the only way to quit it is `kill` or connecting to that port with a debugger client like VS Code, ^C does not work).

This might have some downsides I am unaware of. If using Getwd does not work for some reason, the workaround is to pass the dir to `jjui` as an argument. I did not realize that works initially either, because I expected it to be -R (which we could also add)