### PR TITLE
feat(fuzzy_input): More intuitive movement on history and different suggestions modes.

### DIFF
--- a/internal/ui/status/status.go
+++ b/internal/ui/status/status.go
@@ -163,12 +163,11 @@ func (m *Model) Update(msg tea.Msg) (*Model, tea.Cmd) {
 			if key.Matches(msg, km.ExecShell) {
 				mode = common.ExecShell
 			}
-			m.editStatus = emptyEditStatus
 			m.mode = "exec " + mode.Mode
 			m.input.Prompt = mode.Prompt
 			m.loadEditingSuggestions()
 
-			m.fuzzy = fuzzy_input.NewModel(&m.input, m.input.AvailableSuggestions())
+			m.fuzzy, m.editStatus = fuzzy_input.NewModel(&m.input, m.input.AvailableSuggestions())
 			return m, tea.Batch(m.fuzzy.Init(), m.input.Focus())
 		case key.Matches(msg, km.QuickSearch) && !m.IsFocused():
 			m.editStatus = emptyEditStatus


### PR DESCRIPTION
This patch makes the following changes to the input for `jj exec`/`sh exec`: 

- When entering exec mode, fuzzy suggestions are OFF. This is more intuitive as you would expect on entering a system shell's prompt. Where you can use `ctrl+p`, `ctrl+n` to move on immediate history instead of moving on suggestions. 
- Suggestions are enabled with `ctrl+r`, again a common idiom on shells. First suggestion mode is fuzzy since it will most likely give the expected result.
- Using `ctrl+r` again switches to regex match, this is useful when trying to match more continuous strings than the fuzzy match algorithm.
- Using `ctrl+r` starts the cycle again by turning suggestions off.

Curently `ctrl+r` is not expected to be a customized keybinding (just like we can't directly customize the textinput keybindings for moving on prev/next suggestions). 