### PR TITLE
feat(revisions): Ace jump to revision. `f` key on revisions view.

### DIFF
--- a/internal/config/default/config.toml
+++ b/internal/config/default/config.toml
@@ -27,6 +27,7 @@ limit = 0
   revset = ["L"]
   exec_jj = [":"]
   exec_shell = ["$"]
+  ace_jump = ["f"]
   quick_search = ["/"]
   quick_search_cycle = ["'"]
   custom_commands = ["x"]

--- a/internal/config/keys.go
+++ b/internal/config/keys.go
@@ -31,6 +31,7 @@ func Convert(m KeyMappings[keys]) KeyMappings[key.Binding] {
 		Help:              key.NewBinding(key.WithKeys(m.Help...), key.WithHelp(JoinKeys(m.Help), "help")),
 		Evolog:            key.NewBinding(key.WithKeys(m.Evolog...), key.WithHelp(JoinKeys(m.Evolog), "evolog")),
 		Revset:            key.NewBinding(key.WithKeys(m.Revset...), key.WithHelp(JoinKeys(m.Revset), "revset")),
+		AceJump:           key.NewBinding(key.WithKeys(m.AceJump...), key.WithHelp(JoinKeys(m.AceJump), "ace jump")),
 		QuickSearch:       key.NewBinding(key.WithKeys(m.QuickSearch...), key.WithHelp(JoinKeys(m.QuickSearch), "quick search")),
 		QuickSearchCycle:  key.NewBinding(key.WithKeys(m.QuickSearchCycle...), key.WithHelp(JoinKeys(m.QuickSearchCycle), "locate next match")),
 		CustomCommands:    key.NewBinding(key.WithKeys(m.CustomCommands...), key.WithHelp(JoinKeys(m.CustomCommands), "custom commands menu")),
@@ -159,6 +160,7 @@ type KeyMappings[T any] struct {
 	Revset            T                         `toml:"revset"`
 	ExecJJ            T                         `toml:"exec_jj"`
 	ExecShell         T                         `toml:"exec_shell"`
+	AceJump           T                         `toml:"ace_jump"`
 	QuickSearch       T                         `toml:"quick_search"`
 	QuickSearchCycle  T                         `toml:"quick_search_cycle"`
 	CustomCommands    T                         `toml:"custom_commands"`

--- a/internal/ui/ace_jump/ace_jump.go
+++ b/internal/ui/ace_jump/ace_jump.go
@@ -1,0 +1,91 @@
+package ace_jump
+
+import (
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/charmbracelet/bubbles/key"
+)
+
+type AceKey struct {
+	RowIdx  int
+	id      string
+	bindIdx int
+	bind    key.Binding
+}
+
+type AceJump struct {
+	ace    []*AceKey
+	prefix string
+}
+
+func NewAceJump() *AceJump {
+	return &AceJump{
+		ace:    []*AceKey{},
+		prefix: "",
+	}
+}
+
+func (j *AceJump) Prefix() *string {
+	if j == nil {
+		return nil
+	}
+	return &j.prefix
+}
+
+func (j *AceJump) Append(rowIdx int, id string, bindIdx int) {
+	j.ace = append(j.ace, &AceKey{
+		RowIdx:  rowIdx,
+		id:      id,
+		bindIdx: bindIdx,
+		bind:    aceBindingAt(id, bindIdx),
+	})
+}
+
+func (j *AceJump) First() *AceKey {
+	return j.ace[0]
+}
+
+func (j *AceJump) bindKeys() {
+	for _, a := range j.ace {
+		a.bind = aceBindingAt(a.id, a.bindIdx)
+	}
+}
+
+// returns the single match or nil after narrowing
+func (j *AceJump) Narrow(k tea.KeyMsg) *AceKey {
+	narrow := []*AceKey{}
+	prefixIncremented := false
+	for _, a := range j.ace {
+		if key.Matches(k, a.bind) {
+			if !prefixIncremented {
+				prefixIncremented = true
+				j.prefix = j.prefix + string(a.id[a.bindIdx])
+			}
+			narrow = append(narrow, a)
+			if a.bindIdx+1 < len(a.id) {
+				a.bindIdx++
+			}
+		}
+	}
+
+	if len(narrow) == 1 {
+		return narrow[0]
+	}
+
+	if len(narrow) > 0 {
+		j.ace = narrow
+		j.bindKeys()
+	}
+	return nil
+}
+
+func aceBindingAt(id string, idx int) key.Binding {
+	bs := string(id[idx])
+	lbs, ubs := strings.ToLower(bs), strings.ToUpper(bs)
+	return key.NewBinding(
+		key.WithKeys(lbs, ubs),
+		key.WithHelp(bs, id),
+	)
+}

--- a/internal/ui/helppage/help.go
+++ b/internal/ui/helppage/help.go
@@ -104,6 +104,7 @@ func (h *Model) View() string {
 			h.keyMap.JumpToWorkingCopy.Help().Key,
 		), "jump to parent/child/working-copy"),
 		h.printKeyBinding(h.keyMap.ToggleSelect),
+		h.printKeyBinding(h.keyMap.AceJump),
 		h.printKeyBinding(h.keyMap.QuickSearch),
 		h.printKeyBinding(h.keyMap.QuickSearchCycle),
 		h.printKeyBinding(h.keyMap.FileSearch.Toggle),

--- a/internal/ui/revisions/ace_jump.go
+++ b/internal/ui/revisions/ace_jump.go
@@ -1,0 +1,39 @@
+package revisions
+
+import (
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/idursun/jjui/internal/ui/ace_jump"
+)
+
+func (m *Model) IsAceJumping() bool {
+	return m.aceJump != nil
+}
+
+func (m *Model) HandleAceJump(k tea.KeyMsg) tea.Cmd {
+	if k.String() == tea.KeyEscape.String() {
+		m.aceJump = nil
+	} else if k.String() == tea.KeyEnter.String() {
+		m.cursor = m.aceJump.First().RowIdx
+		m.aceJump = nil
+	} else if found := m.aceJump.Narrow(k); found != nil {
+		m.cursor = found.RowIdx
+		m.aceJump = nil
+	}
+	return nil
+}
+
+func (m *Model) findAceKeys() *ace_jump.AceJump {
+	aj := ace_jump.NewAceJump()
+	for i, row := range m.rows {
+		c := row.Commit
+		if c == nil {
+			continue
+		}
+		aj.Append(i, c.CommitId, 0)
+		if c.Hidden || c.IsConflicting() || c.IsRoot() {
+			continue
+		}
+		aj.Append(i, c.ChangeId, 0)
+	}
+	return aj
+}

--- a/internal/ui/revisions/revisions.go
+++ b/internal/ui/revisions/revisions.go
@@ -7,6 +7,7 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/idursun/jjui/internal/ui/ace_jump"
 	"github.com/idursun/jjui/internal/ui/operations/duplicate"
 
 	"github.com/idursun/jjui/internal/parser"
@@ -47,6 +48,7 @@ type Model struct {
 	keymap            config.KeyMappings[key.Binding]
 	output            string
 	err               error
+	aceJump           *ace_jump.AceJump
 	quickSearch       string
 	selectedRevisions map[string]bool
 	previousOpLogId   string
@@ -278,6 +280,9 @@ func (m *Model) Update(msg tea.Msg) (*Model, tea.Cmd) {
 				m.cursor = workingCopyIndex
 			}
 			return m, m.updateSelection()
+		case key.Matches(msg, m.keymap.AceJump):
+			m.aceJump = m.findAceKeys()
+			return m, nil
 		default:
 			if op, ok := m.op.(operations.HandleKey); ok {
 				cmd = op.HandleKey(msg)
@@ -431,6 +436,7 @@ func (m *Model) View() string {
 	renderer.Cursor = m.cursor
 	renderer.Selections = m.selectedRevisions
 	renderer.SearchText = m.quickSearch
+	renderer.AceJumpPrefix = m.aceJump.Prefix()
 	m.w.SetSize(m.width, m.height)
 	output := m.w.Render(renderer)
 	output = m.textStyle.MaxWidth(m.width).Render(output)

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -59,6 +59,11 @@ func (m Model) handleFocusInputMessage(msg tea.Msg) (tea.Model, tea.Cmd, bool) {
 		return m, leader.TakePending(x), true
 	}
 
+	// capture all keys while on aceJump mode.
+	if k, ok := msg.(tea.KeyMsg); ok && m.revisions.IsAceJumping() {
+		return m, m.revisions.HandleAceJump(k), true
+	}
+
 	var cmd tea.Cmd
 	if _, ok := msg.(common.CloseViewMsg); ok {
 		if m.leader != nil {


### PR DESCRIPTION
This feature implements a simple vim like ace-jump to quickly move to revisions (`revisions.rows`) from the current revset.

Pressing `f` will highlight the first character of each change_id (only non-hidden, non-conflicting, and non-root) or each commit_id.

Wile ace-jump is enabled a temporary case-insensitive keymap is created that matches the next available keys from revisions ids. When an unambiguous revision is selected via its shortest id, the cursor is moved to that revision row.

This allows to have much faster movements than currently using `/` search and `'`

And also opens the door for a future PR to explore on making `/` work with fuzzy search (to match on full-description and not only on the content of the log being displayed) while preserving fast movements on revisions with `f` 