### PR TITLE
feat(git): Support multiple revisions

### DIFF
--- a/internal/ui/git/git_test.go
+++ b/internal/ui/git/git_test.go
@@ -16,7 +16,7 @@ func Test_Push(t *testing.T) {
 	commandRunner.Expect(jj.GitPush())
 	defer commandRunner.Verify()
 
-	op := NewModel(test.NewTestContext(commandRunner), nil, 0, 0)
+	op := NewModel(test.NewTestContext(commandRunner), jj.NewSelectedRevisions(), 0, 0)
 	tm := teatest.NewTestModel(t, op)
 	tm.Send(tea.KeyMsg{Type: tea.KeyEnter})
 	teatest.WaitFor(t, tm.Output(), func(bts []byte) bool {
@@ -31,7 +31,7 @@ func Test_Fetch(t *testing.T) {
 	commandRunner.Expect(jj.GitFetch())
 	defer commandRunner.Verify()
 
-	op := NewModel(test.NewTestContext(commandRunner), nil, 0, 0)
+	op := NewModel(test.NewTestContext(commandRunner), jj.NewSelectedRevisions(), 0, 0)
 	tm := teatest.NewTestModel(t, op)
 	tm.Type("/")
 	tm.Type("fetch")
@@ -68,7 +68,7 @@ func Test_PushChange(t *testing.T) {
 	commandRunner.Expect(jj.GitPush("--change", changeId))
 	defer commandRunner.Verify()
 
-	op := NewModel(test.NewTestContext(commandRunner), &jj.Commit{ChangeId: changeId}, 0, 0)
+	op := NewModel(test.NewTestContext(commandRunner), jj.NewSelectedRevisions(&jj.Commit{ChangeId: changeId}), 0, 0)
 	tm := teatest.NewTestModel(t, op)
 	// Filter for the exact item and ensure selection is at index 0
 	tm.Type("/")

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -143,7 +143,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.revsetModel, _ = m.revsetModel.Update(revset.EditRevSetMsg{Clear: m.state != common.Error})
 			return m, nil
 		case key.Matches(msg, m.keyMap.Git.Mode) && m.revisions.InNormalMode():
-			m.stacked = git.NewModel(m.context, m.revisions.SelectedRevision(), m.Width, m.Height)
+			m.stacked = git.NewModel(m.context, m.revisions.SelectedRevisions(), m.Width, m.Height)
 			return m, m.stacked.Init()
 		case key.Matches(msg, m.keyMap.Undo) && m.revisions.InNormalMode():
 			m.stacked = undo.NewModel(m.context)


### PR DESCRIPTION
This change allows the user to act on multiple selected revisions in the 'git operations' UI.

If only a single revision is selected, everything works as before. If multiple revisions are selected, there will be a single entry to push all selected in a single  `jj git push --change a --change b ...`  call.

In case of multiple revisions, the `c` shortcut will be bound to the new 'push all selected changes' entry and the entries to push a single change will have no keyboard shortcut bound to them. 

<img width="558" height="361" alt="Screenshot 2025-10-03 at 12 35 52" src="https://github.com/user-attachments/assets/842f253f-dd4c-49c0-a384-e0e0690dc457" />

