### PR TITLE
feat(loader): Support JJUI_CONFIG_DIR environment var.

### DIFF
--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -12,6 +12,13 @@ import (
 func getConfigFilePath() string {
 	var configDirs []string
 
+	// useful during development or other non-standard setups.
+	if dir := os.Getenv("JJUI_CONFIG_DIR"); dir != "" {
+		if s, err := os.Stat(dir); err == nil && s.IsDir() {
+			configDirs = append(configDirs, dir)
+		}
+	}
+
 	// os.UserConfigDir() already does this for linux leaving darwin to handle
 	if runtime.GOOS == "darwin" {
 		configDirs = append(configDirs, path.Join(os.Getenv("HOME"), ".config"))


### PR DESCRIPTION
This is useful for jjui developers or other environments that for some reason do not follow conventions.

I (@vic) manage my dot files via nix. When applied, my dot files are immutable, but I still want to experiment with custom settings during jjui development. This change allows me to have jjui to load from a custom directory and not my stable home settings.