### PR TITLE
fix(jj_exec): Tab key must only accept-suggestion if there are matches.

### DIFF
--- a/internal/ui/fuzzy_input/fuzzy_input.go
+++ b/internal/ui/fuzzy_input/fuzzy_input.go
@@ -55,7 +55,7 @@ func (fzf *model) handleKey(msg tea.KeyMsg) tea.Cmd {
 	km := config.Current.GetKeyMap()
 	skipSearch := func() tea.Msg { return nil }
 	switch {
-	case key.Matches(msg, fzf.input.KeyMap.AcceptSuggestion):
+	case key.Matches(msg, fzf.input.KeyMap.AcceptSuggestion) && len(fzf.matches) > 0:
 		suggestion := fuzzy_search.SelectedMatch(fzf)
 		fzf.input.SetValue(suggestion)
 		fzf.input.CursorEnd()


### PR DESCRIPTION
Previous to this change if you entered `: somethi` that has no match in history and then you used `tab`, it expanded to empty string leaving your prompt as `:` which is quite annoying.

Now tab only accepts completion if there is actually any match shown.