### PR TITLE
feat: edit in editor escape hatch for inline describe editor

### DIFF
--- a/internal/config/default/config.toml
+++ b/internal/config/default/config.toml
@@ -93,6 +93,7 @@ limit = 0
   [keys.inline_describe]
     mode = ["enter"]
     accept = ["alt+enter", "ctrl+s"]
+    editor = ["alt+e"]
   [keys.git]
     mode = ["g"]
     push = ["p"]

--- a/internal/config/keys.go
+++ b/internal/config/keys.go
@@ -117,6 +117,7 @@ func Convert(m KeyMappings[keys]) KeyMappings[key.Binding] {
 		InlineDescribe: inlineDescribeModeKeys[key.Binding]{
 			Mode:   key.NewBinding(key.WithKeys(m.InlineDescribe.Mode...), key.WithHelp(JoinKeys(m.InlineDescribe.Mode), "inline describe")),
 			Accept: key.NewBinding(key.WithKeys(m.InlineDescribe.Accept...), key.WithHelp(JoinKeys(m.InlineDescribe.Accept), "accept")),
+			Editor: key.NewBinding(key.WithKeys(m.InlineDescribe.Editor...), key.WithHelp(JoinKeys(m.InlineDescribe.Editor), "open in editor")),
 		},
 		FileSearch: fileSearchKeys[key.Binding]{
 			Toggle: key.NewBinding(key.WithKeys(m.FileSearch.Toggle...), key.WithHelp(JoinKeys(m.FileSearch.Toggle), "fuzzy files search")),
@@ -285,6 +286,7 @@ type opLogModeKeys[T any] struct {
 type inlineDescribeModeKeys[T any] struct {
 	Mode   T `toml:"mode"`
 	Accept T `toml:"accept"`
+	Editor T `toml:"editor"`
 }
 
 type fileSearchKeys[T any] struct {

--- a/internal/ui/operations/describe/describe.go
+++ b/internal/ui/operations/describe/describe.go
@@ -29,6 +29,7 @@ func (o Operation) IsEditing() bool {
 func (o Operation) ShortHelp() []key.Binding {
 	return []key.Binding{
 		o.keyMap.Cancel,
+		o.keyMap.InlineDescribe.Editor,
 		o.keyMap.InlineDescribe.Accept,
 	}
 }
@@ -73,6 +74,16 @@ func (o Operation) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		switch {
 		case key.Matches(keyMsg, o.keyMap.Cancel):
 			return o, common.Close
+		case key.Matches(keyMsg, o.keyMap.InlineDescribe.Editor):
+			commit := &jj.Commit{
+				ChangeId: o.revision,
+			}
+			selectedRevisions := jj.NewSelectedRevisions(commit)
+			return o, o.context.RunCommand(
+				jj.SetDescription(o.revision, o.input.Value()),
+				common.Close,
+				o.context.RunInteractiveCommand(jj.Describe(selectedRevisions), common.Refresh),
+			)
 		case key.Matches(keyMsg, o.keyMap.InlineDescribe.Accept):
 			return o, o.context.RunCommand(jj.SetDescription(o.revision, o.input.Value()), common.Close, common.Refresh)
 		}


### PR DESCRIPTION
Adds an "edit in editor" binding that lets you bail out from the inline describe editor to a full fledged editor.

Inspired by similar functionality that I missed from LazyGit


https://github.com/user-attachments/assets/7b994fb0-b41c-48aa-81c7-7a36623cedb5

