### PR TITLE
fix(fuzzy_files): quote path for editor command

### DIFF
--- a/internal/ui/fuzzy_search/fuzzy_search.go
+++ b/internal/ui/fuzzy_search/fuzzy_search.go
@@ -1,6 +1,7 @@
 package fuzzy_search
 
 import (
+	"fmt"
 	"slices"
 	"strings"
 
@@ -58,7 +59,7 @@ func SelectedMatch(model Model) string {
 		return ""
 	}
 	m := matches[idx]
-	return model.String(m.Index)
+	return fmt.Sprintf("'%s'", model.String(m.Index))
 }
 
 // helper to upcast: Model => tea.Model => Model


### PR DESCRIPTION
## changes
**quote file path to properly process path with space and other shell stuff**
*see #295* 

## implementation

- rather than quoting at `Line: config.GetDefaultEditor() + " " + path`, add quoting at `fuzzy_search.SelectedMatch()` to address all potential issues
https://github.com/idursun/jjui/blob/e5869d0cada3d4cc87ce2f9489b5d9c0ca5a9f96/internal/ui/fuzzy_files/fuzzy_files.go#L148