### PR TITLE
flash: add maxWidth to flash msg rendering

### DIFF
--- a/internal/ui/flash/flash.go
+++ b/internal/ui/flash/flash.go
@@ -98,13 +98,32 @@ func (m *Model) View() []FlashMessageView {
 
 	y := m.Height - 1
 	var messageBoxes []FlashMessageView
+	// reserve padding and calculate max width for messages
+	maxWidth := m.Width - 4
+
 	for _, message := range messages {
-		var content string
+		var text string
+		var style lipgloss.Style
 		if message.error != nil {
-			content = m.errorStyle.Render(message.error.Error())
+			text = message.error.Error()
+			style = m.errorStyle
 		} else {
-			content = m.successStyle.Render(message.text)
+			text = message.text
+			style = m.successStyle
 		}
+
+		// first render without width to check natural size
+		naturalContent := style.Render(text)
+		naturalWidth, _ := lipgloss.Size(naturalContent)
+
+		var content string
+		if naturalWidth <= maxWidth {
+			content = naturalContent
+		} else {
+			// width doesn't fit within maxWidth, set Width for line wrap
+			content = style.Width(maxWidth).Render(text)
+		}
+
 		w, h := lipgloss.Size(content)
 		y -= h
 		messageBoxes = append(messageBoxes, FlashMessageView{


### PR DESCRIPTION
when i was looking at #428, i found out that if content for flash messages is too long, it could actually go beyond current window's width, instead of being line-wrapped

hence, im adding a maxWidth (currently set to 1/2 of screen) to the flash messages with line wrapped


## before
<img width="2032" height="1161" alt="image" src="https://github.com/user-attachments/assets/ce3419ee-dce4-4f2a-ab5d-b91a67134987" />

## after

<img width="2032" height="1161" alt="image" src="https://github.com/user-attachments/assets/a2845a69-ab66-4d4f-99bb-b8f5a020a2db" />
