### PR TITLE
fix(ace_jump): Allow jump only to revisions visible on screen

### DIFF
--- a/internal/ui/revisions/ace_jump.go
+++ b/internal/ui/revisions/ace_jump.go
@@ -24,7 +24,13 @@ func (m *Model) HandleAceJump(k tea.KeyMsg) tea.Cmd {
 
 func (m *Model) findAceKeys() *ace_jump.AceJump {
 	aj := ace_jump.NewAceJump()
-	for i, row := range m.rows {
+	first, last := m.w.FirstRowIndex(), m.w.LastRowIndex()
+	if first == -1 || last == -1 {
+		return nil // wait until rendered
+	}
+	for i := range last - first + 1 {
+		i += first
+		row := m.rows[i]
 		c := row.Commit
 		if c == nil {
 			continue


### PR DESCRIPTION
Reducing the number of jump candidates to only those visible on screen improves the experience since you will likely jump faster as there are less revisions with the same prefix. It also avoids long-jumping to off-screen revisions since that felt weird. 

Thanks to the insight at https://github.com/idursun/jjui/pull/226#issuecomment-3128000055