### PR TITLE
feat: custom commands with sequence keys

### DIFF
--- a/internal/ui/context/custom_command_test.go
+++ b/internal/ui/context/custom_command_test.go
@@ -14,10 +14,11 @@ func TestLoad_CustomCommands(t *testing.T) {
 "restore evolog" = { key = ["ctrl+e"],  args = ["op", "restore", "-r", "$revision"] }
 "resolve vscode" = { key = ["ctrl+r"],  args = ["resolve", "--tool", "vscode"], show = "interactive" }
 "update revset" = { key = ["M"],  revset = "::$change_id" }
+"sequence command" = { key_sequence = ["g", "s"], args = ["status"], desc = "status for change" }
 `
 	registry, err := LoadCustomCommands(content)
 	assert.NoError(t, err)
-	assert.Len(t, registry, 4)
+	assert.Len(t, registry, 5)
 
 	testCases := []struct {
 		name        string
@@ -69,6 +70,23 @@ func TestLoad_CustomCommands(t *testing.T) {
 				assert.Equal(t, []string{"M"}, revsetCmd.Key)
 				assert.Equal(t, "::$change_id", revsetCmd.Revset)
 				assert.Equal(t, "update revset", revsetCmd.Name)
+			},
+		},
+		{
+			name:        "sequence command",
+			commandName: "sequence command",
+			testFunc: func(t *testing.T, cmd CustomCommand) {
+				runCmd, ok := cmd.(CustomRunCommand)
+				assert.True(t, ok, "Command should be CustomRunCommand")
+				assert.Equal(t, []string{"g", "s"}, runCmd.KeySequence)
+				assert.Equal(t, []string{"status"}, runCmd.Args)
+				assert.Equal(t, "sequence command", runCmd.Name)
+				assert.Equal(t, "status for change", runCmd.Desc)
+				labeled, ok := any(runCmd).(LabeledCommand)
+				assert.True(t, ok)
+				assert.Equal(t, "status for change", labeled.Label())
+				seq := runCmd.Sequence()
+				assert.Len(t, seq, 2)
 			},
 		},
 	}

--- a/internal/ui/custom_commands/sequence_overlay.go
+++ b/internal/ui/custom_commands/sequence_overlay.go
@@ -1,0 +1,274 @@
+package customcommands
+
+import (
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/bubbles/key"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/cellbuf"
+	"github.com/idursun/jjui/internal/ui/common"
+	"github.com/idursun/jjui/internal/ui/context"
+)
+
+type SequenceEntry struct {
+	Name      string
+	Remaining []string
+}
+
+type SequenceCandidate struct {
+	Command context.CustomCommand
+	Seq     []key.Binding
+	Index   int
+}
+
+type SequenceTimeoutMsg struct {
+	Started time.Time
+}
+
+// SequenceResult captures the outcome of a key/timeout handled by the overlay.
+type SequenceResult struct {
+	Cmd     tea.Cmd
+	Handled bool
+	Active  bool
+}
+
+// SequenceOverlay renders a lightweight hint panel for in-flight key sequences.
+type SequenceOverlay struct {
+	*common.ViewNode
+	ctx           *context.MainContext
+	prefix        string
+	items         []SequenceEntry
+	shortcutStyle lipgloss.Style
+	matchedStyle  lipgloss.Style
+	textStyle     lipgloss.Style
+	candidates    []SequenceCandidate
+	started       time.Time
+	typed         []string
+}
+
+const sequenceTimeout = 4 * time.Second
+
+func NewSequenceOverlay(ctx *context.MainContext) *SequenceOverlay {
+	return &SequenceOverlay{
+		ViewNode:      common.NewViewNode(0, 0),
+		ctx:           ctx,
+		shortcutStyle: common.DefaultPalette.Get("shortcut"),
+		matchedStyle:  common.DefaultPalette.Get("matched"),
+		textStyle:     common.DefaultPalette.Get("text"),
+	}
+}
+
+func (s *SequenceOverlay) Init() tea.Cmd {
+	return nil
+}
+
+func (s *SequenceOverlay) Update(msg tea.Msg) tea.Cmd {
+	if msg, ok := msg.(SequenceTimeoutMsg); ok {
+		res := s.handleTimeout(msg)
+		return res.Cmd
+	}
+	return nil
+}
+
+func BindingKeyString(b key.Binding) string {
+	if len(b.Keys()) > 0 {
+		return b.Keys()[0]
+	}
+	if h := b.Help(); h.Key != "" {
+		return h.Key
+	}
+	return ""
+}
+
+func (s *SequenceOverlay) Set(prefix []string, entries []SequenceEntry) {
+	s.prefix = strings.Join(prefix, " ")
+	s.items = entries
+}
+
+func (s *SequenceOverlay) Active() bool {
+	return len(s.candidates) > 0
+}
+
+func (s *SequenceOverlay) SetFromCandidates(typed []string, candidates []SequenceCandidate) {
+	entries := make([]SequenceEntry, 0, len(candidates))
+	for _, cand := range candidates {
+		var remaining []string
+		for _, b := range cand.Seq[cand.Index:] {
+			remaining = append(remaining, BindingKeyString(b))
+		}
+		label := cand.Command.Description(s.ctx)
+		if lc, ok := cand.Command.(context.LabeledCommand); ok {
+			label = lc.Label()
+		}
+		entries = append(entries, SequenceEntry{
+			Name:      label,
+			Remaining: remaining,
+		})
+	}
+
+	// Ensure deterministic order for display
+	sort.Slice(entries, func(i, j int) bool { return entries[i].Name < entries[j].Name })
+
+	s.Set(typed, entries)
+}
+
+func (s *SequenceOverlay) HandleKey(msg tea.KeyMsg) SequenceResult {
+	now := time.Now()
+	s.expire(now)
+
+	if len(s.candidates) > 0 {
+		next, res := s.advance(msg)
+		if res.Cmd != nil || !res.Active {
+			return res
+		}
+		if len(next) > 0 {
+			s.candidates = next
+			s.started = now
+			s.typed = append(s.typed, BindingKeyString(next[0].Seq[next[0].Index-1]))
+			s.SetFromCandidates(s.typed, s.candidates)
+			return SequenceResult{
+				Cmd:     s.scheduleTimeout(now),
+				Handled: true,
+				Active:  true,
+			}
+		}
+		// No continuation matched; reset and let other handlers process.
+		s.reset()
+		return SequenceResult{Handled: false, Active: false}
+	}
+
+	return s.maybeStart(msg, now)
+}
+
+func (s *SequenceOverlay) HandleTimeout(msg SequenceTimeoutMsg) SequenceResult {
+	return s.handleTimeout(msg)
+}
+
+func (s *SequenceOverlay) View() string {
+	var view strings.Builder
+	for i, it := range s.items {
+		view.WriteString(s.matchedStyle.Render(s.prefix))
+		if len(it.Remaining) == 0 {
+			continue
+		}
+		for _, r := range it.Remaining {
+			view.WriteString(" → ")
+			view.WriteString(s.shortcutStyle.Render(r))
+		}
+		view.WriteString(" ")
+		view.WriteString(it.Name)
+		if i < len(s.items)-1 {
+			view.WriteString("\n")
+		}
+	}
+	w := s.Parent.Frame.Dx()
+
+	content := view.String()
+	style := lipgloss.NewStyle().
+		PaddingLeft(1).
+		PaddingRight(1).
+		Border(lipgloss.RoundedBorder()).
+		Width(w - 2)
+	content = style.Render(content)
+
+	h := lipgloss.Height(content)
+	sy := s.Parent.Frame.Dy() - h - 1
+
+	s.SetFrame(cellbuf.Rect(0, sy, w, h))
+	return content
+}
+
+func (s *SequenceOverlay) advance(msg tea.KeyMsg) ([]SequenceCandidate, SequenceResult) {
+	matched := false
+	var next []SequenceCandidate
+	for _, cand := range s.candidates {
+		if !cand.Command.IsApplicableTo(s.ctx.SelectedItem) {
+			continue
+		}
+		if key.Matches(msg, cand.Seq[cand.Index]) {
+			matched = true
+			if cand.Index+1 == len(cand.Seq) {
+				cmd := cand.Command.Prepare(s.ctx)
+				s.reset()
+				return nil, SequenceResult{Cmd: cmd, Handled: true, Active: false}
+			}
+			cand.Index++
+			next = append(next, cand)
+		}
+	}
+	if matched {
+		return next, SequenceResult{Handled: true, Active: s.Active()}
+	}
+	return nil, SequenceResult{Handled: false, Active: s.Active()}
+}
+
+func (s *SequenceOverlay) maybeStart(msg tea.KeyMsg, now time.Time) SequenceResult {
+	var starters []SequenceCandidate
+	for _, command := range SortedCustomCommands(s.ctx) {
+		seq := command.Sequence()
+		if len(seq) == 0 || !command.IsApplicableTo(s.ctx.SelectedItem) {
+			continue
+		}
+		if key.Matches(msg, seq[0]) {
+			if len(seq) == 1 {
+				return SequenceResult{Cmd: command.Prepare(s.ctx), Handled: true, Active: false}
+			}
+			starters = append(starters, SequenceCandidate{
+				Command: command,
+				Seq:     seq,
+				Index:   1,
+			})
+		}
+	}
+
+	if len(starters) == 0 {
+		return SequenceResult{Handled: false, Active: false}
+	}
+
+	s.candidates = starters
+	s.started = now
+	s.typed = []string{BindingKeyString(starters[0].Seq[0])}
+	s.SetFromCandidates(s.typed, s.candidates)
+
+	return SequenceResult{
+		Cmd:     s.scheduleTimeout(now),
+		Handled: true,
+		Active:  true,
+	}
+}
+
+func (s *SequenceOverlay) scheduleTimeout(start time.Time) tea.Cmd {
+	if start.IsZero() {
+		return nil
+	}
+	return tea.Tick(sequenceTimeout, func(time.Time) tea.Msg {
+		return SequenceTimeoutMsg{Started: start}
+	})
+}
+
+func (s *SequenceOverlay) handleTimeout(msg SequenceTimeoutMsg) SequenceResult {
+	if s.started.IsZero() || !msg.Started.Equal(s.started) {
+		return SequenceResult{Handled: false, Active: s.Active()}
+	}
+	s.reset()
+	return SequenceResult{Handled: true, Active: false}
+}
+
+func (s *SequenceOverlay) expire(now time.Time) {
+	if len(s.candidates) == 0 || s.started.IsZero() {
+		return
+	}
+	if now.Sub(s.started) > sequenceTimeout {
+		s.reset()
+	}
+}
+
+func (s *SequenceOverlay) reset() {
+	s.candidates = nil
+	s.started = time.Time{}
+	s.typed = nil
+	s.Set(nil, nil)
+}

--- a/internal/ui/custom_commands/sequence_overlay_test.go
+++ b/internal/ui/custom_commands/sequence_overlay_test.go
@@ -1,0 +1,121 @@
+package customcommands
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/idursun/jjui/internal/ui/common"
+	"github.com/idursun/jjui/internal/ui/context"
+	"github.com/idursun/jjui/test"
+	"github.com/stretchr/testify/require"
+)
+
+type executedMsg struct{ name string }
+
+type stubCommand struct {
+	context.CustomCommandBase
+	applicable bool
+	prepared   bool
+}
+
+func (s *stubCommand) Description(ctx *context.MainContext) string {
+	return s.Name
+}
+
+func (s *stubCommand) Prepare(ctx *context.MainContext) tea.Cmd {
+	return func() tea.Msg {
+		s.prepared = true
+		return executedMsg{name: s.Name}
+	}
+}
+
+func (s *stubCommand) IsApplicableTo(item context.SelectedItem) bool {
+	return s.applicable
+}
+
+type overlayModel struct {
+	overlay *SequenceOverlay
+	last    SequenceResult
+}
+
+func (m *overlayModel) Update(msg tea.Msg) tea.Cmd {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		res := m.overlay.HandleKey(msg)
+		m.last = res
+		if res.Active {
+			// Avoid running timeout ticks during tests; we only care about overlay state.
+			return nil
+		}
+		return res.Cmd
+	default:
+		cmd := m.overlay.Update(msg)
+		if cmd != nil {
+			m.last = SequenceResult{Cmd: cmd, Handled: true, Active: m.overlay.Active()}
+		}
+		return cmd
+	}
+}
+
+func TestHandleKey_executes_single_key_sequence(t *testing.T) {
+	ctx := test.NewTestContext(test.NewTestCommandRunner(t))
+
+	cmd := &stubCommand{
+		CustomCommandBase: context.CustomCommandBase{
+			Name:        "Run",
+			KeySequence: []string{"x"},
+		},
+		applicable: true,
+	}
+	ctx.CustomCommands["run"] = cmd
+
+	overlay := NewSequenceOverlay(ctx)
+	overlay.ViewNode.Parent = common.NewViewNode(80, 24)
+	model := &overlayModel{overlay: overlay}
+
+	var msgs []tea.Msg
+	test.SimulateModel(model, test.Type("x"), func(msg tea.Msg) {
+		msgs = append(msgs, msg)
+	})
+
+	require.True(t, cmd.prepared, "expected command Prepare to run for matching key")
+	require.True(t, model.last.Handled, "expected key to be handled")
+	require.False(t, model.last.Active, "single key sequences should not leave overlay active")
+
+	var executed bool
+	for _, msg := range msgs {
+		if got, ok := msg.(executedMsg); ok && got.name == "Run" {
+			executed = true
+			break
+		}
+	}
+	require.True(t, executed, "expected prepared command to emit executedMsg")
+}
+
+func TestHandleKey_executes_multi_key_sequence(t *testing.T) {
+	ctx := test.NewTestContext(test.NewTestCommandRunner(t))
+	cmd := &stubCommand{
+		CustomCommandBase: context.CustomCommandBase{
+			Name:        "GoRun",
+			KeySequence: []string{"g", "o"},
+		},
+		applicable: true,
+	}
+	ctx.CustomCommands["go-run"] = cmd
+
+	overlay := NewSequenceOverlay(ctx)
+	overlay.ViewNode.Parent = common.NewViewNode(80, 24)
+	model := &overlayModel{overlay: overlay}
+
+	executed := false
+	test.SimulateModel(model, test.Type("go"), func(msg tea.Msg) {
+		if got, ok := msg.(executedMsg); ok && got.name == "GoRun" {
+			executed = true
+		}
+	})
+
+	require.True(t, executed, "expected prepared command to emit executedMsg")
+	require.True(t, cmd.prepared, "expected command Prepare to run after full sequence")
+	require.True(t, model.last.Handled, "expected second key to be handled")
+	require.False(t, model.last.Active, "overlay should deactivate after sequence completes")
+}

--- a/test/test_command_runner.go
+++ b/test/test_command_runner.go
@@ -123,8 +123,9 @@ func NewTestCommandRunner(t *testing.T) *CommandRunner {
 
 func NewTestContext(commandRunner appContext.CommandRunner) *appContext.MainContext {
 	return &appContext.MainContext{
-		CommandRunner: commandRunner,
-		JJConfig:      &config.JJConfig{},
-		SelectedItem:  nil,
+		CommandRunner:  commandRunner,
+		JJConfig:       &config.JJConfig{},
+		SelectedItem:   nil,
+		CustomCommands: make(map[string]appContext.CustomCommand),
 	}
 }


### PR DESCRIPTION
This PR adds `key_sequence` property to the custom commands so that they can be invoked by pressing multiple keys in sequence. It also adds a `desc` property which will come in handy later on.

```toml
[custom_commands.bookmark_list]
  key_sequence = ["w", "b", "l"]
  desc = "bookmarks list"
  lua = '''
  revset.set("bookmarks() | remote_bookmarks()")
  '''
```

Additionally, adds a sequence overlay which shows up when the user has pressed one of the first keys of a custom command that has `key_sequence` defined.

<img width="1565" height="238" alt="image" src="https://github.com/user-attachments/assets/edfd8f78-223c-4ed7-a140-b1bef10a2607" />
