### PR TITLE
enhance fuzzy-file live preview. add contextual help and open file in editor

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -151,7 +151,7 @@ func (s *ShowOption) UnmarshalText(text []byte) error {
 	}
 }
 
-func getDefaultEditor() string {
+func GetDefaultEditor() string {
 	editor := os.Getenv("EDITOR")
 	if editor == "" {
 		editor = os.Getenv("VISUAL")
@@ -192,7 +192,7 @@ func Edit() int {
 		}
 	}
 
-	editor := getDefaultEditor()
+	editor := GetDefaultEditor()
 	if editor == "" {
 		log.Fatal("No editor found. Please set $EDITOR or $VISUAL")
 	}


### PR DESCRIPTION


The fuzzy file search now provides much better experience for real-time feedback, improved keybidning discoverability and edit file capabilities.

- Live preview mode now works with debounced revset updates to prevent excessive UI refreshes.

- when the editor on status line is active it is now able to show contextual help or keybindings.

- we now show keybindings available while file finder is active. this allows better key discoverability, since these keys are part of the editing mode and not global to the ui.

- re-use our GetDefaultEditor function and ExecShell to allow the user directly edit by using alt+e while on file finder.



Will open another PR to move hardcoded keybindings to our default toml file.