### PR TITLE
fix(streamer): handle warning messages

### DIFF
--- a/internal/ui/context/command_runner.go
+++ b/internal/ui/context/command_runner.go
@@ -144,3 +144,7 @@ func (c *StreamingCommand) Close() error {
 	})
 	return err
 }
+
+func (c *StreamingCommand) Wait() error {
+	return c.cmd.Wait()
+}

--- a/internal/ui/revisions/revisions.go
+++ b/internal/ui/revisions/revisions.go
@@ -2,6 +2,7 @@ package revisions
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"log"
 	"reflect"
@@ -682,14 +683,15 @@ func (m *Model) loadStreaming(revset string, selectedRevision string, tag uint64
 		return nil
 	}
 
-	streamer, err := graph.NewGraphStreamer(m.context, revset, m.context.JJConfig.Templates.Log)
+	var cmds []tea.Cmd
+	streamer, err := graph.NewGraphStreamer(context.Background(), m.context, revset, m.context.JJConfig.Templates.Log)
 	if err != nil {
-		return func() tea.Msg {
+		cmds = append(cmds, func() tea.Msg {
 			return common.UpdateRevisionsFailedMsg{
 				Err:    err,
 				Output: fmt.Sprintf("%v", err),
 			}
-		}
+		})
 	}
 
 	if m.streamer != nil {
@@ -698,8 +700,8 @@ func (m *Model) loadStreaming(revset string, selectedRevision string, tag uint64
 	}
 	m.streamer = streamer
 	m.hasMore = true
-
-	return m.Update(startRowsStreamingMsg{selectedRevision: selectedRevision, tag: tag})
+	cmds = append(cmds, m.Update(startRowsStreamingMsg{selectedRevision: selectedRevision, tag: tag}))
+	return tea.Batch(cmds...)
 }
 
 func (m *Model) requestMoreRows(tag uint64) tea.Cmd {


### PR DESCRIPTION
This PR changes the way streaming commands are handled in the following way:

The previous code dedicated at most 100ms for reading the stderr and then proceeded parsing the stdout. This also meant every refresh takes at least 100ms. This change gets rid of it. Instead, it takes advantage of the fact that `jj` writes to stderr before writing stdout. 

* If we have something in the stdout that means stderr may or may not have data but if it does then it is already fully flushed. 
* If we don't have anything in stdout then we have an error and non-zero exit code.

In either case, we can read the stderr until the end and return the error and streamer together.

At least this is the intent and I think code reflects the approach.

fixes #408 and also makes the refreshes instant. (tried on home-manager repo)