### PR TITLE
Support interactive file-level restores

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ You can squash revisions into one revision, by pressing `S`. The following revis
 Pressing `l` (as in going right into the details of a revision) will open the details view of the revision you selected.
 
 In this mode, you can:
+- Restore selected files using `r` (press `i` in the dialog for interactive chunk restore)
 - Split selected files using `s`
-- Restore selected files using `r`
 - View diffs of the highlighted by pressing `d`
 
 ![GIF](https://github.com/idursun/jjui/wiki/gifs/jjui_details.gif)

--- a/internal/jj/commands.go
+++ b/internal/jj/commands.go
@@ -136,6 +136,14 @@ func Restore(revision string, files []string) CommandArgs {
 	return args
 }
 
+func RestoreInteractive(revision string, file string) CommandArgs {
+	args := []string{"restore", "-c", revision, "--interactive"}
+	if file != "" {
+		args = append(args, EscapeFileName(file))
+	}
+	return args
+}
+
 func RestoreEvolog(from string, into string) CommandArgs {
 	args := []string{"restore", "--from", from, "--into", into, "--restore-descendants"}
 	return args

--- a/internal/ui/operations/details/details.go
+++ b/internal/ui/operations/details/details.go
@@ -155,6 +155,7 @@ func (s *Operation) internalUpdate(msg tea.Msg) (*Operation, tea.Cmd) {
 			}
 		case key.Matches(msg, s.keyMap.Details.Restore):
 			selectedFiles := s.getSelectedFiles()
+			selected := s.current()
 			s.selectedHint = "gets restored"
 			s.unselectedHint = "stays as is"
 			model := confirmation.New(
@@ -163,6 +164,9 @@ func (s *Operation) internalUpdate(msg tea.Msg) (*Operation, tea.Cmd) {
 				confirmation.WithOption("Yes",
 					s.context.RunCommand(jj.Restore(s.revision.GetChangeId(), selectedFiles), common.Refresh, confirmation.Close),
 					key.NewBinding(key.WithKeys("y"), key.WithHelp("y", "yes"))),
+				confirmation.WithOption("Interactive",
+					tea.Batch(s.context.RunInteractiveCommand(jj.RestoreInteractive(s.revision.GetChangeId(), selected.fileName), common.Refresh), common.Close),
+					key.NewBinding(key.WithKeys("i"), key.WithHelp("i", "interactive"))),
 				confirmation.WithOption("No",
 					confirmation.Close,
 					key.NewBinding(key.WithKeys("n", "esc"), key.WithHelp("n/esc", "no"))),


### PR DESCRIPTION
This helps with discarding chunks that shouldn't get included in the revision, e.g. if it's meant for debugging

https://github.com/user-attachments/assets/08f1ac0c-7514-4f0e-afc1-eabca0f3ad13

