### PR TITLE
revisions: clear selected revisions on cancel

### DIFF
--- a/internal/ui/revisions/revisions.go
+++ b/internal/ui/revisions/revisions.go
@@ -443,7 +443,10 @@ func (m *Model) internalUpdate(msg tea.Msg) tea.Cmd {
 				m.context.ToggleCheckedItem(item)
 				m.jumpToParent(jj.NewSelectedRevisions(commit))
 			case key.Matches(msg, m.keymap.Cancel):
+				m.context.ClearCheckedItems(reflect.TypeFor[appContext.SelectedRevision]())
 				m.op = operations.NewDefault()
+				m.renderer.Reset()
+				return nil
 			case key.Matches(msg, m.keymap.QuickSearchCycle):
 				m.SetCursor(m.search(m.cursor + 1))
 				m.renderer.Reset()


### PR DESCRIPTION
## background

i sometimes select multiple revisions, wanting to have some operations, but realize i'd wanna do something else. i usually use `ctrl+r` to refresh the UI so revision selections are cleared out, but this also resets cursor. would be great to have a way to clear selections without reseting cursor.

this change is quite small, and doesn't seem to affect other operations (please point out if there's any other potential operation being disrupted!)

## changes
revisions: clear selected revisions on cancel

NOTE:
it doesn't interfere with `details` view. When there're details shown, and `esc` cancels out of detail view, selected revisions will not be cleared

it only runs when:
- Not in an editing operation 
- Not in an overlay operation 
- Not in a focused operation