### PR TITLE
feat(prune): adds new command `prune`

### DIFF
--- a/internal/config/default/config.toml
+++ b/internal/config/default/config.toml
@@ -14,6 +14,7 @@ limit = 0
   commit = ["c"]
   refresh = ["ctrl+r"]
   abandon = ["a"]
+  prune = ["alt+a"]
   diff = ["d"]
   quit = ["q"]
   help = ["?"]

--- a/internal/config/keys.go
+++ b/internal/config/keys.go
@@ -26,6 +26,7 @@ func Convert(m KeyMappings[keys]) KeyMappings[key.Binding] {
 		Undo:              key.NewBinding(key.WithKeys(m.Undo...), key.WithHelp(JoinKeys(m.Undo), "undo")),
 		Redo:              key.NewBinding(key.WithKeys(m.Redo...), key.WithHelp(JoinKeys(m.Redo), "redo")),
 		Abandon:           key.NewBinding(key.WithKeys(m.Abandon...), key.WithHelp(JoinKeys(m.Abandon), "abandon")),
+		Prune:             key.NewBinding(key.WithKeys(m.Prune...), key.WithHelp(JoinKeys(m.Prune), "prune")),
 		Edit:              key.NewBinding(key.WithKeys(m.Edit...), key.WithHelp(JoinKeys(m.Edit), "edit")),
 		ForceEdit:         key.NewBinding(key.WithKeys(m.ForceEdit...), key.WithHelp(JoinKeys(m.ForceEdit), "force edit")),
 		Diffedit:          key.NewBinding(key.WithKeys(m.Diffedit...), key.WithHelp(JoinKeys(m.Diffedit), "diff edit")),
@@ -169,6 +170,7 @@ type KeyMappings[T any] struct {
 	Commit            T                         `toml:"commit"`
 	Refresh           T                         `toml:"refresh"`
 	Abandon           T                         `toml:"abandon"`
+	Prune             T                         `toml:"prune"`
 	Diff              T                         `toml:"diff"`
 	Quit              T                         `toml:"quit"`
 	Help              T                         `toml:"help"`

--- a/internal/jj/commands.go
+++ b/internal/jj/commands.go
@@ -106,6 +106,14 @@ func GetDescription(revision string) CommandArgs {
 	return []string{"log", "-r", revision, "--template", "description", "--no-graph", "--ignore-working-copy", "--color", "never", "--quiet"}
 }
 
+func Prune(revision string, ignoreImmutable bool) CommandArgs {
+	args := []string{"abandon", "--retain-bookmarks", revision+"::" }
+	if ignoreImmutable {
+		args = append(args, "--ignore-immutable")
+	}
+	return args
+}
+
 func Abandon(revision SelectedRevisions, ignoreImmutable bool) CommandArgs {
 	args := []string{"abandon", "--retain-bookmarks"}
 	args = append(args, revision.AsArgs()...)

--- a/internal/ui/helppage/help.go
+++ b/internal/ui/helppage/help.go
@@ -116,6 +116,7 @@ func (h *Model) View() string {
 		h.printKeyBinding(h.keyMap.Diffedit),
 		h.printKeyBinding(h.keyMap.Split),
 		h.printKeyBinding(h.keyMap.Abandon),
+		h.printKeyBinding(h.keyMap.Prune),
 		h.printKeyBinding(h.keyMap.Absorb),
 		h.printKeyBinding(h.keyMap.Undo),
 		h.printKeyBinding(h.keyMap.Redo),

--- a/internal/ui/operations/prune/prune.go
+++ b/internal/ui/operations/prune/prune.go
@@ -1,0 +1,82 @@
+package prune
+
+import (
+	"fmt"
+
+	"github.com/charmbracelet/bubbles/key"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/idursun/jjui/internal/jj"
+	"github.com/idursun/jjui/internal/ui/common"
+	"github.com/idursun/jjui/internal/ui/confirmation"
+	"github.com/idursun/jjui/internal/ui/context"
+	"github.com/idursun/jjui/internal/ui/operations"
+)
+
+var _ operations.Operation = (*Operation)(nil)
+var _ common.Editable = (*Operation)(nil)
+
+type Operation struct {
+	model   *confirmation.Model
+	current *jj.Commit
+	context *context.MainContext
+}
+
+func (a *Operation) IsEditing() bool {
+	return true
+}
+
+func (a *Operation) Init() tea.Cmd {
+	return nil
+}
+
+func (a *Operation) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	var cmd tea.Cmd
+	a.model, cmd = a.model.Update(msg)
+	return a, cmd
+}
+
+func (a *Operation) View() string {
+	return a.model.View()
+}
+
+func (a *Operation) ShortHelp() []key.Binding {
+	return a.model.ShortHelp()
+}
+
+func (a *Operation) FullHelp() [][]key.Binding {
+	return [][]key.Binding{a.ShortHelp()}
+}
+
+func (a *Operation) SetSelectedRevision(commit *jj.Commit) {
+	a.current = commit
+}
+
+func (a *Operation) Render(commit *jj.Commit, pos operations.RenderPosition) string {
+	isSelected := commit != nil && commit.GetChangeId() == a.current.GetChangeId()
+	if !isSelected || pos != operations.RenderPositionAfter {
+		return ""
+	}
+	return a.View()
+}
+
+func (a *Operation) Name() string {
+	return "prune"
+}
+
+func NewOperation(context *context.MainContext, selectedRevision *jj.Commit) *Operation {
+	message := fmt.Sprintf("Are you sure you want to abandon this revision and all its descendants?")
+	cmd := func(ignoreImmutable bool) tea.Cmd {
+		return context.RunCommand(jj.Prune(selectedRevision.GetChangeId(), ignoreImmutable), common.Refresh, common.Close)
+	}
+	model := confirmation.New(
+		[]string{message},
+		confirmation.WithAltOption("Yes", cmd(false), cmd(true), key.NewBinding(key.WithKeys("y"), key.WithHelp("y", "yes"))),
+		confirmation.WithOption("No", common.Close, key.NewBinding(key.WithKeys("n", "esc"), key.WithHelp("n/esc", "no"))),
+		confirmation.WithStylePrefix("abandon"),
+	)
+
+	op := &Operation{
+		model: model,
+	}
+	return op
+}

--- a/internal/ui/operations/prune/prune_test.go
+++ b/internal/ui/operations/prune/prune_test.go
@@ -1,0 +1,51 @@
+package prune
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/x/exp/teatest"
+	"github.com/idursun/jjui/internal/jj"
+	"github.com/idursun/jjui/test"
+)
+
+var commit = &jj.Commit{ChangeId: "a"}
+
+func Test_Accept(t *testing.T) {
+	commandRunner := test.NewTestCommandRunner(t)
+	commandRunner.Expect(jj.Prune(commit.GetChangeId(), false))
+	defer commandRunner.Verify()
+
+	model := NewOperation(test.NewTestContext(commandRunner), commit)
+	model.SetSelectedRevision(commit)
+
+	tm := teatest.NewTestModel(t, model)
+	teatest.WaitFor(t, tm.Output(), func(bts []byte) bool {
+		return bytes.Contains(bts, []byte("abandon"))
+	})
+
+	tm.Send(tea.KeyMsg{Type: tea.KeyEnter})
+	teatest.WaitFor(t, tm.Output(), func(bts []byte) bool {
+		return commandRunner.IsVerified()
+	})
+	tm.Quit()
+	tm.WaitFinished(t, teatest.WithFinalTimeout(3*time.Second))
+}
+
+func Test_Cancel(t *testing.T) {
+	commandRunner := test.NewTestCommandRunner(t)
+	defer commandRunner.Verify()
+
+	model := NewOperation(test.NewTestContext(commandRunner), commit)
+	model.SetSelectedRevision(commit)
+
+	tm := teatest.NewTestModel(t, model)
+	tm.Send(tea.KeyMsg{Type: tea.KeyEsc})
+	teatest.WaitFor(t, tm.Output(), func(bts []byte) bool {
+		return commandRunner.IsVerified()
+	})
+	tm.Quit()
+	tm.WaitFinished(t, teatest.WithFinalTimeout(3*time.Second))
+}

--- a/internal/ui/revisions/revisions.go
+++ b/internal/ui/revisions/revisions.go
@@ -32,6 +32,7 @@ import (
 	"github.com/idursun/jjui/internal/ui/operations/bookmark"
 	"github.com/idursun/jjui/internal/ui/operations/details"
 	"github.com/idursun/jjui/internal/ui/operations/evolog"
+	"github.com/idursun/jjui/internal/ui/operations/prune"
 	"github.com/idursun/jjui/internal/ui/operations/rebase"
 	"github.com/idursun/jjui/internal/ui/operations/squash"
 )
@@ -430,6 +431,10 @@ func (m *Model) internalUpdate(msg tea.Msg) (*Model, tea.Cmd) {
 			case key.Matches(msg, m.keymap.Abandon):
 				selections := m.SelectedRevisions()
 				m.op = abandon.NewOperation(m.context, selections)
+				return m, m.op.Init()
+			case key.Matches(msg, m.keymap.Prune):
+				revision := m.SelectedRevision()
+				m.op = prune.NewOperation(m.context, revision)
 				return m, m.op.Init()
 			case key.Matches(msg, m.keymap.Bookmark.Set):
 				m.op = bookmark.NewSetBookmarkOperation(m.context, m.SelectedRevision().GetChangeId())


### PR DESCRIPTION
Prune takes a selected change and abandons it as well as all of it's descendants.

Consider the following tree
```
@
|
A   I
|   |
B G H
| |/
D F
|/
E
|
J
```
Make change F selected and execute the `prune` command (by default the keybinding is `alt + a`). It will warn the user, asking for confirmation, and then run `jj abandon -r F::`. 

This will abandon changes F, G, H, and I.

See Issue #337