### PR TITLE
fix(preview): Limit preview resize to range 5% up to 95%.

### DIFF
--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -164,9 +164,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.previewVisible = !m.previewVisible
 			cmds = append(cmds, common.SelectionChanged)
 			return m, tea.Batch(cmds...)
-		case key.Matches(msg, m.keyMap.Preview.Expand):
+		case key.Matches(msg, m.keyMap.Preview.Expand) && m.previewVisible && m.previewWindowPercentage < 95.0:
 			m.previewWindowPercentage += config.Current.Preview.WidthIncrementPercentage
-		case key.Matches(msg, m.keyMap.Preview.Shrink):
+		case key.Matches(msg, m.keyMap.Preview.Shrink) && m.previewVisible && m.previewWindowPercentage > 5.0:
 			m.previewWindowPercentage -= config.Current.Preview.WidthIncrementPercentage
 		case key.Matches(msg, m.keyMap.CustomCommands):
 			m.stacked = customcommands.NewModel(m.context, m.width, m.height)


### PR DESCRIPTION
This fixes two bugs:

- The preview resize messages were being handled even if the preview window was hidden. This caused strange problems if ctrl+h or ctrl+l were hit while preview was hidden.

  We now only handle resize messages if preview is actually shown. Because these commands effects are intended to be immediatly visible to the user.


- There was no limit to scaling up and when we hit more than 100% the screen was messed up and preview window was no longer able to be resized.