### PR TITLE
feat(docs): Deploy to gh-pages.

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,40 @@
+name: GH Pages
+on:
+  gollum:
+  workflow_dispatch:
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install mdbook
+        run: |
+          set -e
+          MDBOOK_VERSION=$(curl -s "https://api.github.com/repos/rust-lang/mdBook/releases/latest" | grep -Po '"tag_name": "v\K[0-9.]+')
+          wget -qO mdbook.tar.gz https://github.com/rust-lang/mdBook/releases/latest/download/mdbook-v$MDBOOK_VERSION-x86_64-unknown-linux-gnu.tar.gz
+          sudo tar xf mdbook.tar.gz -C /usr/local/bin mdbook
+          mdbook --version
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          repository: '${{github.repository}}.wiki'
+      - name: Build
+        run: mdbook build
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: './book'
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
This change renders our wiki documentation using [mdbook](https://github.com/rust-lang/mdBook) and publishes to github pages.

[Example published pages (from vic's jjui wiki fork)](https://vic.github.io/jjui/)

The advantage of having our wiki published as gh-pages are:

- People might want to see a beautiful documentation website.
- Our documentation website can be indexed by search engines.
- Generated website has integrated search, syntax lighlight.
- Wiki remains truth of source for documentation.
- Editing docs in wiki is easier and encourages contribution.
- Our website has a `print` button at the top-right, allowing people to save current documentation for offline usage (includes screenshots). see #166

### Enabling GitHub Actions as source for Pages.

> [!IMPORTANT]
>  Before merging, go to repository `Settings` / `Pages`.  Set `Source` to `GitHub Actions`. And *That's It!*

### How it works

The action in this PR clones the current repository's wiki. And then runs mdbook on it and pushes the generated html to gh-pages.

> [!NOTE]
> mdbook expects to find a `book.toml` and associated files  `theme/index.hbs`, These files are in the *wiki repo* (see bellow) since they are not expected to change and are only used for mdbook.

I [forked the wiki](https://github.com/vic/jjui/wiki) to test that everything works and site gets published correctly.

I made the following changes to the wiki:
  - Added SUMMARY.md (this is needed for mdbook to generate the navigation sidebar)
  - Added book.toml and associated theme/ files it expects.

It's not possible to send a PR to the wiki repository, so I will add instructions on how to review the changes I made.

```shell
# Clone original wiki
jj git clone --colocate git@github.com:idursun/jjui.wiki.git jjui-wiki
cd jjui-wiki

# Add vic's remote to see changes
jj git remote add vic git@github.com:vic/jjui.wiki.git
jj git fetch --remote vic

# review changes
jj diff --from master@origin --to master@vic
```

After these changes are pushed to the wiki `master@origin`, this PR can be merged.

The github action included in this PR will automatically run when the wiki is updated (or manually triggered)