### PR TITLE
operation: add ForceApply to squash/rebase footer

### DIFF
--- a/internal/ui/operations/rebase/rebase_operation.go
+++ b/internal/ui/operations/rebase/rebase_operation.go
@@ -54,8 +54,10 @@ type styles struct {
 	text         lipgloss.Style
 }
 
-var _ operations.Operation = (*Operation)(nil)
-var _ common.Focusable = (*Operation)(nil)
+var (
+	_ operations.Operation = (*Operation)(nil)
+	_ common.Focusable     = (*Operation)(nil)
+)
 
 type Operation struct {
 	context        *context.MainContext
@@ -148,6 +150,8 @@ func (r *Operation) SetSelectedRevision(commit *jj.Commit) {
 
 func (r *Operation) ShortHelp() []key.Binding {
 	return []key.Binding{
+		r.keyMap.Apply,
+		r.keyMap.ForceApply,
 		r.keyMap.Rebase.Revision,
 		r.keyMap.Rebase.Branch,
 		r.keyMap.Rebase.Source,

--- a/internal/ui/operations/squash/squash_operation.go
+++ b/internal/ui/operations/squash/squash_operation.go
@@ -102,6 +102,7 @@ func (s *Operation) Name() string {
 func (s *Operation) ShortHelp() []key.Binding {
 	return []key.Binding{
 		s.keyMap.Apply,
+		s.keyMap.ForceApply,
 		s.keyMap.Cancel,
 		s.keyMap.Squash.KeepEmptied,
 		s.keyMap.Squash.Interactive,


### PR DESCRIPTION
## changes

- Updates `ShortHelp` key bindings for rebase and squash operations to include 'ForceApply'.