### PR TITLE
feat(confirmation): Show key-bindings on confirmation dialog.

### DIFF
--- a/internal/ui/confirmation/confirmation.go
+++ b/internal/ui/confirmation/confirmation.go
@@ -39,6 +39,32 @@ type Model struct {
 	stylePrefix string
 }
 
+func (m *Model) ShortHelp() []key.Binding {
+	var bindings []key.Binding
+	for _, option := range m.options {
+		bindings = append(bindings, option.keyBinding)
+	}
+	bindings = append(bindings,
+		key.NewBinding(
+			key.WithKeys("left", "h"),
+			key.WithHelp("←", "left"),
+		),
+		key.NewBinding(
+			key.WithKeys("right", "l"),
+			key.WithHelp("→", "right"),
+		),
+		key.NewBinding(
+			key.WithKeys("enter"),
+			key.WithHelp("↵", "select"),
+		),
+	)
+	return bindings
+}
+
+func (m *Model) FullHelp() [][]key.Binding {
+	return [][]key.Binding{m.ShortHelp()}
+}
+
 // Option is a function that configures a Model
 type Option func(*Model)
 
@@ -66,7 +92,7 @@ func (m *Model) Init() tea.Cmd {
 	return nil
 }
 
-func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+func (m *Model) Update(msg tea.Msg) (*Model, tea.Cmd) {
 	km := config.Current.GetKeyMap()
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
@@ -102,7 +128,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 func (m *Model) View() string {
 	w := strings.Builder{}
 	for i, message := range m.messages {
-		w.WriteString(m.Styles.Text.Render(message))
+		w.WriteString(m.Styles.Text.PaddingLeft(1).Render(message))
 		if i < len(m.messages)-1 {
 			w.WriteString(m.Styles.Text.Render("\n"))
 		}
@@ -120,11 +146,6 @@ func (m *Model) View() string {
 	return m.Styles.Border.Render(content)
 }
 
-// AddOption adds an option to the confirmation dialog (legacy method)
-func (m *Model) AddOption(label string, cmd tea.Cmd, keyBinding key.Binding) {
-	m.options = append(m.options, option{label, cmd, keyBinding, cmd})
-}
-
 // getStyleKey prefixes the key with the style prefix if one is set
 func (m *Model) getStyleKey(key string) string {
 	if m.stylePrefix == "" {
@@ -133,7 +154,7 @@ func (m *Model) getStyleKey(key string) string {
 	return m.stylePrefix + " " + key
 }
 
-func New(messages []string, opts ...Option) Model {
+func New(messages []string, opts ...Option) *Model {
 	m := Model{
 		messages: messages,
 		options:  []option{},
@@ -153,7 +174,7 @@ func New(messages []string, opts ...Option) Model {
 		Dimmed:   common.DefaultPalette.Get(m.getStyleKey("confirmation dimmed")).PaddingLeft(2).PaddingRight(2),
 	}
 
-	return m
+	return &m
 }
 
 func Close() tea.Msg {

--- a/internal/ui/confirmation/confirmation_test.go
+++ b/internal/ui/confirmation/confirmation_test.go
@@ -83,15 +83,13 @@ func TestConfirmationWithOption(t *testing.T) {
 }
 
 func TestLegacyAddOption(t *testing.T) {
-	model := New([]string{"Test message"})
-
 	var cmdCalled bool
 	testCmd := func() tea.Msg {
 		cmdCalled = true
 		return nil
 	}
 
-	model.AddOption("Yes", testCmd, key.NewBinding(key.WithKeys("y")))
+	model := New([]string{"Test message"}, WithOption("Yes", testCmd, key.NewBinding(key.WithKeys("y"))))
 
 	assert.Equal(t, 1, len(model.options))
 	assert.Equal(t, "Yes", model.options[0].label)

--- a/internal/ui/operations/abandon/abandon.go
+++ b/internal/ui/operations/abandon/abandon.go
@@ -13,9 +13,17 @@ import (
 )
 
 type Operation struct {
-	model   tea.Model
+	model   *confirmation.Model
 	current *jj.Commit
 	context *context.MainContext
+}
+
+func (a *Operation) ShortHelp() []key.Binding {
+	return a.model.ShortHelp()
+}
+
+func (a *Operation) FullHelp() [][]key.Binding {
+	return [][]key.Binding{a.ShortHelp()}
 }
 
 func (a *Operation) SetSelectedRevision(commit *jj.Commit) {
@@ -58,13 +66,13 @@ func NewOperation(context *context.MainContext, selectedRevisions jj.SelectedRev
 	}
 	model := confirmation.New(
 		[]string{message},
-		confirmation.WithAltOption("Yes", cmd(false), cmd(true), key.NewBinding(key.WithKeys("y"))),
-		confirmation.WithOption("No", common.Close, key.NewBinding(key.WithKeys("n", "esc"))),
+		confirmation.WithAltOption("Yes", cmd(false), cmd(true), key.NewBinding(key.WithKeys("y"), key.WithHelp("y", "yes"))),
+		confirmation.WithOption("No", common.Close, key.NewBinding(key.WithKeys("n", "esc"), key.WithHelp("n/esc", "no"))),
 		confirmation.WithStylePrefix("abandon"),
 	)
 
 	op := &Operation{
-		model: &model,
+		model: model,
 	}
 	return op
 }

--- a/internal/ui/operations/details/details_test.go
+++ b/internal/ui/operations/details/details_test.go
@@ -29,7 +29,8 @@ func TestModel_Init_ExecutesStatusCommand(t *testing.T) {
 	commandRunner.Expect(jj.Status(Revision)).SetOutput([]byte(StatusOutput))
 	defer commandRunner.Verify()
 
-	tm := teatest.NewTestModel(t, New(test.NewTestContext(commandRunner), Commit))
+	model := test.NewShell(New(test.NewTestContext(commandRunner), Commit))
+	tm := teatest.NewTestModel(t, model)
 	teatest.WaitFor(t, tm.Output(), func(bts []byte) bool {
 		return bytes.Contains(bts, []byte("file.txt"))
 	})

--- a/internal/ui/operations/details/show_details_operation.go
+++ b/internal/ui/operations/details/show_details_operation.go
@@ -10,7 +10,7 @@ import (
 )
 
 type Operation struct {
-	Overlay tea.Model
+	Overlay Model
 	Current *jj.Commit
 	keyMap  config.KeyMappings[key.Binding]
 }
@@ -20,17 +20,7 @@ func (s *Operation) SetSelectedRevision(commit *jj.Commit) {
 }
 
 func (s *Operation) ShortHelp() []key.Binding {
-	return []key.Binding{
-		s.keyMap.Up,
-		s.keyMap.Down,
-		s.keyMap.Cancel,
-		s.keyMap.Details.Diff,
-		s.keyMap.Details.ToggleSelect,
-		s.keyMap.Details.Split,
-		s.keyMap.Details.Restore,
-		s.keyMap.Details.Absorb,
-		s.keyMap.Details.RevisionsChangingFile,
-	}
+	return s.Overlay.ShortHelp()
 }
 
 func (s *Operation) FullHelp() [][]key.Binding {

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"fmt"
+	"github.com/charmbracelet/bubbles/help"
 	"time"
 
 	"github.com/idursun/jjui/internal/ui/flash"
@@ -301,6 +302,10 @@ func (m Model) View() string {
 	if m.oplog != nil {
 		m.status.SetMode("oplog")
 		m.status.SetHelp(m.oplog)
+	} else if m.stacked != nil {
+		if s, ok := m.stacked.(help.KeyMap); ok {
+			m.status.SetHelp(s)
+		}
 	} else {
 		m.status.SetHelp(m.revisions)
 		m.status.SetMode(m.revisions.CurrentOperation().Name())

--- a/internal/ui/undo/undo.go
+++ b/internal/ui/undo/undo.go
@@ -11,7 +11,15 @@ import (
 )
 
 type Model struct {
-	confirmation tea.Model
+	confirmation *confirmation.Model
+}
+
+func (m Model) ShortHelp() []key.Binding {
+	return m.confirmation.ShortHelp()
+}
+
+func (m Model) FullHelp() [][]key.Binding {
+	return [][]key.Binding{m.ShortHelp()}
 }
 
 func (m Model) Init() tea.Cmd {
@@ -34,11 +42,11 @@ func NewModel(context *context.MainContext) Model {
 	model := confirmation.New(
 		[]string{lastOperation, "Are you sure you want to undo last change?"},
 		confirmation.WithStylePrefix("undo"),
-		confirmation.WithOption("Yes", context.RunCommand(jj.Undo(), common.Refresh, common.Close), key.NewBinding(key.WithKeys("y"))),
+		confirmation.WithOption("Yes", context.RunCommand(jj.Undo(), common.Refresh, common.Close), key.NewBinding(key.WithKeys("y"), key.WithHelp("y", "yes"))),
+		confirmation.WithOption("No", common.Close, key.NewBinding(key.WithKeys("n", "esc"), key.WithHelp("n/esc", "no"))),
 	)
 	model.Styles.Border = common.DefaultPalette.GetBorder("undo border", lipgloss.NormalBorder()).Padding(1)
-	model.AddOption("No", common.Close, key.NewBinding(key.WithKeys("n", "esc")))
 	return Model{
-		confirmation: &model,
+		confirmation: model,
 	}
 }

--- a/test/shell.go
+++ b/test/shell.go
@@ -4,19 +4,26 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/idursun/jjui/internal/ui/common"
 	"github.com/idursun/jjui/internal/ui/confirmation"
+	"reflect"
 	"time"
 )
 
-type model struct {
-	closed        bool
-	embeddedModel tea.Model
+type teaModelLike interface {
+	Init() tea.Cmd
+	View() string
 }
 
-func (m model) Init() tea.Cmd {
+// model is a generic shell that can wrap any teaModelLike
+type model[T teaModelLike] struct {
+	closed        bool
+	embeddedModel T
+}
+
+func (m model[T]) Init() tea.Cmd {
 	return m.embeddedModel.Init()
 }
 
-func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+func (m model[T]) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case common.CloseViewMsg, confirmation.CloseMsg:
 		m.closed = true
@@ -25,21 +32,51 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return tea.QuitMsg{}
 		})
 	default:
-		var cmd tea.Cmd
-		m.embeddedModel, cmd = m.embeddedModel.Update(msg)
+		updatedModel, cmd := callUpdate(m.embeddedModel, msg)
+		if updatedModel != nil {
+			m.embeddedModel = updatedModel.(T)
+		}
 		return m, cmd
 	}
 }
 
-func (m model) View() string {
+// callUpdate this is acting as an adapter to call the Update method on the embedded model
+// embeddedModels don't have to implement the Update method as `Update(msg tea.Msg) (tea.Model, tea.Cmd)`
+func callUpdate(model interface{}, msg tea.Msg) (interface{}, tea.Cmd) {
+	modelValue := reflect.ValueOf(model)
+
+	// Find the Update method
+	updateMethod := modelValue.MethodByName("Update")
+	if !updateMethod.IsValid() {
+		// No Update method found
+		return model, nil
+	}
+
+	results := updateMethod.Call([]reflect.Value{reflect.ValueOf(msg)})
+	if len(results) != 2 {
+		return model, nil
+	}
+
+	updatedModel := results[0].Interface()
+
+	var cmd tea.Cmd
+	if !results[1].IsNil() {
+		cmd = results[1].Interface().(tea.Cmd)
+	}
+
+	return updatedModel, cmd
+}
+
+func (m model[T]) View() string {
 	if m.closed {
 		return "closed"
 	}
 	return m.embeddedModel.View()
 }
 
-func NewShell(embeddedModel tea.Model) tea.Model {
-	return model{
+// NewShell creates a new shell wrapping the provided model
+func NewShell[T teaModelLike](embeddedModel T) tea.Model {
+	return model[T]{
 		embeddedModel: embeddedModel,
 	}
 }


### PR DESCRIPTION
This helps the user to not having to move using direction keys, but directly use shortcuts instead.

Buttons are moved to their own line since now they occupy more space due to them including key-bindings help.