### PR TITLE
feat(suggest): Allow configuring default suggest mode for exec commands

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -17,6 +17,7 @@ var Current = loadDefaultConfig()
 type Config struct {
 	Keys      KeyMappings[keys] `toml:"keys"`
 	UI        UIConfig          `toml:"ui"`
+	Suggest   SuggestConfig     `toml:"suggest"`
 	Revisions RevisionsConfig   `toml:"revisions"`
 	Preview   PreviewConfig     `toml:"preview"`
 	OpLog     OpLogConfig       `toml:"oplog"`
@@ -221,4 +222,33 @@ func Edit() int {
 	cmd.Stderr = os.Stderr
 	_ = cmd.Run()
 	return cmd.ProcessState.ExitCode()
+}
+
+type SuggestMode int
+
+const (
+	SuggestModeOff SuggestMode = iota
+	SuggestModeFuzzy
+	SuggestModeRegex
+)
+
+type SuggestConfig struct {
+	Exec SuggestExecConfig `toml:"exec"`
+}
+
+type SuggestExecConfig struct {
+	Mode string `toml:"mode"`
+}
+
+func GetSuggestExecMode(c *Config) (SuggestMode, error) {
+	switch value := c.Suggest.Exec.Mode; value {
+	case "off":
+		return SuggestModeOff, nil
+	case "fuzzy":
+		return SuggestModeFuzzy, nil
+	case "regex":
+		return SuggestModeRegex, nil
+	default:
+		return SuggestModeOff, fmt.Errorf("invalid value for 'suggest.exec.mode': %q (expected one of: off, fuzzy, regex)", value)
+	}
 }

--- a/internal/config/default/config.toml
+++ b/internal/config/default/config.toml
@@ -112,11 +112,13 @@ limit = 0
 [ui]
   theme = ""
   auto_refresh_interval = 0
+  [ui.tracer]
+    enabled = false
+  [ui.colors]
 
-[ui.tracer]
-  enabled = false
-
-[ui.colors]
+[suggest]
+  [suggest.exec]
+    mode = "off"
 
 [revisions]
   log_batching = true


### PR DESCRIPTION
This PR introduces a new configuration section for suggestion modes, refactors suggestion mode handling to use a centralized enum and configuration, and updates the fuzzy exec command logic to use these new settings.

The idea behind the nested configuration is that one can image there being multiple places where some suggest/fuzzy search UI is to be used, and the config option `suggest` can group them all. For now, only the exec commands for exec jj and exec shell command.

I directly open this PR without discussing this feature first simply because I already had this implemented and only wanted to upstream the feature if you are keen on merging. I am open to any and all modifications.

If this gets merged, will update the documentation as well.

Follow-up FRs/ideas beyond the scope of this PR:
1. feat(keybinds): Allow configuring keybinds for the exec suggest UI.
2. feat(fuzzy_suggest): Allow cycling through history of exec commands using up and down arrows, and simultaneously allow using `ctrl+{p,n}` to cycle through the suggestions.
3. refactor(config): Extract parsing and setting the current config file into a single `ParseConfig()` function which would validate the config values for all config options. As of now, each config option is parsed and validated somewhere random across the whole code space.