### PR TITLE
fix(ace_jump): close operation after applying jump

### DIFF
--- a/internal/ui/operations/ace_jump/operation.go
+++ b/internal/ui/operations/ace_jump/operation.go
@@ -118,7 +118,7 @@ func (o *Operation) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case key.Matches(msg, o.keymap.Apply):
 			o.cursor.SetCursor(o.aceJump.First().RowIdx)
 			o.aceJump = nil
-			return o, nil
+			return o, common.Close
 		default:
 			return o, o.HandleKey(msg)
 		}


### PR DESCRIPTION
## summary 
**fix ace jump panic after model not being closed properly**.   

*bug details and reproducible steps see #350*


## changes
a pretty short and self explanatory PR

- return `common.Close` after `enter` is pressed so that operation model will be closed and reset upon next ace jump activation