### PR TITLE
feat(revisions): Move to revision parent when toggle selection.

### DIFF
--- a/internal/ui/revisions/revisions.go
+++ b/internal/ui/revisions/revisions.go
@@ -291,8 +291,14 @@ func (m *Model) Update(msg tea.Msg) (*Model, tea.Cmd) {
 
 			switch {
 			case key.Matches(msg, m.keymap.ToggleSelect):
-				changeId := m.rows[m.cursor].Commit.GetChangeId()
+				commit := m.rows[m.cursor].Commit
+				changeId := commit.GetChangeId()
 				m.selectedRevisions[changeId] = !m.selectedRevisions[changeId]
+				immediate, _ := m.context.RunCommandImmediate(jj.GetParent(jj.NewSelectedRevisions(commit)))
+				parentIndex := m.selectRevision(string(immediate))
+				if parentIndex != -1 {
+					m.cursor = parentIndex
+				}
 			case key.Matches(msg, m.keymap.Cancel):
 				m.op = operations.NewDefault()
 			case key.Matches(msg, m.keymap.QuickSearchCycle):


### PR DESCRIPTION
Automatically moves the cursor to the revision parent (on same branch) when a revision selection is toggled.

This is a QOL improvement when working on multiple revisions as you no longer have to move and only press space.

Implements the proposal from [#221 comment](https://github.com/idursun/jjui/discussions/221#discussioncomment-13898398) and makes moving-on-selection consistent on both revisions and files.