### PR TITLE
Make preview horizontally scrollable

### DIFF
--- a/internal/ui/preview/preview_test.go
+++ b/internal/ui/preview/preview_test.go
@@ -1,0 +1,135 @@
+package preview
+
+import (
+	"testing"
+
+	"github.com/charmbracelet/x/cellbuf"
+	"github.com/idursun/jjui/internal/ui/common"
+	"github.com/idursun/jjui/test"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestModel_Init(t *testing.T) {
+	commandRunner := test.NewTestCommandRunner(t)
+	defer commandRunner.Verify()
+
+	parent := common.NewSizeable(10, 10)
+
+	ctx := test.NewTestContext(commandRunner)
+	model := New(ctx, parent)
+	test.SimulateModel(model, model.Init())
+}
+
+func TestModel_View(t *testing.T) {
+	tests := []struct {
+		name     string
+		scrollBy cellbuf.Position
+		atBottom bool
+		width    int
+		height   int
+		content  string
+		expected string
+	}{
+		{
+			name:     "clips",
+			scrollBy: cellbuf.Position{},
+			width:    5,
+			height:   2,
+			content: test.Stripped(`
+			+++++..
+			+abcde.
+			+++++..
+			`),
+			expected: test.Stripped(`
+			│++++
+			│+abc
+			`),
+		},
+		{
+			name:     "clips when at bottom",
+			scrollBy: cellbuf.Position{},
+			atBottom: true,
+			width:    5,
+			height:   3,
+			content: test.Stripped(`
+			+++++..
+			+abcde.
+			+++++..
+			`),
+			expected: test.Stripped(`
+			─────
+			+++++
+			+abcd
+			`),
+		},
+		{
+			name:     "Scroll by down and right",
+			scrollBy: cellbuf.Position{X: 1, Y: 1},
+			width:    5,
+			height:   2,
+			content: test.Stripped(`
+			.......
+			.abcde.
+			.......
+			`),
+			expected: test.Stripped(`
+			│abcd
+			│....
+			`),
+		},
+		{
+			name:     "Scroll down when at bottom",
+			scrollBy: cellbuf.Position{X: 0, Y: 1},
+			atBottom: true,
+			width:    5,
+			height:   3,
+			content: test.Stripped(`
+			.......
+			.abcde.
+			.......
+			`),
+			expected: test.Stripped(`
+			─────
+			.abcd
+			.....
+			`),
+		},
+		{
+			name:     "Scroll 2 right when at bottom",
+			scrollBy: cellbuf.Position{X: 2, Y: 0},
+			atBottom: true,
+			width:    5,
+			height:   3,
+			content: test.Stripped(`
+			.......
+			.abcde.
+			.......
+			`),
+			expected: test.Stripped(`
+			─────
+			.....
+			bcde.
+			`),
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			parent := common.NewSizeable(10, 10)
+			ctx := test.NewTestContext(test.NewTestCommandRunner(t))
+
+			model := New(ctx, parent)
+			model.previewAtBottom = tc.atBottom
+			model.SetFrame(cellbuf.Rect(0, 0, tc.width, tc.height))
+			model.SetContent(tc.content)
+			if tc.scrollBy.X > 0 {
+				model.ScrollHorizontal(tc.scrollBy.X)
+			}
+			if tc.scrollBy.Y > 0 {
+				model.Scroll(tc.scrollBy.Y)
+			}
+			v := test.Stripped(model.View())
+
+			assert.Equal(t, tc.expected, v)
+		})
+	}
+}

--- a/test/strings.go
+++ b/test/strings.go
@@ -1,0 +1,17 @@
+package test
+
+import "strings"
+
+// Stripped normalizes a string for comparisons by trimming surrounding
+// whitespace, trimming each individual line, and removing carriage returns.
+func Stripped(s string) string {
+	s = strings.ReplaceAll(s, "\r", "")
+	s = strings.TrimSpace(s)
+
+	lines := strings.Split(s, "\n")
+	for i := range lines {
+		lines[i] = strings.TrimSpace(lines[i])
+	}
+
+	return strings.Join(lines, "\n")
+}


### PR DESCRIPTION
This PR makes preview window horizontally scrollable (with mouse wheel). Additionally, custom viewport is removed in favour of using the bubbles/viewport which is way more responsive during renders.

I also replaced the surrounding border with a divider. This not only creates more space for the preview but also makes the draggable edge stand out.



https://github.com/user-attachments/assets/355b0b52-aa5f-499c-997b-98a606cd88b3

