### PR TITLE
chore(github): Add Adda0 as an automatic reviewer for Nix-related changes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,6 +4,6 @@
 * @idursun
 
 # Nix-related
-/nix/ @vic @doprz
-*.nix @vic @doprz
-flake.lock @vic @doprz
+/nix/ @vic @doprz @adda0
+*.nix @vic @doprz @adda0
+flake.lock @vic @doprz @adda0


### PR DESCRIPTION
Since I maintain the nixpkgs package of jjui, I would like to be notified about changes to the upstream Nix configuration as well.

I can also help review the related PRs.