### PR TITLE
feat: remove auto refresh in favour of focus tracking

### DIFF
--- a/cmd/jjui/main.go
+++ b/cmd/jjui/main.go
@@ -38,7 +38,6 @@ func getVersion() string {
 
 var (
 	revset     string
-	period     int
 	limit      int
 	version    bool
 	editConfig bool
@@ -48,8 +47,6 @@ var (
 func init() {
 	flag.StringVar(&revset, "revset", "", "Set default revset")
 	flag.StringVar(&revset, "r", "", "Set default revset (same as --revset)")
-	flag.IntVar(&period, "period", -1, "Override auto-refresh interval (seconds, set to 0 to disable)")
-	flag.IntVar(&period, "p", -1, "Override auto-refresh interval (alias for --period)")
 	flag.IntVar(&limit, "limit", 0, "Number of revisions to show (default: 0)")
 	flag.IntVar(&limit, "n", 0, "Number of revisions to show (alias for --limit)")
 	flag.BoolVar(&version, "version", false, "Show version information")
@@ -180,9 +177,6 @@ func main() {
 	common.DefaultPalette.Update(appContext.JJConfig.GetApplicableColors())
 	common.DefaultPalette.Update(config.Current.UI.Colors)
 
-	if period >= 0 {
-		config.Current.UI.AutoRefreshInterval = period
-	}
 	if revset != "" {
 		appContext.DefaultRevset = revset
 	} else if config.Current.Revisions.Revset != "" {
@@ -192,7 +186,7 @@ func main() {
 	}
 	appContext.CurrentRevset = appContext.DefaultRevset
 
-	p := tea.NewProgram(ui.New(appContext), tea.WithAltScreen())
+	p := tea.NewProgram(ui.New(appContext), tea.WithAltScreen(), tea.WithReportFocus())
 	if _, err := p.Run(); err != nil {
 		fmt.Printf("Error running program: %v\n", err)
 		os.Exit(1)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -120,10 +120,7 @@ type TracerConfig struct {
 type UIConfig struct {
 	Theme  ThemeConfig      `toml:"theme"`
 	Colors map[string]Color `toml:"colors"`
-	// TODO(ilyagr): It might make sense to rename this to `auto_refresh_period` to match `--period` option
-	// once we have a mechanism to deprecate the old name softly.
-	AutoRefreshInterval int          `toml:"auto_refresh_interval"`
-	Tracer              TracerConfig `toml:"tracer"`
+	Tracer TracerConfig     `toml:"tracer"`
 }
 
 type RevisionsConfig struct {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -46,17 +46,6 @@ light = "light-theme"
 	assert.Equal(t, "light-theme", config.UI.Theme.Light)
 }
 
-func TestLoad_AutoRefreshInterval(t *testing.T) {
-	content := `
-[ui]
-auto_refresh_interval = 5000
-`
-	config := &Config{}
-	err := config.Load(content)
-	assert.NoError(t, err)
-	assert.Equal(t, 5000, config.UI.AutoRefreshInterval)
-}
-
 func TestLoad_Colors_StringAndObject(t *testing.T) {
 	content := `
 [ui.colors]

--- a/internal/config/default/config.toml
+++ b/internal/config/default/config.toml
@@ -109,7 +109,6 @@ limit = 0
 
 [ui]
   theme = ""
-  auto_refresh_interval = 0
 
 [ui.tracer]
   enabled = false

--- a/internal/jj/commands.go
+++ b/internal/jj/commands.go
@@ -326,14 +326,6 @@ func Absorb(changeId string, files ...string) CommandArgs {
 	return args
 }
 
-func OpLogId(snapshot bool) CommandArgs {
-	args := []string{"op", "log", "--color", "never", "--quiet", "--no-graph", "--limit", "1", "--template", "id"}
-	if !snapshot {
-		args = append(args, "--ignore-working-copy")
-	}
-	return args
-}
-
 func OpLog(limit int) CommandArgs {
 	args := []string{"op", "log", "--color", "always", "--quiet", "--ignore-working-copy"}
 	if limit > 0 {

--- a/internal/ui/common/msgs.go
+++ b/internal/ui/common/msgs.go
@@ -8,10 +8,9 @@ import (
 )
 
 type (
-	CloseViewMsg   struct{}
-	ToggleHelpMsg  struct{}
-	AutoRefreshMsg struct{}
-	RefreshMsg     struct {
+	CloseViewMsg  struct{}
+	ToggleHelpMsg struct{}
+	RefreshMsg    struct {
 		SelectedRevision string
 		KeepSelections   bool
 	}

--- a/internal/ui/revisions/revisions.go
+++ b/internal/ui/revisions/revisions.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 	"slices"
 	"strings"
+	"sync/atomic"
 
 	"github.com/idursun/jjui/internal/ui/ace_jump"
 	"github.com/idursun/jjui/internal/ui/operations/duplicate"
@@ -37,7 +38,7 @@ import (
 type Model struct {
 	*common.Sizeable
 	rows             []parser.Row
-	tag              uint64
+	tag              atomic.Uint64
 	revisionToSelect string
 	offScreenRows    []parser.Row
 	streamer         *graph.GraphStreamer
@@ -50,7 +51,6 @@ type Model struct {
 	err              error
 	aceJump          *ace_jump.AceJump
 	quickSearch      string
-	previousOpLogId  string
 	isLoading        bool
 	w                *graph.Renderer
 	textStyle        lipgloss.Style
@@ -160,14 +160,6 @@ func (m *Model) Update(msg tea.Msg) (*Model, tea.Cmd) {
 		m.output = msg.Output
 		m.err = msg.Err
 		return m, nil
-	case common.AutoRefreshMsg:
-		id, _ := m.context.RunCommandImmediate(jj.OpLogId(true))
-		currentOperationId := string(id)
-		log.Println("Previous operation ID:", m.previousOpLogId, "Current operation ID:", currentOperationId)
-		if currentOperationId != m.previousOpLogId {
-			m.previousOpLogId = currentOperationId
-			return m, common.RefreshAndKeepSelections
-		}
 	case common.RefreshMsg:
 		if !msg.KeepSelections {
 			m.context.ClearCheckedItems(reflect.TypeFor[appContext.SelectedRevision]())
@@ -175,8 +167,8 @@ func (m *Model) Update(msg tea.Msg) (*Model, tea.Cmd) {
 		m.isLoading = true
 		cmd, _ := m.updateOperation(msg)
 		if config.Current.Revisions.LogBatching {
-			m.tag += 1
-			return m, tea.Batch(m.loadStreaming(m.context.CurrentRevset, msg.SelectedRevision, m.tag), cmd)
+			currentTag := m.tag.Add(1)
+			return m, tea.Batch(m.loadStreaming(m.context.CurrentRevset, msg.SelectedRevision, currentTag), cmd)
 		} else {
 			return m, tea.Batch(m.load(m.context.CurrentRevset, msg.SelectedRevision), cmd)
 		}
@@ -202,7 +194,7 @@ func (m *Model) Update(msg tea.Msg) (*Model, tea.Cmd) {
 		log.Println("Starting streaming revisions message received with tag:", msg.tag, "revision to select:", msg.selectedRevision)
 		return m, m.requestMoreRows(msg.tag)
 	case appendRowsBatchMsg:
-		if msg.tag != m.tag {
+		if msg.tag != m.tag.Load() {
 			return m, nil
 		}
 		m.offScreenRows = append(m.offScreenRows, msg.rows...)
@@ -275,7 +267,7 @@ func (m *Model) Update(msg tea.Msg) (*Model, tea.Cmd) {
 			if m.cursor < len(m.rows)-1 {
 				m.cursor++
 			} else if m.hasMore {
-				return m, m.requestMoreRows(m.tag)
+				return m, m.requestMoreRows(m.tag.Load())
 			}
 		case key.Matches(msg, m.keymap.JumpToParent):
 			m.jumpToParent(m.SelectedRevisions())
@@ -488,7 +480,7 @@ func (m *Model) load(revset string, selectedRevision string) tea.Cmd {
 }
 
 func (m *Model) loadStreaming(revset string, selectedRevision string, tag uint64) tea.Cmd {
-	if m.tag != tag {
+	if m.tag.Load() != tag {
 		return nil
 	}
 
@@ -525,8 +517,12 @@ func (m *Model) requestMoreRows(tag uint64) tea.Cmd {
 		if m.streamer == nil || !m.hasMore {
 			return nil
 		}
-		batch := m.streamer.RequestMore()
-		return appendRowsBatchMsg{batch.Rows, batch.HasMore, tag}
+		if tag == m.tag.Load() {
+			batch := m.streamer.RequestMore()
+			return appendRowsBatchMsg{batch.Rows, batch.HasMore, tag}
+		}
+		log.Println("cancelling request more revisions, tag mismatch:", tag, m.tag.Load())
+		return nil
 	}
 }
 

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -2,7 +2,6 @@ package ui
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/charmbracelet/bubbles/help"
 
@@ -47,10 +46,8 @@ type Model struct {
 	stacked      tea.Model
 }
 
-type triggerAutoRefreshMsg struct{}
-
 func (m Model) Init() tea.Cmd {
-	return tea.Sequence(tea.SetWindowTitle(fmt.Sprintf("jjui - %s", m.context.Location)), m.revisions.Init(), m.scheduleAutoRefresh())
+	return tea.Batch(tea.SetWindowTitle(fmt.Sprintf("jjui - %s", m.context.Location)), m.revisions.Init())
 }
 
 func (m Model) handleFocusInputMessage(msg tea.Msg) (tea.Model, tea.Cmd, bool) {
@@ -126,6 +123,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	var cmds []tea.Cmd
 
 	switch msg := msg.(type) {
+	case tea.FocusMsg:
+		return m, common.RefreshAndKeepSelections
 	case tea.KeyMsg:
 		switch {
 		case key.Matches(msg, m.keyMap.Cancel) && m.state == common.Error:
@@ -225,10 +224,6 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, m.diff.Init()
 	case common.UpdateRevisionsSuccessMsg:
 		m.state = common.Ready
-	case triggerAutoRefreshMsg:
-		return m, tea.Batch(m.scheduleAutoRefresh(), func() tea.Msg {
-			return common.AutoRefreshMsg{}
-		})
 	case common.UpdateRevSetMsg:
 		m.context.CurrentRevset = string(msg)
 		m.revsetModel.AddToHistory(m.context.CurrentRevset)
@@ -385,16 +380,6 @@ func (m Model) renderLeftView(footerHeight int, topViewHeight int, bottomPreview
 		leftView = m.revisions.View()
 	}
 	return leftView
-}
-
-func (m Model) scheduleAutoRefresh() tea.Cmd {
-	interval := config.Current.UI.AutoRefreshInterval
-	if interval > 0 {
-		return tea.Tick(time.Duration(interval)*time.Second, func(time.Time) tea.Msg {
-			return triggerAutoRefreshMsg{}
-		})
-	}
-	return nil
 }
 
 func (m Model) isSafeToQuit() bool {


### PR DESCRIPTION
Auto-refresh, which relied on refreshing revisions on a fixed interval configured via `ui.auto_refresh_interval`, worked most of the time but was also the source of many bugs that annoyed me for a while. It’s also turned off by default, so many people, including myself, don’t even use it.

This PR removes auto-refresh in favour of focus tracking. Basically, whenever your focus moves away from your terminal and then comes back, `jjui` will refresh itself. This way, if you’ve made changes somewhere else, you’ll always be presented with the latest state of your repo. This approach is deterministic and much more reliable than auto-refresh, as it wouldn’t refresh if you happened to focus back between the refresh interval.