### PR TITLE
feat: add failure test scenario support

### DIFF
--- a/internal/ui/redo/redo_test.go
+++ b/internal/ui/redo/redo_test.go
@@ -2,12 +2,15 @@ package redo
 
 import (
 	"bytes"
+	"errors"
+	"reflect"
 	"testing"
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/x/exp/teatest"
 	"github.com/idursun/jjui/internal/jj"
+	"github.com/idursun/jjui/internal/ui/common"
 	"github.com/idursun/jjui/test"
 )
 
@@ -45,4 +48,69 @@ func TestCancel(t *testing.T) {
 	})
 	tm.Quit()
 	tm.WaitFinished(t, teatest.WithFinalTimeout(3*time.Second))
+}
+
+func TestRedoNothingToRedo(t *testing.T) {
+	commandRunner := test.NewTestCommandRunner(t)
+	commandRunner.Expect(jj.OpLog(1))
+	commandRunner.Expect(jj.Redo()).SetError(errors.New("Error: Nothing to redo."))
+	defer commandRunner.Verify()
+
+	model := NewModel(test.NewTestContext(commandRunner))
+	_, cmd := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+
+	msgs := collectMsgs(cmd)
+	if len(msgs) == 0 {
+		t.Fatalf("expected command messages, got none")
+	}
+
+	var completed *common.CommandCompletedMsg
+	for i := range msgs {
+		if msg, ok := msgs[i].(common.CommandCompletedMsg); ok {
+			completed = &msg
+			break
+		}
+	}
+
+	if completed == nil {
+		t.Fatalf("expected CommandCompletedMsg in %+v", msgs)
+	}
+
+	if completed.Err == nil {
+		t.Fatalf("expected error message, got nil")
+	}
+
+	if completed.Err.Error() != "Error: Nothing to redo." {
+		t.Fatalf("unexpected error message: %v", completed.Err)
+	}
+}
+
+func collectMsgs(cmd tea.Cmd) []tea.Msg {
+	if cmd == nil {
+		return nil
+	}
+	msg := cmd()
+	if msg == nil {
+		return nil
+	}
+
+	switch m := msg.(type) {
+	case tea.BatchMsg:
+		var out []tea.Msg
+		for _, c := range m {
+			out = append(out, collectMsgs(c)...)
+		}
+		return out
+	}
+
+	val := reflect.ValueOf(msg)
+	if val.Kind() == reflect.Slice && val.Type().Elem() == reflect.TypeOf((tea.Cmd)(nil)) {
+		var out []tea.Msg
+		for i := 0; i < val.Len(); i++ {
+			out = append(out, collectMsgs(val.Index(i).Interface().(tea.Cmd))...)
+		}
+		return out
+	}
+
+	return []tea.Msg{msg}
 }


### PR DESCRIPTION
## background
- While i was working on [feat: add `jj redo` functionality](https://github.com/idursun/jjui/pull/322), i wanted to add more test on failure scenario (e.g., calling `jj redo` on a newly-init jj repo, which gives `Error: Nothing to redo`).
- But currently in `test/test_command_runner.go`, the execution error isn't bubbled up, as `_, _ = t.RunCommandImmediate(args)` is used. 
- Hence, i would like to propose below changes to improve testability of current codebase.


## changes
- Adds an err field to ExpectedCommand plus a fluent SetError helper, letting tests queue failures alongside stubbed output.
- Buffered output and stored error from `RunCommandImmediate` is now returned, so subsequent helpers see exactly what the fake command reported.
- Async `RunCommand` wrapper is updated to propagate those results in the emitted `common.CommandCompletedMsg`.
- Adds UT for `redo` functionality, which includes the above-mentioned "Nothing to redo" scenario. 
