### PR TITLE
feat: make log format and revset configurable

### DIFF
--- a/cmd/jjui/main.go
+++ b/cmd/jjui/main.go
@@ -185,6 +185,8 @@ func main() {
 	}
 	if revset != "" {
 		appContext.DefaultRevset = revset
+	} else if appContext.JJConfig.Revsets.Log != "" {
+		appContext.DefaultRevset = config.Current.Revision.Revset
 	} else {
 		appContext.DefaultRevset = appContext.JJConfig.Revsets.Log
 	}

--- a/cmd/jjui/main.go
+++ b/cmd/jjui/main.go
@@ -186,7 +186,7 @@ func main() {
 	if revset != "" {
 		appContext.DefaultRevset = revset
 	} else if appContext.JJConfig.Revsets.Log != "" {
-		appContext.DefaultRevset = config.Current.Log.Revset
+		appContext.DefaultRevset = config.Current.Revisions.Revset
 	} else {
 		appContext.DefaultRevset = appContext.JJConfig.Revsets.Log
 	}

--- a/cmd/jjui/main.go
+++ b/cmd/jjui/main.go
@@ -186,7 +186,7 @@ func main() {
 	if revset != "" {
 		appContext.DefaultRevset = revset
 	} else if appContext.JJConfig.Revsets.Log != "" {
-		appContext.DefaultRevset = config.Current.Revision.Revset
+		appContext.DefaultRevset = config.Current.Log.Revset
 	} else {
 		appContext.DefaultRevset = appContext.JJConfig.Revsets.Log
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -104,6 +104,7 @@ type UIConfig struct {
 
 type RevisionConfig struct {
 	LogCommand []string `toml:"log_command"`
+	Revset     string   `toml:"revset"`
 }
 
 type PreviewConfig struct {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -17,6 +17,7 @@ var Current = loadDefaultConfig()
 type Config struct {
 	Keys                           KeyMappings[keys] `toml:"keys"`
 	UI                             UIConfig          `toml:"ui"`
+	Revision                       RevisionConfig    `toml:"revision"`
 	Preview                        PreviewConfig     `toml:"preview"`
 	OpLog                          OpLogConfig       `toml:"oplog"`
 	Graph                          GraphConfig       `toml:"graph"`
@@ -101,8 +102,11 @@ type UIConfig struct {
 	AutoRefreshInterval int `toml:"auto_refresh_interval"`
 }
 
+type RevisionConfig struct {
+	LogCommand []string `toml:"log_command"`
+}
+
 type PreviewConfig struct {
-	LogCommand               []string `toml:"log_command"`
 	RevisionCommand          []string `toml:"revision_command"`
 	OplogCommand             []string `toml:"oplog_command"`
 	FileCommand              []string `toml:"file_command"`

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -17,7 +17,7 @@ var Current = loadDefaultConfig()
 type Config struct {
 	Keys                           KeyMappings[keys] `toml:"keys"`
 	UI                             UIConfig          `toml:"ui"`
-	Revision                       RevisionConfig    `toml:"revision"`
+	Log                            LogConfig         `toml:"log"`
 	Preview                        PreviewConfig     `toml:"preview"`
 	OpLog                          OpLogConfig       `toml:"oplog"`
 	Graph                          GraphConfig       `toml:"graph"`
@@ -102,9 +102,9 @@ type UIConfig struct {
 	AutoRefreshInterval int `toml:"auto_refresh_interval"`
 }
 
-type RevisionConfig struct {
-	LogCommand []string `toml:"log_command"`
-	Revset     string   `toml:"revset"`
+type LogConfig struct {
+	Template string `toml:"template"`
+	Revset   string `toml:"revset"`
 }
 
 type PreviewConfig struct {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -17,7 +17,7 @@ var Current = loadDefaultConfig()
 type Config struct {
 	Keys                           KeyMappings[keys] `toml:"keys"`
 	UI                             UIConfig          `toml:"ui"`
-	Log                            LogConfig         `toml:"log"`
+	Revisions                      RevisionsConfig   `toml:"revisions"`
 	Preview                        PreviewConfig     `toml:"preview"`
 	OpLog                          OpLogConfig       `toml:"oplog"`
 	Graph                          GraphConfig       `toml:"graph"`
@@ -102,7 +102,7 @@ type UIConfig struct {
 	AutoRefreshInterval int `toml:"auto_refresh_interval"`
 }
 
-type LogConfig struct {
+type RevisionsConfig struct {
 	Template string `toml:"template"`
 	Revset   string `toml:"revset"`
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -102,6 +102,7 @@ type UIConfig struct {
 }
 
 type PreviewConfig struct {
+	LogCommand               []string `toml:"log_command"`
 	RevisionCommand          []string `toml:"revision_command"`
 	OplogCommand             []string `toml:"oplog_command"`
 	FileCommand              []string `toml:"file_command"`

--- a/internal/config/default/config.toml
+++ b/internal/config/default/config.toml
@@ -110,8 +110,10 @@ limit = 0
 
 [ui.colors]
 
-[preview]
+[revision]
   log_command = ["log", "--color", "always", "--quiet"]
+
+[preview]
   revision_command = ["show", "--color", "always", "-r", "$change_id"]
   oplog_command = ["op", "show", "$operation_id", "--color", "always"]
   file_command = ["diff", "--color", "always", "-r", "$change_id", "$file"]

--- a/internal/config/default/config.toml
+++ b/internal/config/default/config.toml
@@ -110,9 +110,9 @@ limit = 0
 
 [ui.colors]
 
-[revision]
-  log_command = ["log", "--color", "always", "--quiet"]
-  # revset = "zzzzzzz"  # defaults to jj's revsets.log
+[log]
+  # template = 'builtin_log_compact' # overrides jj's templates.log
+  # revset = "zzzzzzz"               # overrides jj's revsets.log
 
 [preview]
   revision_command = ["show", "--color", "always", "-r", "$change_id"]

--- a/internal/config/default/config.toml
+++ b/internal/config/default/config.toml
@@ -110,7 +110,7 @@ limit = 0
 
 [ui.colors]
 
-[log]
+[revisions]
   # template = 'builtin_log_compact' # overrides jj's templates.log
   # revset = "zzzzzzz"               # overrides jj's revsets.log
 

--- a/internal/config/default/config.toml
+++ b/internal/config/default/config.toml
@@ -111,6 +111,7 @@ limit = 0
 [ui.colors]
 
 [preview]
+  log_command = ["log", "--color", "always", "--quiet"]
   revision_command = ["show", "--color", "always", "-r", "$change_id"]
   oplog_command = ["op", "show", "$operation_id", "--color", "always"]
   file_command = ["diff", "--color", "always", "-r", "$change_id", "$file"]

--- a/internal/config/default/config.toml
+++ b/internal/config/default/config.toml
@@ -112,6 +112,7 @@ limit = 0
 
 [revision]
   log_command = ["log", "--color", "always", "--quiet"]
+  # revset = "zzzzzzz"  # defaults to jj's revsets.log
 
 [preview]
   revision_command = ["show", "--color", "always", "-r", "$change_id"]

--- a/internal/jj/commands.go
+++ b/internal/jj/commands.go
@@ -34,12 +34,15 @@ func ConfigListAll() CommandArgs {
 }
 
 func Log(revset string, limit int) CommandArgs {
-	args := config.Current.Revision.LogCommand
+	args := []string{"log", "--color", "always", "--quiet"}
 	if revset != "" {
 		args = append(args, "-r", revset)
 	}
 	if limit > 0 {
 		args = append(args, "--limit", strconv.Itoa(limit))
+	}
+	if config.Current.Log.Template != "" {
+		args = append(args, "-T", config.Current.Log.Template)
 	}
 	return args
 }

--- a/internal/jj/commands.go
+++ b/internal/jj/commands.go
@@ -41,8 +41,8 @@ func Log(revset string, limit int) CommandArgs {
 	if limit > 0 {
 		args = append(args, "--limit", strconv.Itoa(limit))
 	}
-	if config.Current.Log.Template != "" {
-		args = append(args, "-T", config.Current.Log.Template)
+	if config.Current.Revisions.Template != "" {
+		args = append(args, "-T", config.Current.Revisions.Template)
 	}
 	return args
 }

--- a/internal/jj/commands.go
+++ b/internal/jj/commands.go
@@ -2,9 +2,10 @@ package jj
 
 import (
 	"fmt"
-	"github.com/idursun/jjui/internal/config"
 	"strconv"
 	"strings"
+
+	"github.com/idursun/jjui/internal/config"
 )
 
 const (
@@ -33,7 +34,7 @@ func ConfigListAll() CommandArgs {
 }
 
 func Log(revset string, limit int) CommandArgs {
-	args := config.Current.Preview.LogCommand
+	args := config.Current.Revision.LogCommand
 	if revset != "" {
 		args = append(args, "-r", revset)
 	}

--- a/internal/jj/commands.go
+++ b/internal/jj/commands.go
@@ -2,6 +2,7 @@ package jj
 
 import (
 	"fmt"
+	"github.com/idursun/jjui/internal/config"
 	"strconv"
 	"strings"
 )
@@ -32,7 +33,7 @@ func ConfigListAll() CommandArgs {
 }
 
 func Log(revset string, limit int) CommandArgs {
-	args := []string{"log", "--color", "always", "--quiet"}
+	args := config.Current.Preview.LogCommand
 	if revset != "" {
 		args = append(args, "-r", revset)
 	}


### PR DESCRIPTION
One of the few times something that _sounded_ easy _was_ easy.

Not certain if `preview` is the right table to add the `log_command` field, but happy to move it if there's a better place for it.

Tested that it works with both 2-line and 1-line log formats. (My preferred is a 1-line, hence this PR.)

Resolves #217