### PR TITLE
fix(details): Quote file paths when changing revset from details.

### DIFF
--- a/internal/ui/operations/details/details.go
+++ b/internal/ui/operations/details/details.go
@@ -249,7 +249,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		case key.Matches(msg, m.keyMap.Details.RevisionsChangingFile):
 			if item, ok := m.files.SelectedItem().(item); ok {
-				return m, tea.Batch(common.Close, common.UpdateRevSet(fmt.Sprintf("files(%s)", item.fileName)))
+				return m, tea.Batch(common.Close, common.UpdateRevSet(fmt.Sprintf("files(\"%s\")", item.fileName)))
 			}
 		default:
 			if len(m.files.Items()) > 0 {


### PR DESCRIPTION
This fixes an error when changing the revset from details view when the file path starts with a dot.

.github/workflows/foo

Without this change, the revset sees the first dot as a syntax error (trying to call a function). To prevent this, we quote the full path since maybe other paths could be interpreted as jj expressions unless we quote them as we do now.


Noticed about this when using #203.