### PR TITLE
feat(lua): add ability to await on operation results (cancelled/applied)

### DIFF
--- a/internal/ui/common/msgs.go
+++ b/internal/ui/common/msgs.go
@@ -8,7 +8,9 @@ import (
 )
 
 type (
-	CloseViewMsg   struct{}
+	CloseViewMsg struct {
+		Applied bool
+	}
 	ToggleHelpMsg  struct{}
 	AutoRefreshMsg struct{}
 	RefreshMsg     struct {
@@ -69,6 +71,10 @@ const (
 
 func Close() tea.Msg {
 	return CloseViewMsg{}
+}
+
+func CloseApplied() tea.Msg {
+	return CloseViewMsg{Applied: true}
 }
 
 func SelectionChanged() tea.Msg {

--- a/internal/ui/operations/describe/describe.go
+++ b/internal/ui/operations/describe/describe.go
@@ -90,11 +90,11 @@ func (o *Operation) Update(msg tea.Msg) tea.Cmd {
 			selectedRevisions := jj.NewSelectedRevisions(o.revision)
 			return o.context.RunCommand(
 				jj.SetDescription(o.revision.GetChangeId(), o.input.Value()),
-				common.Close,
+				common.CloseApplied,
 				o.context.RunInteractiveCommand(jj.Describe(selectedRevisions), common.Refresh),
 			)
 		case key.Matches(msg, o.keyMap.InlineDescribe.Accept):
-			return o.context.RunCommand(jj.SetDescription(o.revision.GetChangeId(), o.input.Value()), common.Close, common.Refresh)
+			return o.context.RunCommand(jj.SetDescription(o.revision.GetChangeId(), o.input.Value()), common.CloseApplied, common.Refresh)
 		}
 	}
 


### PR DESCRIPTION
This PR updates the lua bridge to know if an operation has been applied or cancelled. This will allow #310 to be implemented like the following:

```toml
[custom_commands."inline commit"]
  key_sequence = ["w", "x"]
  lua = '''
  if revisions.start_inline_describe() then
    jj("new")
  end
  '''
```

A new revision is created only if the user pressed apply (i.e. `alt+enter`)

I’ll gradually apply the same approach to the remaining operations. 

fixes #310 