### PR TITLE
feat: squash files from details view

### DIFF
--- a/internal/config/default/config.toml
+++ b/internal/config/default/config.toml
@@ -62,6 +62,7 @@ limit = 0
     mode = ["l"]
     close = ["h"]
     split = ["s"]
+    squash = ["S"]
     restore = ["r"]
     absorb = ["A"]
     diff = ["d"]

--- a/internal/config/keys.go
+++ b/internal/config/keys.go
@@ -78,6 +78,7 @@ func Convert(m KeyMappings[keys]) KeyMappings[key.Binding] {
 			Mode:                  key.NewBinding(key.WithKeys(m.Details.Mode...), key.WithHelp(JoinKeys(m.Details.Mode), "details")),
 			Close:                 key.NewBinding(key.WithKeys(m.Details.Close...), key.WithHelp(JoinKeys(m.Details.Close), "close")),
 			Split:                 key.NewBinding(key.WithKeys(m.Details.Split...), key.WithHelp(JoinKeys(m.Details.Split), "split")),
+			Squash:                key.NewBinding(key.WithKeys(m.Details.Squash...), key.WithHelp(JoinKeys(m.Details.Squash), "squash")),
 			Restore:               key.NewBinding(key.WithKeys(m.Details.Restore...), key.WithHelp(JoinKeys(m.Details.Restore), "restore")),
 			Absorb:                key.NewBinding(key.WithKeys(m.Details.Absorb...), key.WithHelp(JoinKeys(m.Details.Absorb), "absorb")),
 			Diff:                  key.NewBinding(key.WithKeys(m.Details.Diff...), key.WithHelp(JoinKeys(m.Details.Diff), "diff")),
@@ -251,6 +252,7 @@ type detailsModeKeys[T any] struct {
 	Split                 T `toml:"split"`
 	Restore               T `toml:"restore"`
 	Absorb                T `toml:"absorb"`
+	Squash                T `toml:"squash"`
 	Diff                  T `toml:"diff"`
 	ToggleSelect          T `toml:"select"`
 	RevisionsChangingFile T `toml:"revisions_changing_file"`

--- a/internal/jj/commands.go
+++ b/internal/jj/commands.go
@@ -79,11 +79,11 @@ func Split(revision string, files []string) CommandArgs {
 	return args
 }
 
-func SquashFiles(revision string, files []string) CommandArgs {
-	args := []string{"squash", "-r", revision, "--use-destination-message"}
+func SquashFiles(from string, into string, files []string) CommandArgs {
+	args := []string{"squash", "--from", from, "--into", into, "--use-destination-message"}
 	var escapedFiles []string
 	for _, file := range files {
-		escapedFiles = append(escapedFiles, escapeFileName(file))
+		escapedFiles = append(escapedFiles, EscapeFileName(file))
 	}
 	args = append(args, escapedFiles...)
 	return args

--- a/internal/jj/commands.go
+++ b/internal/jj/commands.go
@@ -79,6 +79,16 @@ func Split(revision string, files []string) CommandArgs {
 	return args
 }
 
+func SquashFiles(revision string, files []string) CommandArgs {
+	args := []string{"squash", "-r", revision, "--use-destination-message"}
+	var escapedFiles []string
+	for _, file := range files {
+		escapedFiles = append(escapedFiles, escapeFileName(file))
+	}
+	args = append(args, escapedFiles...)
+	return args
+}
+
 func Describe(revision string) CommandArgs {
 	return []string{"describe", "-r", revision, "--edit"}
 }

--- a/internal/ui/common/msgs.go
+++ b/internal/ui/common/msgs.go
@@ -43,7 +43,10 @@ type (
 		Commit       *jj.Commit
 		RawFileOut   []byte // raw output from `jj file list`
 	}
-	ShowPreview bool
+	ShowPreview     bool
+	JumpToParentMsg struct {
+		Commit *jj.Commit
+	}
 )
 
 type State int
@@ -101,6 +104,15 @@ func FileSearch(revset string, preview bool, commit *jj.Commit, rawFileOut []byt
 			Revset:       revset,
 			PreviewShown: preview,
 		}
+	}
+}
+
+func JumpToParent(commit *jj.Commit) tea.Cmd {
+	return func() tea.Msg {
+		if commit == nil {
+			return nil
+		}
+		return JumpToParentMsg{Commit: commit}
 	}
 }
 

--- a/internal/ui/helppage/help.go
+++ b/internal/ui/helppage/help.go
@@ -131,6 +131,7 @@ func (h *Model) View() string {
 		h.printKeyBinding(h.keyMap.Details.ToggleSelect),
 		h.printKeyBinding(h.keyMap.Details.Restore),
 		h.printKeyBinding(h.keyMap.Details.Split),
+		h.printKeyBinding(h.keyMap.Details.Squash),
 		h.printKeyBinding(h.keyMap.Details.Diff),
 		h.printKeyBinding(h.keyMap.Details.RevisionsChangingFile),
 		"",

--- a/internal/ui/operations/details/details.go
+++ b/internal/ui/operations/details/details.go
@@ -241,6 +241,26 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 			)
 			m.confirmation = model
 			return m, m.confirmation.Init()
+		case key.Matches(msg, m.keyMap.Details.Squash):
+			selectedFiles, isVirtuallySelected := m.getSelectedFiles()
+			m.files.SetDelegate(itemDelegate{
+				isVirtuallySelected: isVirtuallySelected,
+				selectedHint:        "gets squashed into parent",
+				unselectedHint:      "stays as is",
+				styles:              m.styles,
+			})
+			model := confirmation.New(
+				[]string{"Are you sure you want to squash the selected files?"},
+				confirmation.WithStylePrefix("revisions"),
+				confirmation.WithOption("Yes",
+					tea.Batch(m.context.RunCommand(jj.SquashFiles(m.revision.GetChangeId(), selectedFiles), common.Refresh), confirmation.Close),
+					key.NewBinding(key.WithKeys("y"), key.WithHelp("y", "yes"))),
+				confirmation.WithOption("No",
+					confirmation.Close,
+					key.NewBinding(key.WithKeys("n", "esc"), key.WithHelp("n/esc", "no"))),
+			)
+			m.confirmation = model
+			return m, m.confirmation.Init()
 		case key.Matches(msg, m.keyMap.Details.Restore):
 			selectedFiles, isVirtuallySelected := m.getSelectedFiles()
 			m.files.SetDelegate(itemDelegate{

--- a/internal/ui/operations/details/show_details_operation.go
+++ b/internal/ui/operations/details/show_details_operation.go
@@ -3,16 +3,41 @@ package details
 import (
 	"github.com/charmbracelet/bubbles/key"
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
 	"github.com/idursun/jjui/internal/config"
 	"github.com/idursun/jjui/internal/jj"
+	"github.com/idursun/jjui/internal/ui/common"
 	"github.com/idursun/jjui/internal/ui/context"
 	"github.com/idursun/jjui/internal/ui/operations"
 )
 
+type mode int
+
+const (
+	viewMode mode = iota
+	squashTargetMode
+)
+
 type Operation struct {
-	Overlay Model
-	Current *jj.Commit
-	keyMap  config.KeyMappings[key.Binding]
+	context           *context.MainContext
+	Overlay           Model
+	Current           *jj.Commit
+	keyMap            config.KeyMappings[key.Binding]
+	targetMarkerStyle lipgloss.Style
+	selected          *jj.Commit
+}
+
+func (s *Operation) HandleKey(msg tea.KeyMsg) tea.Cmd {
+	if s.Overlay.mode == squashTargetMode {
+		switch {
+		case key.Matches(msg, s.keyMap.Cancel):
+			return common.Close
+		case key.Matches(msg, s.keyMap.Apply):
+			selectedFiles, _ := s.Overlay.getSelectedFiles()
+			return tea.Batch(s.context.RunCommand(jj.SquashFiles(s.selected.GetChangeId(), s.Current.GetChangeId(), selectedFiles), common.Refresh), common.Close)
+		}
+	}
+	return nil
 }
 
 func (s *Operation) SetSelectedRevision(commit *jj.Commit) {
@@ -28,12 +53,29 @@ func (s *Operation) FullHelp() [][]key.Binding {
 }
 
 func (s *Operation) Update(msg tea.Msg) (operations.OperationWithOverlay, tea.Cmd) {
-	var cmd tea.Cmd
-	s.Overlay, cmd = s.Overlay.Update(msg)
-	return s, cmd
+	switch s.Overlay.mode {
+	case viewMode:
+		var cmd tea.Cmd
+		s.Overlay, cmd = s.Overlay.Update(msg)
+		return s, cmd
+	case squashTargetMode:
+		switch msg := msg.(type) {
+		case tea.KeyMsg:
+			cmd := s.HandleKey(msg)
+			return s, cmd
+		}
+	}
+	return s, nil
 }
 
 func (s *Operation) Render(commit *jj.Commit, pos operations.RenderPosition) string {
+	if s.Overlay.mode == squashTargetMode {
+		if pos == operations.RenderBeforeChangeId && s.Current != nil && s.Current.GetChangeId() == commit.GetChangeId() {
+			return s.targetMarkerStyle.Render("<< squash >>")
+		}
+		return ""
+	}
+
 	isSelected := s.Current != nil && s.Current.GetChangeId() == commit.GetChangeId()
 	if !isSelected || pos != operations.RenderPositionAfter {
 		return ""
@@ -42,13 +84,19 @@ func (s *Operation) Render(commit *jj.Commit, pos operations.RenderPosition) str
 }
 
 func (s *Operation) Name() string {
+	if s.Overlay.mode == squashTargetMode {
+		return "target"
+	}
 	return "details"
 }
 
 func NewOperation(context *context.MainContext, selected *jj.Commit) (operations.Operation, tea.Cmd) {
 	op := &Operation{
-		Overlay: New(context, selected),
-		keyMap:  config.Current.GetKeyMap(),
+		Overlay:           New(context, selected),
+		context:           context,
+		selected:          selected,
+		keyMap:            config.Current.GetKeyMap(),
+		targetMarkerStyle: common.DefaultPalette.Get("details target_marker"),
 	}
 	return op, op.Overlay.Init()
 }

--- a/internal/ui/revisions/revisions.go
+++ b/internal/ui/revisions/revisions.go
@@ -261,6 +261,19 @@ func (m *Model) Update(msg tea.Msg) (*Model, tea.Cmd) {
 			})
 		}
 		return m, tea.Batch(cmds...)
+	case common.JumpToParentMsg:
+		if msg.Commit == nil {
+			return m, nil
+		}
+		m.jumpToParent(jj.NewSelectedRevisions(msg.Commit))
+		return m, m.updateSelection()
+	}
+
+	// TODO: This is duplicated at the end of the function, needs refactoring
+	if curSelected := m.SelectedRevision(); curSelected != nil {
+		if op, ok := m.op.(operations.TracksSelectedRevision); ok {
+			op.SetSelectedRevision(curSelected)
+		}
 	}
 
 	if len(m.rows) == 0 {
@@ -286,11 +299,7 @@ func (m *Model) Update(msg tea.Msg) (*Model, tea.Cmd) {
 				return m, m.requestMoreRows(m.tag)
 			}
 		case key.Matches(msg, m.keymap.JumpToParent):
-			immediate, _ := m.context.RunCommandImmediate(jj.GetParent(m.SelectedRevisions()))
-			parentIndex := m.selectRevision(string(immediate))
-			if parentIndex != -1 {
-				m.cursor = parentIndex
-			}
+			m.jumpToParent(m.SelectedRevisions())
 		case key.Matches(msg, m.keymap.JumpToChildren):
 			immediate, _ := m.context.RunCommandImmediate(jj.GetFirstChild(m.SelectedRevision()))
 			index := m.selectRevision(string(immediate))
@@ -613,7 +622,7 @@ func (m *Model) updateOperation(msg tea.Msg) (tea.Cmd, bool) {
 	// This is currently a hack due to the lack of a mechanism to handle mode changes.
 	// The 'restore' mode name was added to facilitate this special case.
 	// Future refactoring will address mode changes more generically.
-	if m.op != nil && m.op.Name() == "restore" {
+	if m.op != nil && (m.op.Name() == "restore" || m.op.Name() == "target") {
 		if _, ok := msg.(tea.KeyMsg); ok {
 			return nil, false
 		}
@@ -624,4 +633,12 @@ func (m *Model) updateOperation(msg tea.Msg) (tea.Cmd, bool) {
 		return cmd, true
 	}
 	return nil, false
+}
+
+func (m *Model) jumpToParent(revisions jj.SelectedRevisions) {
+	immediate, _ := m.context.RunCommandImmediate(jj.GetParent(revisions))
+	parentIndex := m.selectRevision(string(immediate))
+	if parentIndex != -1 {
+		m.cursor = parentIndex
+	}
 }


### PR DESCRIPTION
This might not be worth adding, since the existing squash command is more general — so you may take it as a suggestion.

I often want to squash file(s) from the current revision into the parent. When using JJUI, I usually enter the details view first to see what's going on, then I select the files I want to squash. However, there is no squash operation in details mode: you must exit details, select the source revision, press `S`, select the parent, then interactively select the files.

This PR adds a shortcut `S` to the details view that squashes the selected files into the parent directly.

Limitations:
- You can only select at the level of files, not lines
- Squashing is always into the parent (if the parent is unique)

Despite its narrow scope, I use this command all the time, so perhaps it is worth sharing.