### PR TITLE
refactor: use simple layout functions to lay out the main UI

### DIFF
--- a/internal/ui/common/sizable.go
+++ b/internal/ui/common/sizable.go
@@ -1,5 +1,7 @@
 package common
 
+import "github.com/charmbracelet/x/cellbuf"
+
 type ISizeable interface {
 	SetWidth(w int)
 	SetHeight(h int)
@@ -10,6 +12,7 @@ var _ ISizeable = (*Sizeable)(nil)
 type Sizeable struct {
 	Width  int
 	Height int
+	Frame  cellbuf.Rectangle
 }
 
 func (s *Sizeable) SetWidth(w int) {
@@ -18,6 +21,12 @@ func (s *Sizeable) SetWidth(w int) {
 
 func (s *Sizeable) SetHeight(h int) {
 	s.Height = h
+}
+
+func (s *Sizeable) SetFrame(f cellbuf.Rectangle) {
+	s.Frame = f
+	s.Width = f.Dx()
+	s.Height = f.Dy()
 }
 
 func NewSizeable(width, height int) *Sizeable {

--- a/internal/ui/layout/layout.go
+++ b/internal/ui/layout/layout.go
@@ -1,0 +1,55 @@
+package layout
+
+import "github.com/charmbracelet/x/cellbuf"
+
+// Implements a simple layout function mostly copied from charmbracelet/uv and to be replaced by it later
+
+type Constraint interface {
+	Apply(size int) int
+}
+
+type Percent int
+
+func (p Percent) Apply(size int) int {
+	if p < 0 {
+		return 0
+	}
+	if p > 100 {
+		return size
+	}
+	return size * int(p) / 100
+}
+
+type Fixed int
+
+func (f Fixed) Apply(size int) int {
+	if f < 0 {
+		return 0
+	}
+	if int(f) > size {
+		return size
+	}
+	return int(f)
+}
+
+func SplitVertical(area cellbuf.Rectangle, constraint Constraint) (top cellbuf.Rectangle, bottom cellbuf.Rectangle) {
+	height := min(constraint.Apply(area.Dy()), area.Dy())
+	top = cellbuf.Rectangle{
+		Min: area.Min, Max: cellbuf.Pos(area.Max.X, area.Min.Y+height),
+	}
+	bottom = cellbuf.Rectangle{
+		Min: cellbuf.Pos(area.Min.X, area.Min.Y+height), Max: area.Max,
+	}
+	return
+}
+
+func SplitHorizontal(area cellbuf.Rectangle, constraint Constraint) (left cellbuf.Rectangle, right cellbuf.Rectangle) {
+	width := min(constraint.Apply(area.Dx()), area.Dx())
+	left = cellbuf.Rectangle{
+		Min: area.Min, Max: cellbuf.Pos(area.Min.X+width, area.Max.Y),
+	}
+	right = cellbuf.Rectangle{
+		Min: cellbuf.Pos(area.Min.X+width, area.Min.Y), Max: area.Max,
+	}
+	return
+}


### PR DESCRIPTION
This PR simplifies the main UI composition code to use frames and cellbuf SetContent functions. It also adds simple layout functions which are borrowed from [uv/layout.go](https://github.com/charmbracelet/ultraviolet/blob/main/layout.go)

This PR is stacked on top of #388 