### PR TITLE
$checked_commit_ids expands to none() without checked commit

### DIFF
--- a/internal/ui/context/main_context.go
+++ b/internal/ui/context/main_context.go
@@ -146,7 +146,9 @@ func (ctx *MainContext) CreateReplacements() map[string]string {
 		replacements[jj.CheckedFilesPlaceholder] = strings.Join(checkedFiles, "\t")
 	}
 
-	if len(checkedRevisions) > 0 {
+	if len(checkedRevisions) == 0 {
+		replacements[jj.CheckedCommitIdsPlaceholder] = "none()"
+	} else {
 		replacements[jj.CheckedCommitIdsPlaceholder] = strings.Join(checkedRevisions, "|")
 	}
 


### PR DESCRIPTION
in order to use the checked commits or the selected commit if no commit is checked with `coalesce($checked_commit_ids, $change_id)`