### PR TITLE
feat: add command outputs as (auto-expiring) flash messages

### DIFF
--- a/internal/jj/commands.go
+++ b/internal/jj/commands.go
@@ -237,7 +237,7 @@ func TemplatedArgs(templatedArgs []string, replacements map[string]string) Comma
 }
 
 func Absorb(changeId string, files ...string) CommandArgs {
-	args := []string{"absorb", "--from", changeId}
+	args := []string{"absorb", "--from", changeId, "--color", "never"}
 	var escapedFiles []string
 	for _, file := range files {
 		escapedFiles = append(escapedFiles, escapeFileName(file))

--- a/internal/ui/context/command_runner.go
+++ b/internal/ui/context/command_runner.go
@@ -10,6 +10,7 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"slices"
 	"sync"
 )
 
@@ -57,6 +58,9 @@ func (a *MainCommandRunner) RunCommand(args []string, continuations ...tea.Cmd) 
 	commands := make([]tea.Cmd, 0)
 	commands = append(commands,
 		func() tea.Msg {
+			if !slices.Contains(args, "--color") {
+				args = append(args, "--color", "always")
+			}
 			c := exec.Command("jj", args...)
 			c.Dir = a.Location
 			output, err := c.CombinedOutput()

--- a/internal/ui/flash/flash.go
+++ b/internal/ui/flash/flash.go
@@ -1,0 +1,120 @@
+package flash
+
+import (
+	"strings"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/idursun/jjui/internal/ui/common"
+	"github.com/idursun/jjui/internal/ui/context"
+)
+
+const expiringMessageTimeout = 4 * time.Second
+
+type Model struct {
+	context      *context.MainContext
+	messages     []flashMessage
+	successStyle lipgloss.Style
+	errorStyle   lipgloss.Style
+	currentId    uint64
+}
+
+type expireMessageMsg struct {
+	id uint64
+}
+
+type flashMessage struct {
+	text    string
+	error   error
+	timeout int
+	id      uint64
+}
+
+func (m *Model) Init() tea.Cmd {
+	return nil
+}
+
+func (m *Model) Update(msg tea.Msg) (*Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case expireMessageMsg:
+		for i, message := range m.messages {
+			if message.id == msg.id {
+				m.messages = append(m.messages[:i], m.messages[i+1:]...)
+				break
+			}
+		}
+		return m, nil
+	case common.CommandCompletedMsg:
+		id := m.add(msg.Output, msg.Err)
+		if msg.Err == nil {
+			return m, tea.Tick(expiringMessageTimeout, func(t time.Time) tea.Msg {
+				return expireMessageMsg{id: id}
+			})
+		}
+		return m, nil
+	case common.UpdateRevisionsFailedMsg:
+		m.add(msg.Output, msg.Err)
+	}
+	return m, nil
+}
+
+func (m *Model) View() string {
+	messages := m.messages
+	if len(messages) == 0 {
+		return ""
+	}
+
+	var messageBoxes []string
+	for _, message := range messages {
+		style := m.successStyle
+		if message.error != nil {
+			style = m.errorStyle
+			messageBoxes = append(messageBoxes, style.Render(message.text+"\n"+message.error.Error()))
+		} else {
+			messageBoxes = append(messageBoxes, style.Render(message.text))
+		}
+	}
+	return lipgloss.JoinVertical(lipgloss.Right, messageBoxes...)
+}
+
+func (m *Model) add(text string, error error) uint64 {
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return 0
+	}
+
+	msg := flashMessage{
+		id:    m.nextId(),
+		text:  text,
+		error: error,
+	}
+
+	m.messages = append(m.messages, msg)
+	return msg.id
+}
+
+func (m *Model) Any() bool {
+	return len(m.messages) > 0
+}
+
+func (m *Model) DeleteOldest() {
+	m.messages = m.messages[1:]
+}
+
+func (m *Model) nextId() uint64 {
+	m.currentId = m.currentId + 1
+	return m.currentId
+}
+
+func New(context *context.MainContext) *Model {
+	fg := lipgloss.NewStyle().GetForeground()
+	successStyle := common.DefaultPalette.GetBorder("success", lipgloss.NormalBorder()).Foreground(fg).PaddingLeft(1).PaddingRight(1)
+	errorStyle := common.DefaultPalette.GetBorder("error", lipgloss.NormalBorder()).Foreground(fg).PaddingLeft(1).PaddingRight(1)
+	return &Model{
+		context:      context,
+		messages:     make([]flashMessage, 0),
+		successStyle: successStyle,
+		errorStyle:   errorStyle,
+	}
+}


### PR DESCRIPTION
Previously, revset errors were displayed under the revset component and similarly command errors were displayed under the status line. This not only looks out of place but also complicates the widget implementations unnecessarily. 

I have introduced a flash message view, which displays success and error messages at the bottom right corner. Success messages expire after 4 seconds, but error messages are sticky and they are dismissed by pressing `esc`.

Multiple messages stack on top of each other.

<img width="1338" height="864" alt="image" src="https://github.com/user-attachments/assets/ca143ed2-ac3a-4885-9eb3-dcde206d90d5" />

<img width="1338" height="864" alt="image" src="https://github.com/user-attachments/assets/bf2934df-6d8f-48bb-b576-cdd898777902" />

<img width="1338" height="864" alt="image" src="https://github.com/user-attachments/assets/43924513-78cb-41ae-a02a-b0027e9b458b" />

