### PR TITLE
keys: add pageup/down to keys config

### DIFF
--- a/internal/config/default/config.toml
+++ b/internal/config/default/config.toml
@@ -3,6 +3,8 @@ limit = 0
 [keys]
   up = ["up", "k"]
   down = ["down", "j"]
+  scroll_up = ["pgup"]
+  scroll_down = ["pgdown"]
   jump_to_parent = ["J"]
   jump_to_children = ["K"]
   jump_to_working_copy = ["@"]

--- a/internal/config/keys.go
+++ b/internal/config/keys.go
@@ -10,6 +10,8 @@ func Convert(m KeyMappings[keys]) KeyMappings[key.Binding] {
 	return KeyMappings[key.Binding]{
 		Up:                key.NewBinding(key.WithKeys(m.Up...), key.WithHelp(JoinKeys(m.Up), "up")),
 		Down:              key.NewBinding(key.WithKeys(m.Down...), key.WithHelp(JoinKeys(m.Down), "down")),
+		ScrollUp:          key.NewBinding(key.WithKeys(m.ScrollUp...), key.WithHelp(JoinKeys(m.ScrollUp), "scroll up")),
+		ScrollDown:        key.NewBinding(key.WithKeys(m.ScrollDown...), key.WithHelp(JoinKeys(m.ScrollDown), "scroll down")),
 		JumpToParent:      key.NewBinding(key.WithKeys(m.JumpToParent...), key.WithHelp(JoinKeys(m.JumpToParent), "jump to parent")),
 		JumpToChildren:    key.NewBinding(key.WithKeys(m.JumpToChildren...), key.WithHelp(JoinKeys(m.JumpToChildren), "jump to children")),
 		JumpToWorkingCopy: key.NewBinding(key.WithKeys(m.JumpToWorkingCopy...), key.WithHelp(JoinKeys(m.JumpToWorkingCopy), "jump to working copy")),
@@ -160,6 +162,8 @@ type keys []string
 type KeyMappings[T any] struct {
 	Up                T                         `toml:"up"`
 	Down              T                         `toml:"down"`
+	ScrollUp          T                         `toml:"scroll_up"`
+	ScrollDown        T                         `toml:"scroll_down"`
 	JumpToParent      T                         `toml:"jump_to_parent"`
 	JumpToChildren    T                         `toml:"jump_to_children"`
 	JumpToWorkingCopy T                         `toml:"jump_to_working_copy"`

--- a/internal/ui/revisions/revisions.go
+++ b/internal/ui/revisions/revisions.go
@@ -48,11 +48,6 @@ var (
 	_ common.IMouseAware = (*Model)(nil)
 )
 
-var (
-	pageDownKey = key.NewBinding(key.WithKeys("pgdown"))
-	pageUpKey   = key.NewBinding(key.WithKeys("pgup"))
-)
-
 type Model struct {
 	*common.ViewNode
 	*common.MouseAware
@@ -415,10 +410,10 @@ func (m *Model) internalUpdate(msg tea.Msg) tea.Cmd {
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
 		switch {
-		case key.Matches(msg, m.keymap.Up, pageUpKey):
-			return m.handleIntent(intents.Navigate{Delta: -1, Page: key.Matches(msg, pageUpKey)})
-		case key.Matches(msg, m.keymap.Down, pageDownKey):
-			return m.handleIntent(intents.Navigate{Delta: 1, Page: key.Matches(msg, pageDownKey)})
+		case key.Matches(msg, m.keymap.Up, m.keymap.ScrollUp):
+			return m.handleIntent(intents.Navigate{Delta: -1, Page: key.Matches(msg, m.keymap.ScrollUp)})
+		case key.Matches(msg, m.keymap.Down, m.keymap.ScrollDown):
+			return m.handleIntent(intents.Navigate{Delta: 1, Page: key.Matches(msg, m.keymap.ScrollDown)})
 		case key.Matches(msg, m.keymap.JumpToParent):
 			return m.handleIntent(intents.Navigate{Target: intents.TargetParent})
 		case key.Matches(msg, m.keymap.JumpToChildren):


### PR DESCRIPTION
Added ScrollUp/Down to be registered keys in config, instead of using
`var`s, and the keys are exposed to configs, which address the comments
in #360 and fixes #360.
