### PR TITLE
revset: fix revset not using default when empty

### DIFF
--- a/internal/ui/revset/revset.go
+++ b/internal/ui/revset/revset.go
@@ -83,6 +83,10 @@ func New(context *appContext.MainContext) *Model {
 }
 
 func (m *Model) Init() tea.Cmd {
+	// Ensure CurrentRevset is initialized
+	if m.context.CurrentRevset == "" {
+		m.context.CurrentRevset = m.context.DefaultRevset
+	}
 	return nil
 }
 
@@ -129,6 +133,9 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 			m.Editing = false
 			m.autoComplete.Blur()
 			value := m.autoComplete.Value()
+			if strings.TrimSpace(value) == "" {
+				value = m.context.DefaultRevset
+			}
 			return tea.Batch(common.Close, common.UpdateRevSet(value))
 		case tea.KeyUp:
 			if len(m.History) > 0 {


### PR DESCRIPTION
When jjui is launched with a `--revset/-r` flag, the input argument should be come the default revset for the session, i.e., when user hits `L` and then `enter` with empty string, it should default to the argument defined by `-r` flag.

However, currently There's a mismatch between the display of `revset` and the actual jj log fetched: `revset` is user's session-wide default defined by `-r` flag, actual jj log is user's jj/jjui config.

This is due to `m.context.CurrentRevset` is updated to empty string, instead of default, when the text input is an empty string.

See 
<img width="1675" height="652" alt="image" src="https://github.com/user-attachments/assets/95c3f7ca-f0aa-41a4-9a68-1ebcc37f5fd4" />

[![asciicast](https://asciinema.org/a/CJ0dsrGzlEWvv0ApI31GnHmAr.svg)](https://asciinema.org/a/CJ0dsrGzlEWvv0ApI31GnHmAr)