### PR TITLE
oplog,list: refactor scrolling with Scrollable/StreamableList interface

### DIFF
--- a/internal/scripting/lua.go
+++ b/internal/scripting/lua.go
@@ -171,7 +171,7 @@ func registerAPI(L *lua.LState, runner *Runner) {
 		target := parseNavigateTarget(stringVal(payload, "target"))
 		intent := intents.Navigate{
 			Delta:      intVal(payload, "by"),
-			Page:       boolVal(payload, "page"),
+			IsPage:     boolVal(payload, "page"),
 			Target:     target,
 			ChangeID:   stringVal(payload, "to"),
 			FallbackID: stringVal(payload, "fallback"),

--- a/internal/ui/common/list/list.go
+++ b/internal/ui/common/list/list.go
@@ -1,6 +1,10 @@
 package list
 
-import "io"
+import (
+	"io"
+
+	"github.com/idursun/jjui/internal/ui/common"
+)
 
 type IList interface {
 	Len() int
@@ -15,4 +19,101 @@ type IListCursor interface {
 type IItemRenderer interface {
 	Render(w io.Writer, width int)
 	Height() int
+}
+
+// IScrollableList defines the interface for list models that support scrolling navigation.
+type IScrollableList interface {
+	IList
+	IListCursor
+
+	// VisibleRange returns the first and last visible row indices,
+	// used to calculate page-based scrolling distances.
+	VisibleRange() (firstRowIndex, lastRowIndex int)
+
+	// ListName returns a name for the list, used in boundary
+	// messages like "Already at the top of {ListName}".
+	ListName() string
+}
+
+// IStreamableList is list interface that can dynamically load more data
+// If HasMore() returns true, the scroll function will request more items when
+// scrolling past the current end of the list.
+type IStreamableList interface {
+	HasMore() bool
+}
+
+type ScrollResult struct {
+	NewCursor        int
+	EnsureCursorView bool
+	NavigateMessage  *common.CommandCompletedMsg
+	RequestMore      bool
+}
+
+// Scroll calculates the new cursor position for list navigation.
+// It returns a ScrollResult containing the new cursor position and any messages.
+// The caller is responsible for updating the cursor using the returned NewCursor value.
+func Scroll(nav IScrollableList, delta int, isPage bool) ScrollResult {
+	currentCursor := nav.Cursor()
+	totalItems := nav.Len()
+	firstRowIndex, lastRowIndex := nav.VisibleRange()
+	contextName := nav.ListName()
+
+	result := ScrollResult{
+		NewCursor:        currentCursor,
+		EnsureCursorView: true,
+	}
+
+	if totalItems == 0 {
+		return result
+	}
+
+	// Check if more items are available
+	streamable, isStreamable := nav.(IStreamableList)
+	hasMore := isStreamable && streamable.HasMore()
+
+	step := delta
+	if isPage {
+		span := max(lastRowIndex-firstRowIndex-1, 1)
+		if step < 0 {
+			step = -span
+		} else {
+			step = span
+		}
+	}
+
+	if step > 0 {
+		// Moving down
+		if currentCursor == totalItems-1 && !hasMore {
+			result.NavigateMessage = &common.CommandCompletedMsg{
+				Output: "Already at the bottom of " + contextName,
+				Err:    nil,
+			}
+			return result
+		}
+		if currentCursor+step < totalItems {
+			result.NewCursor = currentCursor + step
+		} else if isStreamable && hasMore {
+			// Request more data only if the list implements streaming AND there's more data
+			result.RequestMore = true
+			result.NewCursor = currentCursor
+		} else if totalItems > 0 {
+			// no further scroll: clamp to the last item
+			result.NewCursor = totalItems - 1
+		}
+	} else {
+		// Moving up
+		if currentCursor == 0 {
+			result.NavigateMessage = &common.CommandCompletedMsg{
+				Output: "Already at the top of " + contextName,
+				Err:    nil,
+			}
+			return result
+		}
+		amount := -step
+		if currentCursor > 0 {
+			result.NewCursor = max(currentCursor-amount, 0)
+		}
+	}
+
+	return result
 }

--- a/internal/ui/common/list/list_test.go
+++ b/internal/ui/common/list/list_test.go
@@ -1,0 +1,178 @@
+package list
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// mockScrollableList is a mock implementation of IScrollableList for testing
+type mockScrollableList struct {
+	items         []string
+	cursor        int
+	firstRowIndex int
+	lastRowIndex  int
+	listName      string
+}
+
+func (m *mockScrollableList) Len() int {
+	return len(m.items)
+}
+
+func (m *mockScrollableList) Cursor() int {
+	return m.cursor
+}
+
+func (m *mockScrollableList) SetCursor(index int) {
+	m.cursor = index
+}
+
+func (m *mockScrollableList) VisibleRange() (int, int) {
+	return m.firstRowIndex, m.lastRowIndex
+}
+
+func (m *mockScrollableList) ListName() string {
+	return m.listName
+}
+
+func (m *mockScrollableList) GetItemRenderer(index int) IItemRenderer {
+	return nil
+}
+
+// mockStreamableList extends mockScrollableList to implement IStreamableList
+type mockStreamableList struct {
+	mockScrollableList
+	hasMore bool
+}
+
+func (m *mockStreamableList) HasMore() bool {
+	return m.hasMore
+}
+
+func TestScroll_EmptyList(t *testing.T) {
+	mock := &mockScrollableList{
+		items:         []string{},
+		cursor:        0,
+		firstRowIndex: 0,
+		lastRowIndex:  10,
+		listName:      "test list",
+	}
+
+	result := Scroll(mock, 1, false)
+
+	assert.Equal(t, 0, result.NewCursor)
+	assert.Nil(t, result.NavigateMessage)
+	assert.False(t, result.RequestMore)
+}
+
+func TestScroll_SingleItemList(t *testing.T) {
+	tests := []struct {
+		name       string
+		delta      int
+		wantCursor int
+		wantMsg    string
+	}{
+		{
+			name:       "scroll down on single item",
+			delta:      1,
+			wantCursor: 0,
+			wantMsg:    "Already at the bottom of test list",
+		},
+		{
+			name:       "scroll up on single item",
+			delta:      -1,
+			wantCursor: 0,
+			wantMsg:    "Already at the top of test list",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := &mockScrollableList{
+				items:         []string{"item1"},
+				cursor:        0,
+				firstRowIndex: 0,
+				lastRowIndex:  10,
+				listName:      "test list",
+			}
+
+			result := Scroll(mock, tt.delta, false)
+
+			assert.Equal(t, tt.wantCursor, result.NewCursor)
+			assert.NotNil(t, result.NavigateMessage)
+			assert.Equal(t, tt.wantMsg, result.NavigateMessage.Output)
+		})
+	}
+}
+
+func TestScroll_BoundaryMessages(t *testing.T) {
+	tests := []struct {
+		name        string
+		startCursor int
+		delta       int
+		listName    string
+		wantMsg     string
+	}{
+		{
+			name:        "top boundary",
+			startCursor: 0,
+			delta:       -1,
+			listName:    "revset `main`",
+			wantMsg:     "Already at the top of revset `main`",
+		},
+		{
+			name:        "bottom boundary",
+			startCursor: 9,
+			delta:       1,
+			listName:    "revset `@`",
+			wantMsg:     "Already at the bottom of revset `@`",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			items := make([]string, 10)
+			mock := &mockScrollableList{
+				items:         items,
+				cursor:        tt.startCursor,
+				firstRowIndex: 0,
+				lastRowIndex:  10,
+				listName:      tt.listName,
+			}
+
+			result := Scroll(mock, tt.delta, false)
+
+			assert.NotNil(t, result.NavigateMessage)
+			assert.Equal(t, tt.wantMsg, result.NavigateMessage.Output)
+			assert.Nil(t, result.NavigateMessage.Err)
+		})
+	}
+}
+
+func TestScroll_EnsureCursorViewAlwaysTrue(t *testing.T) {
+	mock := &mockScrollableList{
+		items:         []string{"item1", "item2", "item3"},
+		cursor:        1,
+		firstRowIndex: 0,
+		lastRowIndex:  10,
+		listName:      "test list",
+	}
+
+	tests := []struct {
+		name   string
+		delta  int
+		isPage bool
+	}{
+		{"scroll down", 1, false},
+		{"scroll up", -1, false},
+		{"page down", 1, true},
+		{"page up", -1, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := Scroll(mock, tt.delta, tt.isPage)
+			assert.True(t, result.EnsureCursorView)
+		})
+	}
+}

--- a/internal/ui/intents/revisions_intents.go
+++ b/internal/ui/intents/revisions_intents.go
@@ -75,7 +75,7 @@ const (
 
 type Navigate struct {
 	Delta       int              // +N down, -N up
-	Page        bool             // use page-sized step when true
+	IsPage      bool             // use page-sized step when true
 	Target      NavigationTarget // logical destination (parent/child/working)
 	ChangeID    string           // explicit change/commit id to select
 	FallbackID  string           // optional fallback change/commit id


### PR DESCRIPTION
### oplog,list: refactor scrolling with Scrollable/StreamableList interface
Refactored revisions/operation_log scrolling to have an IScrollableList
interface, with `scroll` method for navigation, which handles:
- Boundary detection (top/bottom of list)
- Page vs. single-step navigation
- Streaming/infinite scroll support
- User feedback messages (reaching top/bottom of list)

Also added a IStreamableList to handle streaming data that needs to by
loaded dynamically