### PR TITLE
refactor: serialise command execution

### DIFF
--- a/internal/ui/common/msgs.go
+++ b/internal/ui/common/msgs.go
@@ -27,8 +27,9 @@ type (
 	}
 	CommandRunningMsg   string
 	CommandCompletedMsg struct {
-		Output string
-		Err    error
+		Output       string
+		Err          error
+		Continuation tea.Cmd
 	}
 	SelectionChangedMsg struct{}
 	QuickSearchMsg      string

--- a/internal/ui/context/command_runner.go
+++ b/internal/ui/context/command_runner.go
@@ -24,9 +24,13 @@ type CommandRunner interface {
 
 type MainCommandRunner struct {
 	Location string
+	lock     sync.Mutex
 }
 
 func (a *MainCommandRunner) RunCommandImmediate(args []string) ([]byte, error) {
+	a.lock.Lock()
+	defer a.lock.Unlock()
+
 	c := exec.Command("jj", args...)
 	c.Dir = a.Location
 	if output, err := c.Output(); err != nil {
@@ -66,6 +70,9 @@ func (a *MainCommandRunner) RunCommand(args []string, continuations ...tea.Cmd) 
 	commands := make([]tea.Cmd, 0)
 	commands = append(commands,
 		func() tea.Msg {
+			a.lock.Lock()
+			defer a.lock.Unlock()
+
 			if !slices.Contains(args, "--color") {
 				args = append([]string{"--color", "always"}, args...)
 			}
@@ -97,15 +104,18 @@ func (a *MainCommandRunner) RunInteractiveCommand(args []string, continuation te
 	errBuffer := &bytes.Buffer{}
 	c.Stderr = errBuffer
 	c.Dir = a.Location
-	return tea.Batch(
+	a.lock.Lock()
+
+	return tea.Sequence(
 		common.CommandRunning(args),
 		tea.ExecProcess(c, func(err error) tea.Msg {
+			defer a.lock.Unlock()
+
 			if err != nil {
 				return common.CommandCompletedMsg{Err: errors.New(errBuffer.String())}
+			} else {
+				return common.CommandCompletedMsg{Err: nil, Continuation: continuation}
 			}
-			return tea.Batch(continuation, func() tea.Msg {
-				return common.CommandCompletedMsg{Err: nil}
-			})()
 		}),
 	)
 }
@@ -120,13 +130,13 @@ type StreamingCommand struct {
 
 func (c *StreamingCommand) Close() error {
 	var err error
+	pipeErr := c.ReadCloser.Close()
 	c.once.Do(func() {
 		log.Println("closing streaming command")
-		pipeErr := c.ReadCloser.Close()
 
 		if c.ctx.Err() != nil {
 			log.Println("killing process due to context cancellation")
-			if killErr := c.cmd.Process.Kill(); killErr != nil {
+			if killErr := c.cmd.Process.Kill(); killErr != nil && !errors.Is(killErr, os.ErrProcessDone) {
 				err = killErr
 				return
 			}
@@ -142,5 +152,6 @@ func (c *StreamingCommand) Close() error {
 			err = pipeErr
 		}
 	})
+
 	return err
 }

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -122,6 +122,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	var cmds []tea.Cmd
 
 	switch msg := msg.(type) {
+	case common.CommandCompletedMsg:
+		if msg.Continuation != nil {
+			cmds = append(cmds, msg.Continuation)
+		}
 	case tea.FocusMsg:
 		return m, common.RefreshAndKeepSelections
 	case tea.KeyMsg:


### PR DESCRIPTION
This first attempt at serialising the command execution to prevent occasional stale workspace situations.

fixes #376