### PR TITLE
revisions: add highlight to QuickSearch, make search case insensitive

### DIFF
--- a/internal/config/default/default_dark.toml
+++ b/internal/config/default/default_dark.toml
@@ -12,7 +12,7 @@ error = "red"
 "confirmation dimmed" = "white"
 "help title" = { fg = "green", bold = true }
 "revisions details selected" = { bg = "bright black" }
-"revisions matched" = { underline = false }
+"revisions matched" = { underline = false, reverse = true }
 "revset title" = "magenta"
 "revset text" = { fg = "green", bold = true }
 "revset completion text" = "white"

--- a/internal/config/default/default_light.toml
+++ b/internal/config/default/default_light.toml
@@ -12,7 +12,7 @@ error = "red"
 "confirmation dimmed" = "white"
 "help title" = { fg = "green", bold = true }
 "revisions details selected" = { bg = "bright black" }
-"revisions matched" = { underline = false }
+"revisions matched" = { underline = false, reverse = true }
 "revset title" = "magenta"
 "revset text" = { fg = "green", bold = true }
 "revset completion text" = "white"

--- a/internal/ui/revisions/item_renderer_test.go
+++ b/internal/ui/revisions/item_renderer_test.go
@@ -82,6 +82,7 @@ func TestRenderMainLines_MultipleDescriptionLines(t *testing.T) {
 		selectedStyle: lipgloss.NewStyle().Background(lipgloss.Color("blue")),
 		textStyle:     lipgloss.NewStyle(),
 		dimmedStyle:   lipgloss.NewStyle(),
+		matchedStyle:  lipgloss.NewStyle(),
 		isGutterInLane: func(lineIndex, segmentIndex int) bool {
 			return true
 		},
@@ -128,6 +129,7 @@ func TestRenderMainLines_WithElidedLine(t *testing.T) {
 		selectedStyle: lipgloss.NewStyle().Background(lipgloss.Color("blue")),
 		textStyle:     lipgloss.NewStyle(),
 		dimmedStyle:   lipgloss.NewStyle(),
+		matchedStyle:  lipgloss.NewStyle(),
 		isGutterInLane: func(lineIndex, segmentIndex int) bool {
 			return true
 		},

--- a/internal/ui/revisions/revisions_quicksearch_test.go
+++ b/internal/ui/revisions/revisions_quicksearch_test.go
@@ -1,0 +1,94 @@
+package revisions
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/idursun/jjui/internal/jj"
+	"github.com/idursun/jjui/internal/parser"
+	"github.com/stretchr/testify/assert"
+)
+
+// mockNonFocusableOperation is a mock operation that is never focused, editing, or overlay
+type mockNonFocusableOperation struct{}
+
+func (m *mockNonFocusableOperation) Render(commit *jj.Commit, renderPosition int) string {
+	return ""
+}
+
+func (m *mockNonFocusableOperation) Name() string {
+	return "mock"
+}
+
+func (m *mockNonFocusableOperation) Init() tea.Cmd {
+	return nil
+}
+
+func (m *mockNonFocusableOperation) Update(msg tea.Msg) tea.Cmd {
+	return nil
+}
+
+func (m *mockNonFocusableOperation) View() string {
+	return ""
+}
+
+func (m *mockNonFocusableOperation) IsFocused() bool {
+	return false
+}
+
+func (m *mockNonFocusableOperation) IsEditing() bool {
+	return false
+}
+
+func (m *mockNonFocusableOperation) IsOverlay() bool {
+	return false
+}
+
+// TestQuickSearch_EnterKeyClearsSearch tests that Enter clears the search
+func TestQuickSearch_EnterKeyClearsSearch(t *testing.T) {
+	model := &Model{
+		quickSearch: "test",
+		renderer:    newRevisionListRenderer(nil, nil),
+		op:          &mockNonFocusableOperation{},
+		rows:        []parser.Row{{Commit: &jj.Commit{ChangeId: "test123"}}},
+	}
+
+	msg := tea.KeyMsg{Type: tea.KeyEnter}
+	cmd := model.internalUpdate(msg)
+
+	assert.Equal(t, "", model.quickSearch, "KeyEnter should clear quicksearch")
+	assert.Nil(t, cmd)
+}
+
+// TestQuickSearch_EscapeKeyClearsSearch tests that Escape clears the search
+func TestQuickSearch_EscapeKeyClearsSearch(t *testing.T) {
+	model := &Model{
+		quickSearch: "test",
+		renderer:    newRevisionListRenderer(nil, nil),
+		op:          &mockNonFocusableOperation{},
+		rows:        []parser.Row{{Commit: &jj.Commit{ChangeId: "test123"}}},
+	}
+
+	msg := tea.KeyMsg{Type: tea.KeyEsc}
+	cmd := model.internalUpdate(msg)
+
+	assert.Equal(t, "", model.quickSearch, "KeyEsc should clear quicksearch")
+	assert.Nil(t, cmd)
+}
+
+// TestQuickSearch_EnterWithEmptySearch tests that Enter with empty search does nothing special
+func TestQuickSearch_EnterWithEmptySearch(t *testing.T) {
+	model := &Model{
+		quickSearch: "",
+		renderer:    newRevisionListRenderer(nil, nil),
+		rows:        []parser.Row{{Commit: &jj.Commit{ChangeId: "test123"}}},
+		op:          &mockNonFocusableOperation{},
+	}
+
+	msg := tea.KeyMsg{Type: tea.KeyEnter}
+	_ = model.internalUpdate(msg)
+
+	// When quickSearch is empty, Enter should not be handled by the quicksearch logic
+	// The cmd might be nil or something else depending on other handlers
+	assert.Equal(t, "", model.quickSearch)
+}


### PR DESCRIPTION
## changes
revisions: add highlight to QuickSearch, make search case insensitive
- Added "quicksearch matched" style to dark/light themes 
- Added highlight to all case-insensitive matches of the search term
- Pressing enter/esc clears quicksearch and return to normal view

## others
This is a neat little feature that i have been using in my local build, as brought up in #394. 
did some polish on the code and opening this PR for visibility, would like to see if anyone else would enjoy this feature

## screenshot
<img width="400" height="235" alt="image" src="https://github.com/user-attachments/assets/d1470d99-342d-4c9b-a49e-4e28cf7461ef" />
