### PR TITLE
feat(placeholders): Add $checked_files and $checked_commit_ids.

### DIFF
--- a/internal/jj/commands.go
+++ b/internal/jj/commands.go
@@ -12,6 +12,17 @@ const (
 	FilePlaceholder        = "$file"
 	OperationIdPlaceholder = "$operation_id"
 	RevsetPlaceholder      = "$revset"
+
+	// user checked file names, separated by `\t` tab.
+	// tab is a lot less common than spaces on filenames,
+	// and is also part of shell's IFS separator.
+	// this allows programs like `ls -l ${checked_files[@]}`
+	CheckedFilesPlaceholder = "$checked_files"
+
+	// user checked commit ids, separated by `|`.
+	// the reason is user can use checked commits as revsets
+	// given to jj commands.
+	CheckedCommitIdsPlaceholder = "$checked_commit_ids"
 )
 
 type CommandArgs []string


### PR DESCRIPTION
This patch allows custom-commands and exec-commands to have access to user selected revisions and files. By "selected" we mean, marked as _checked_  (✓)  using space ` ` on the UI.


You can test this branch in two ways:

- Select some revisions from the UI and then execute a command like: `$ echo $checked_commit_ids`

- Select some files from the details UI and execute: NOTE: expansion is performed by underlying $SHELL. This example assumes bash:

   `$ ls -la ${checked_files[@]}`


See [#223 comment](https://github.com/idursun/jjui/issues/223#issuecomment-3134918996)

Closes #223