### PR TITLE
feat(preview): Allow showing preview at bottom (config and toggle-key)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -120,6 +120,7 @@ type PreviewConfig struct {
 	OplogCommand             []string `toml:"oplog_command"`
 	FileCommand              []string `toml:"file_command"`
 	ShowAtStart              bool     `toml:"show_at_start"`
+	ShowAtBottom             bool     `toml:"show_at_bottom"`
 	WidthPercentage          float64  `toml:"width_percentage"`
 	WidthIncrementPercentage float64  `toml:"width_increment_percentage"`
 }

--- a/internal/config/default/config.toml
+++ b/internal/config/default/config.toml
@@ -62,6 +62,7 @@ limit = 0
     revisions_changing_file = ["*"]
   [keys.preview]
     mode = ["p"]
+    toggle_bottom = ["P"]
     scroll_up = ["ctrl+p"]
     scroll_down = ["ctrl+n"]
     half_page_down = ["ctrl+d"]
@@ -104,6 +105,7 @@ limit = 0
   revision_command = ["show", "--color", "always", "-r", "$change_id"]
   oplog_command = ["op", "show", "$operation_id", "--color", "always"]
   file_command = ["diff", "--color", "always", "-r", "$change_id", "$file"]
+  show_at_bottom = false
   show_at_start = false
   width_percentage = 50.0
   width_increment_percentage = 5.0

--- a/internal/config/keys.go
+++ b/internal/config/keys.go
@@ -81,6 +81,7 @@ func Convert(m KeyMappings[keys]) KeyMappings[key.Binding] {
 		},
 		Preview: previewModeKeys[key.Binding]{
 			Mode:         key.NewBinding(key.WithKeys(m.Preview.Mode...), key.WithHelp(JoinKeys(m.Preview.Mode), "preview")),
+			ToggleBottom: key.NewBinding(key.WithKeys(m.Preview.ToggleBottom...), key.WithHelp(JoinKeys(m.Preview.ToggleBottom), "toggle bottom")),
 			ScrollUp:     key.NewBinding(key.WithKeys(m.Preview.ScrollUp...), key.WithHelp(JoinKeys(m.Preview.ScrollUp), "preview scroll up")),
 			ScrollDown:   key.NewBinding(key.WithKeys(m.Preview.ScrollDown...), key.WithHelp(JoinKeys(m.Preview.ScrollDown), "preview scroll down")),
 			HalfPageDown: key.NewBinding(key.WithKeys(m.Preview.HalfPageDown...), key.WithHelp(JoinKeys(m.Preview.HalfPageDown), "preview half page down")),
@@ -231,6 +232,7 @@ type gitModeKeys[T any] struct {
 
 type previewModeKeys[T any] struct {
 	Mode         T `toml:"mode"`
+	ToggleBottom T `toml:"toggle_bottom"`
 	ScrollUp     T `toml:"scroll_up"`
 	ScrollDown   T `toml:"scroll_down"`
 	HalfPageDown T `toml:"half_page_down"`


### PR DESCRIPTION

The option `preview.show_at_bottom` (default: false) and the `P` key
allow moving the preview window to the bottom instead of being shown to
the side.

Fixes #93
