### PR TITLE
feat(details): show conflicted files

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ You can download pre-built binaries from the [releases](https://github.com/idurs
 
 ## Compatibility
 
-Minimum supported `jj` version is **v0.21**+.
+Minimum supported `jj` version is **v0.26**+.
 
 ## Contributing
 

--- a/internal/config/jj_config.go
+++ b/internal/config/jj_config.go
@@ -23,6 +23,7 @@ func (c *JJConfig) GetApplicableColors() map[string]Color {
 		"diff modified",
 		"diff removed",
 		"change_id",
+		"conflict",
 	}
 	for _, key := range applicableColorKeys {
 		if color, ok := c.Colors[key]; ok {

--- a/internal/jj/commands.go
+++ b/internal/jj/commands.go
@@ -106,7 +106,8 @@ func Snapshot() CommandArgs {
 }
 
 func Status(revision string) CommandArgs {
-	return []string{"log", "-r", revision, "--summary", "--no-graph", "--color", "never", "--quiet", "--template", "", "--ignore-working-copy"}
+	template := `separate(";", diff.files().map(|x| x.target().conflict())) ++ "\n"`
+	return []string{"log", "-r", revision, "--summary", "--no-graph", "--color", "never", "--quiet", "--template", template, "--ignore-working-copy"}
 }
 
 func BookmarkSet(revision string, name string) CommandArgs {

--- a/internal/ui/operations/details/details_test.go
+++ b/internal/ui/operations/details/details_test.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	Revision     = "ignored"
-	StatusOutput = "M file.txt\nA newfile.txt\n"
+	StatusOutput = "false false\nM file.txt\nA newfile.txt\n"
 )
 
 func TestModel_Init_ExecutesStatusCommand(t *testing.T) {
@@ -68,7 +68,7 @@ func TestModel_Update_SplitsSelectedFiles(t *testing.T) {
 func TestModel_Update_HandlesMovedFiles(t *testing.T) {
 	commandRunner := test.NewTestCommandRunner(t)
 	commandRunner.Expect(jj.Snapshot())
-	commandRunner.Expect(jj.Status(Revision)).SetOutput([]byte("R internal/ui/{revisions => }/file.go\nR {file => sub/newfile}\n"))
+	commandRunner.Expect(jj.Status(Revision)).SetOutput([]byte("false false\nR internal/ui/{revisions => }/file.go\nR {file => sub/newfile}\n"))
 	commandRunner.Expect(jj.Restore(Revision, []string{"internal/ui/file.go", "sub/newfile"}))
 	defer commandRunner.Verify()
 


### PR DESCRIPTION
Adds conflict marker to the file list in the details view. I had to use a template to get this information which is only available after jj v0.26+.

I have tested it manually, and works fine. I will add some tests for this when I get to resolving the flakiness in the details tests suite.

<img width="328" height="54" alt="image" src="https://github.com/user-attachments/assets/6f42e7c0-8dab-46c4-b3ae-cdd39e9c23a2" />


fixes #209