### PR TITLE
fix(oplog): improve operation id detection

### DIFF
--- a/internal/ui/oplog/oplog_parser_test.go
+++ b/internal/ui/oplog/oplog_parser_test.go
@@ -1,0 +1,37 @@
+package oplog
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParse(t *testing.T) {
+	tests := []struct {
+		name     string
+		fileName string
+		expected int
+	}{
+		{
+			name:     "single",
+			fileName: "single.log",
+			expected: 1,
+		},
+		{
+			name:     "multi",
+			fileName: "multi.log",
+			expected: 2,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			file, err := os.Open(fmt.Sprintf("testdata/%s", test.fileName))
+			assert.NoError(t, err)
+
+			rows := parseRows(file)
+			assert.Len(t, rows, test.expected)
+		})
+	}
+}

--- a/internal/ui/oplog/row.go
+++ b/internal/ui/oplog/row.go
@@ -13,9 +13,21 @@ type rowLine struct {
 	Segments []*screen.Segment
 }
 
+func isOperationId(text string) bool {
+	if len(text) != 12 {
+		return false
+	}
+	for _, r := range text {
+		if !(r >= 'a' && r <= 'f' || r >= '0' && r <= '9') {
+			return false
+		}
+	}
+	return true
+}
+
 func (l *rowLine) FindIdIndex() int {
 	for i, segment := range l.Segments {
-		if len(segment.Text) == 12 {
+		if isOperationId(segment.Text) {
 			return i
 		}
 	}

--- a/internal/ui/oplog/testdata/multi.log
+++ b/internal/ui/oplog/testdata/multi.log
@@ -1,0 +1,6 @@
+[1m[38;5;2m@[0m  [1m[38;5;12mf468151957e6[39m [38;5;3midursun@Ibrahims-MacBook-Pro.local[39m [38;5;14mnow, lasted 26 milliseconds[39m[0m
+│  [1msnapshot working copy[0m
+│  [1m[38;5;13margs: jj op log -n 2 --color always[39m[0m
+○  [38;5;4m5ce8658087d8[39m [38;5;3midursun@Ibrahims-MacBook-Pro.local[39m [38;5;6m2 minutes ago, lasted 27 milliseconds[39m
+│  new empty commit
+│  [38;5;5margs: jj new[39m

--- a/internal/ui/oplog/testdata/single.log
+++ b/internal/ui/oplog/testdata/single.log
@@ -1,0 +1,3 @@
+[1m[38;5;2m@[0m  [1m[38;5;12m5ce8658087d8[39m [38;5;3midursun@Ibrahims-MacBook-Pro.local[39m [38;5;14m15 seconds ago, lasted 27 milliseconds[39m[0m
+│  [1mnew empty commit[0m
+│  [1m[38;5;13margs: jj new[39m[0m


### PR DESCRIPTION
Use a dedicated operation id detection function instead of just the length of the segment text.

fixes #377