### PR TITLE
feat(lua): add choose method and ui

### DIFF
--- a/internal/ui/choose/choose.go
+++ b/internal/ui/choose/choose.go
@@ -1,0 +1,157 @@
+package choose
+
+import (
+	"github.com/charmbracelet/bubbles/help"
+	"github.com/charmbracelet/bubbles/key"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/cellbuf"
+	"github.com/idursun/jjui/internal/config"
+	"github.com/idursun/jjui/internal/ui/common"
+)
+
+type SelectedMsg struct {
+	Value string
+}
+
+type CancelledMsg struct{}
+
+var (
+	_ common.Model     = (*Model)(nil)
+	_ common.IViewNode = (*Model)(nil)
+	_ help.KeyMap      = (*Model)(nil)
+)
+
+type Model struct {
+	*common.ViewNode
+	options  []string
+	selected int
+	title    string
+	keymap   config.KeyMappings[key.Binding]
+	styles   styles
+}
+
+type styles struct {
+	border lipgloss.Style
+	text   lipgloss.Style
+	title  lipgloss.Style
+}
+
+func New(options []string) *Model {
+	return NewWithTitle(options, "")
+}
+
+func NewWithTitle(options []string, title string) *Model {
+	keymap := config.Current.GetKeyMap()
+	return &Model{
+		ViewNode: common.NewViewNode(0, 0),
+		options:  options,
+		title:    title,
+		keymap:   keymap,
+		styles: styles{
+			border: common.DefaultPalette.GetBorder("choose border", lipgloss.RoundedBorder()),
+			text:   common.DefaultPalette.Get("choose text"),
+			title:  common.DefaultPalette.Get("choose title"),
+		},
+	}
+}
+
+func (m *Model) Init() tea.Cmd {
+	return nil
+}
+
+func (m *Model) Update(msg tea.Msg) tea.Cmd {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch {
+		case key.Matches(msg, m.keymap.Up):
+			m.move(-1)
+		case key.Matches(msg, m.keymap.Down):
+			m.move(1)
+		case key.Matches(msg, m.keymap.Apply):
+			return m.selectCurrent()
+		case key.Matches(msg, m.keymap.Cancel):
+			return newCmd(CancelledMsg{})
+		}
+	case common.CloseViewMsg:
+		return newCmd(CancelledMsg{})
+	}
+	return nil
+}
+
+func (m *Model) move(delta int) {
+	if len(m.options) == 0 {
+		return
+	}
+	next := m.selected + delta
+	n := len(m.options)
+	if next < 0 {
+		next = 0
+	}
+	if next >= n {
+		next = n - 1
+	}
+	m.selected = next
+}
+
+func (m *Model) selectCurrent() tea.Cmd {
+	if len(m.options) == 0 {
+		return newCmd(CancelledMsg{})
+	}
+	value := m.options[m.selected]
+	return newCmd(SelectedMsg{Value: value})
+}
+
+func (m *Model) View() string {
+	var rows []string
+	if m.title != "" {
+		rows = append(rows, m.styles.title.Render(m.title))
+	}
+	for i, opt := range m.options {
+		style := m.styles.text
+		prefix := "  "
+		if i == m.selected {
+			prefix = "> "
+		}
+		rows = append(rows, style.Render(prefix+opt))
+	}
+	content := lipgloss.JoinVertical(0, rows...)
+	content = m.styles.border.Padding(0, 1).Render(content)
+	w, h := lipgloss.Size(content)
+
+	if m.Parent != nil {
+		pw, ph := m.Parent.Width, m.Parent.Height
+		sx := max((pw-w)/2, 0)
+		sy := max((ph-h)/2, 0)
+		m.SetFrame(cellbuf.Rect(sx, sy, w, h))
+	}
+
+	return content
+}
+
+func (m *Model) ShortHelp() []key.Binding {
+	return []key.Binding{
+		m.keymap.Up,
+		m.keymap.Down,
+		m.keymap.Apply,
+		m.keymap.Cancel,
+	}
+}
+
+func (m *Model) FullHelp() [][]key.Binding {
+	return [][]key.Binding{m.ShortHelp()}
+}
+
+func newCmd(msg tea.Msg) tea.Cmd {
+	return func() tea.Msg { return msg }
+}
+
+func ShowWithTitle(options []string, title string) tea.Cmd {
+	return func() tea.Msg {
+		return common.ShowChooseMsg{Options: options, Title: title}
+	}
+}
+
+func Show(options []string) tea.Cmd {
+	return ShowWithTitle(options, "")
+}

