### PR TITLE
operation: Add use destination message to squash operation

### DIFF
--- a/internal/config/default/config.toml
+++ b/internal/config/default/config.toml
@@ -60,6 +60,7 @@ limit = 0
   [keys.squash]
     mode = ["S"]
     keep_emptied = ["e"]
+    use_destination_message = ["d"]
     interactive = ["i"]
   [keys.details]
     mode = ["l"]

--- a/internal/config/keys.go
+++ b/internal/config/keys.go
@@ -73,9 +73,10 @@ func Convert(m KeyMappings[keys]) KeyMappings[key.Binding] {
 			Onto:   key.NewBinding(key.WithKeys(m.Duplicate.Onto...), key.WithHelp(JoinKeys(m.Duplicate.Onto), "duplicate onto")),
 		},
 		Squash: squashModeKeys[key.Binding]{
-			Mode:        key.NewBinding(key.WithKeys(m.Squash.Mode...), key.WithHelp(JoinKeys(m.Squash.Mode), "squash")),
-			KeepEmptied: key.NewBinding(key.WithKeys(m.Squash.KeepEmptied...), key.WithHelp(JoinKeys(m.Squash.KeepEmptied), "keep emptied commits")),
-			Interactive: key.NewBinding(key.WithKeys(m.Squash.Interactive...), key.WithHelp(JoinKeys(m.Squash.Interactive), "interactive")),
+			Mode:                  key.NewBinding(key.WithKeys(m.Squash.Mode...), key.WithHelp(JoinKeys(m.Squash.Mode), "squash")),
+			KeepEmptied:           key.NewBinding(key.WithKeys(m.Squash.KeepEmptied...), key.WithHelp(JoinKeys(m.Squash.KeepEmptied), "keep emptied commits")),
+			UseDestinationMessage: key.NewBinding(key.WithKeys(m.Squash.UseDestinationMessage...), key.WithHelp(JoinKeys(m.Squash.UseDestinationMessage), "use destination message")),
+			Interactive:           key.NewBinding(key.WithKeys(m.Squash.Interactive...), key.WithHelp(JoinKeys(m.Squash.Interactive), "interactive")),
 		},
 		Details: detailsModeKeys[key.Binding]{
 			Mode:                  key.NewBinding(key.WithKeys(m.Details.Mode...), key.WithHelp(JoinKeys(m.Details.Mode), "details")),
@@ -217,9 +218,10 @@ type bookmarkModeKeys[T any] struct {
 }
 
 type squashModeKeys[T any] struct {
-	Mode        T `toml:"mode"`
-	KeepEmptied T `toml:"keep_emptied"`
-	Interactive T `toml:"interactive"`
+	Mode                  T `toml:"mode"`
+	KeepEmptied           T `toml:"keep_emptied"`
+	UseDestinationMessage T `toml:"use_destination_message"`
+	Interactive           T `toml:"interactive"`
 }
 
 type revertModeKeys[T any] struct {

--- a/internal/jj/commands.go
+++ b/internal/jj/commands.go
@@ -199,12 +199,15 @@ func BookmarkUntrack(name string) CommandArgs {
 	return []string{"bookmark", "untrack", name}
 }
 
-func Squash(from SelectedRevisions, destination string, files []string, keepEmptied bool, interactive bool, ignoreImmutable bool) CommandArgs {
+func Squash(from SelectedRevisions, destination string, files []string, keepEmptied bool, useDestinationMessage bool, interactive bool, ignoreImmutable bool) CommandArgs {
 	args := []string{"squash"}
 	args = append(args, from.AsPrefixedArgs("--from")...)
 	args = append(args, "--into", destination)
 	if keepEmptied {
 		args = append(args, "--keep-emptied")
+	}
+	if useDestinationMessage {
+		args = append(args, "--use-destination-message")
 	}
 	if interactive {
 		args = append(args, "--interactive")

--- a/internal/ui/helppage/help_item_groups.go
+++ b/internal/ui/helppage/help_item_groups.go
@@ -149,6 +149,7 @@ func (h *Model) buildMiddleGroups() menuColumn {
 		itemGroup{
 			h.newModeItem(&h.keyMap.Squash.Mode, "Squash"),
 			h.newBindingItem(h.keyMap.Squash.KeepEmptied),
+			h.newBindingItem(h.keyMap.Squash.UseDestinationMessage),
 			h.newBindingItem(h.keyMap.Squash.Interactive),
 			helpItem{"", ""},
 		},


### PR DESCRIPTION
Add the --use-destination-message option to the squash operation.

I added a extra toggle option to the squash operation:
<img width="1199" height="374" alt="image" src="https://github.com/user-attachments/assets/5b363718-53c5-4222-8bda-8d58dc26cbf4" />

Only after I had already implemented it did I read the 'discussion-first approach' for features. If needed I can open a issue first and change the implementation if needed, but since I already had the code I thought it was better to just open a PR.