### PR TITLE
list/renderer: fix viewport adjustment on PageDown

### DIFF
--- a/internal/ui/common/list/renderer.go
+++ b/internal/ui/common/list/renderer.go
@@ -109,7 +109,14 @@ func (r *ListRenderer) RenderWithOptions(opts RenderOptions) string {
 		if isFocused {
 			selectedLineEnd = r.totalLineCount()
 		}
+		// If EnsureFocusVisible is true and we haven't rendered the focused item yet, continue
+		// Otherwise, break when we exceed the viewport
 		if r.totalLineCount() > r.End {
+			if opts.EnsureFocusVisible && selectedLineEnd == -1 {
+				// continue rendering to reach the focused item
+				lastRenderedRowIndex = i
+				continue
+			}
 			lastRenderedRowIndex = i
 			break
 		}


### PR DESCRIPTION
With the fix from #387, when PageDown moved the cursor below the viewport, the renderer broke early before rendering the focused item, so `selectedLineStart` and `selectedLineEnd` stayed -1, which leads to the viewport not being adjusted and rerendered.

Now the renderer continues rendering until it reaches the focused item, even if it's below the viewport. So that the viewport is adjusted to show the focused item and the screen scrolls to follow the cursor

broken:
[![asciicast](https://asciinema.org/a/758652.svg)](https://asciinema.org/a/758652)

fix: 
[![asciicast](https://asciinema.org/a/hW05tZYZm5jKPqoXYhxYg0zwD.svg)](https://asciinema.org/a/hW05tZYZm5jKPqoXYhxYg0zwD)