--- a/internal/ui/choose/choose_test.go
+++ b/internal/ui/choose/choose_test.go
@@ -1,0 +1,31 @@
+package choose
+
+import (
+	"testing"
+
+	"github.com/idursun/jjui/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewWithTitle(t *testing.T) {
+	options := []string{"Option 1", "Option 2", "Option 3"}
+	title := "Choose an option"
+	model := NewWithTitle(options, title)
+
+	assert.NotEmpty(t, model.title)
+}
+
+func TestModel_View(t *testing.T) {
+	options := []string{"Option 1", "Option 2", "Option 3"}
+	title := "Choose an option"
+	model := NewWithTitle(options, title)
+	test.SimulateModel(model, model.Init())
+	output := model.View()
+	require.NotEmpty(t, output)
+
+	assert.Contains(t, output, title)
+	for _, option := range options {
+		assert.Contains(t, output, option)
+	}
+}

--- a/internal/ui/common/msgs.go
+++ b/internal/ui/common/msgs.go
@@ -39,6 +39,10 @@ type (
 		Line string
 		Mode ExecMode
 	}
+	ShowChooseMsg struct {
+		Options []string
+		Title   string
+	}
 	ExecProcessCompletedMsg struct {
 		Err error
 		Msg ExecMsg

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -19,6 +19,7 @@ import (
 	"github.com/idursun/jjui/internal/config"
 	"github.com/idursun/jjui/internal/jj"
 	"github.com/idursun/jjui/internal/ui/bookmarks"
+	"github.com/idursun/jjui/internal/ui/choose"
 	"github.com/idursun/jjui/internal/ui/common"
 	"github.com/idursun/jjui/internal/ui/context"
 	customcommands "github.com/idursun/jjui/internal/ui/custom_commands"
@@ -360,6 +361,13 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 			m.scriptRunner = nil
 		}
 		return cmd
+	case common.ShowChooseMsg:
+		model := choose.NewWithTitle(msg.Options, msg.Title)
+		model.Parent = m.ViewNode
+		m.stacked = model
+		return m.stacked.Init()
+	case choose.SelectedMsg, choose.CancelledMsg:
+		m.stacked = nil
 	case common.ShowPreview:
 		m.previewModel.SetVisible(bool(msg))
 		cmds = append(cmds, common.SelectionChanged)


### PR DESCRIPTION
Added a Bubble Tea-based chooser overlay with optional title styling, and extended the Lua API with `choose`/`split_lines` so scripts can prompt for selections (positional options or table with options/title) and split text into lines.

The UI is barebones at the moment but gets the job done.

New Lua functions are:

  - choose(...options) → string|nil
  - choose({ options = { ... }, title = "Your title" }) → string|nil
  - split_lines(text: string, keep_empty?: boolean) → {strings}

```toml
[custom_commands."choose bookmark"]
  key_sequence = ["w", "i"]
  lua = '''
  local output, err = jj("bookmark", "list",  "-T", "name ++ '\n'")
  choice = choose({options = split_lines(output), title="choose a bookmark"})
  if choice then 
    flash("choice: " .. choice)
  else
    flash("none selected")
  end
  '''
```

<img width="527" height="507" alt="image" src="https://github.com/user-attachments/assets/4c8a32b8-39ab-4363-b93a-8dbfc8376142" />
