### PR TITLE
Coming back to previous state  when exec command failed

### DIFF
--- a/internal/ui/common/msgs.go
+++ b/internal/ui/common/msgs.go
@@ -37,6 +37,10 @@ type (
 		Line string
 		Mode ExecMode
 	}
+	ExecProcessCompletedMsg struct {
+		Err error
+		Msg ExecMsg
+	}
 	FileSearchMsg struct {
 		Revset       string
 		PreviewShown bool

--- a/internal/ui/status/status_test.go
+++ b/internal/ui/status/status_test.go
@@ -1,0 +1,71 @@
+package status
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/idursun/jjui/internal/config"
+	"github.com/idursun/jjui/internal/ui/common"
+	"github.com/idursun/jjui/internal/ui/context"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStatus_Update_ExecProcessCompletedMsg(t *testing.T) {
+	cases := []struct {
+		name           string
+		msg            common.ExecProcessCompletedMsg
+		expectedMode   string
+		expectedPrompt string
+		expectedInput  string
+		shouldFocus    bool
+		expectCmd      bool
+	}{
+		{
+			name: "Execution failed, should restore input",
+			msg: common.ExecProcessCompletedMsg{
+				Err: errors.New("exit status 1"),
+				Msg: common.ExecMsg{
+					Line: "invalid command",
+					Mode: common.ExecShell,
+				},
+			},
+			expectedMode:   "exec sh",
+			expectedPrompt: "$ ",
+			expectedInput:  "invalid command",
+			shouldFocus:    true,
+			expectCmd:      true,
+		},
+		{
+			name: "Execution succeeded",
+			msg: common.ExecProcessCompletedMsg{
+				Err: nil,
+			},
+			expectCmd: false,
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := &context.MainContext{
+				Histories: config.NewHistories(),
+			}
+			m := New(ctx)
+			cmd := m.Update(tt.msg)
+
+			if tt.expectCmd {
+				assert.NotNil(t, cmd)
+			} else {
+				assert.Nil(t, cmd)
+			}
+
+			if tt.shouldFocus {
+				assert.True(t, m.IsFocused())
+				assert.Equal(t, tt.expectedMode, m.mode)
+				assert.Equal(t, tt.expectedPrompt, m.input.Prompt)
+				assert.Equal(t, tt.expectedInput, m.input.Value())
+			} else {
+				assert.False(t, m.IsFocused())
+			}
+		})
+	}
+}

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -207,6 +207,8 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 		}
 	case common.ExecMsg:
 		return exec_process.ExecLine(m.context, msg)
+	case common.ExecProcessCompletedMsg:
+		cmds = append(cmds, common.Refresh)
 	case common.ToggleHelpMsg:
 		if m.stacked == nil {
 			m.stacked = helppage.New(m.context)


### PR DESCRIPTION
This PR enhances the user experience when executing commands (jj or shell) by automatically restoring failed commands to the input field, allowing users to easily
edit and retry without having to retype the entire command.



