### PR TITLE
main: pass through jj error

### DIFF
--- a/cmd/jjui/main.go
+++ b/cmd/jjui/main.go
@@ -64,10 +64,14 @@ func init() {
 }
 
 func getJJRootDir(location string) (string, error) {
-	cmd := exec.Command("jj", "root")
+	cmd := exec.Command("jj", "root", "--color=always")
 	cmd.Dir = location
+
 	output, err := cmd.Output()
 	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			return "", fmt.Errorf("%s", strings.TrimSpace(string(exitErr.Stderr)))
+		}
 		return "", err
 	}
 	return strings.TrimSpace(string(output)), nil
@@ -103,7 +107,7 @@ func main() {
 
 	rootLocation, err := getJJRootDir(location)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error: There is no jj repo in \"%s\".\n", location)
+		fmt.Fprintf(os.Stderr, "%s\n", err)
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
jjui doesn't pass through the stderr returned by jj, and errors are printed out as `Error: There is no jj repo in $DIR`
this change allows jj stderr to be caught and printed to user


## before
<img width="1683" height="378" alt="image" src="https://github.com/user-attachments/assets/50c1c204-2065-447f-a822-441fbff75f0a" />

## after
<img width="1670" height="570" alt="image" src="https://github.com/user-attachments/assets/1fc40602-a27a-421d-8002-23e2bb17fd5b" />
