### PR TITLE
feat(describe): Allow multiple revisions

### DIFF
--- a/internal/jj/commands.go
+++ b/internal/jj/commands.go
@@ -89,8 +89,10 @@ func SquashFiles(from string, into string, files []string) CommandArgs {
 	return args
 }
 
-func Describe(revision string) CommandArgs {
-	return []string{"describe", "-r", revision, "--edit"}
+func Describe(revisions SelectedRevisions) CommandArgs {
+	args := []string{"describe", "--edit"}
+	args = append(args, revisions.AsArgs()...)
+	return args
 }
 
 func SetDescription(revision string, description string) CommandArgs {

--- a/internal/ui/revisions/revisions.go
+++ b/internal/ui/revisions/revisions.go
@@ -343,8 +343,8 @@ func (m *Model) Update(msg tea.Msg) (*Model, tea.Cmd) {
 				currentRevision := m.SelectedRevision().GetChangeId()
 				return m, m.context.RunInteractiveCommand(jj.Split(currentRevision, []string{}), common.Refresh)
 			case key.Matches(msg, m.keymap.Describe):
-				currentRevision := m.SelectedRevision().GetChangeId()
-				return m, m.context.RunInteractiveCommand(jj.Describe(currentRevision), common.Refresh)
+				selections := m.SelectedRevisions()
+				return m, m.context.RunInteractiveCommand(jj.Describe(selections), common.Refresh)
 			case key.Matches(msg, m.keymap.Evolog.Mode):
 				m.op, cmd = evolog.NewOperation(m.context, m.SelectedRevision(), m.Width, m.Height)
 			case key.Matches(msg, m.keymap.Diff):


### PR DESCRIPTION
`jj describe` takes multiple revsets to describe. This change allows users to describe multiple revisions simultaneously by first selecting them via `space`, followed by `D`. 