### PR TITLE
Add github issue templates.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,32 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+## Description
+
+<!-- Thanks for your report! Please describe your problem or request here.
+For questions, use https://github.com/idursun/jjui/discussions/new instead.
+Feel free to remove any of the sections below if they don't seem useful. -->
+
+
+## Steps to Reproduce the Problem
+
+1.
+1.
+1.
+
+## Expected Behavior
+
+
+## Actual Behavior
+
+
+## Specifications
+
+- Platform:
+- Version:

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,23 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: 'FR: '
+labels: ''
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Why current features fail to cover this request**
+A clear and concise description of why current features cannot solve the problem.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
This can help people describe better their issues and help them explain us how our current features fail to solve their issue.