### PR TITLE
abandon: add force apply to footer help menu

### DIFF
--- a/internal/ui/operations/abandon/abandon.go
+++ b/internal/ui/operations/abandon/abandon.go
@@ -12,8 +12,10 @@ import (
 	"github.com/idursun/jjui/internal/ui/operations"
 )
 
-var _ operations.Operation = (*Operation)(nil)
-var _ common.Editable = (*Operation)(nil)
+var (
+	_ operations.Operation = (*Operation)(nil)
+	_ common.Editable      = (*Operation)(nil)
+)
 
 type Operation struct {
 	model   *confirmation.Model
@@ -40,7 +42,13 @@ func (a *Operation) View() string {
 }
 
 func (a *Operation) ShortHelp() []key.Binding {
-	return a.model.ShortHelp()
+	baseHelp := a.model.ShortHelp()
+
+	additionalHelp := key.NewBinding(
+		key.WithKeys("alt+enter"),
+		key.WithHelp("alt+enter", "force apply"),
+	)
+	return append(baseHelp, additionalHelp)
 }
 
 func (a *Operation) FullHelp() [][]key.Binding {


### PR DESCRIPTION
it's a surprise to find out force apply works for `abandon` on immutable changes
adding this to the short help menu of `abandon`
