### PR TITLE
operations: enable ace jump for set_parents/duplicate/rebase/squash

### DIFF
--- a/internal/ui/common/msgs.go
+++ b/internal/ui/common/msgs.go
@@ -61,6 +61,10 @@ type (
 		Prompt   string
 		Password chan []byte
 	}
+	RestoreOperationMsg struct {
+		Operation any
+	}
+	StartAceJumpMsg struct{}
 	// DeferredUpdateMsg is used to defer an update until the next render cycle
 	// However, this is very hacky and should only be used for single model updates that doesn't interact with any other model
 	// Rule of thumb is that if you are updating a model with a public message, then you probably shouldn't use this
@@ -83,6 +87,18 @@ func Close() tea.Msg {
 
 func CloseApplied() tea.Msg {
 	return CloseViewMsg{Applied: true}
+}
+
+func RestoreOperation(op interface{}) tea.Cmd {
+	return func() tea.Msg {
+		return RestoreOperationMsg{Operation: op}
+	}
+}
+
+func StartAceJump() tea.Cmd {
+	return func() tea.Msg {
+		return StartAceJumpMsg{}
+	}
 }
 
 func SelectionChanged() tea.Msg {

--- a/internal/ui/operations/duplicate/duplicate_operation.go
+++ b/internal/ui/operations/duplicate/duplicate_operation.go
@@ -71,6 +71,8 @@ func (r *Operation) View() string {
 
 func (r *Operation) HandleKey(msg tea.KeyMsg) tea.Cmd {
 	switch {
+	case key.Matches(msg, r.keyMap.AceJump):
+		return common.StartAceJump()
 	case key.Matches(msg, r.keyMap.Duplicate.Onto):
 		r.Target = TargetDestination
 	case key.Matches(msg, r.keyMap.Duplicate.After):
@@ -97,6 +99,7 @@ func (r *Operation) ShortHelp() []key.Binding {
 		r.keyMap.Duplicate.After,
 		r.keyMap.Duplicate.Before,
 		r.keyMap.Duplicate.Onto,
+		r.keyMap.AceJump,
 	}
 }
 

--- a/internal/ui/operations/rebase/rebase_operation.go
+++ b/internal/ui/operations/rebase/rebase_operation.go
@@ -105,6 +105,8 @@ func (r *Operation) View() string {
 
 func (r *Operation) HandleKey(msg tea.KeyMsg) tea.Cmd {
 	switch {
+	case key.Matches(msg, r.keyMap.AceJump):
+		return common.StartAceJump()
 	case key.Matches(msg, r.keyMap.Rebase.Revision):
 		r.Source = SourceRevision
 	case key.Matches(msg, r.keyMap.Rebase.Branch):
@@ -183,6 +185,7 @@ func (r *Operation) ShortHelp() []key.Binding {
 		r.keyMap.Rebase.Onto,
 		r.keyMap.Rebase.Insert,
 		r.keyMap.Rebase.SkipEmptied,
+		r.keyMap.AceJump,
 	}
 }
 

--- a/internal/ui/operations/set_parents/set_parents_operation.go
+++ b/internal/ui/operations/set_parents/set_parents_operation.go
@@ -52,6 +52,7 @@ func (m *Model) ShortHelp() []key.Binding {
 	return []key.Binding{
 		m.keyMap.ToggleSelect,
 		m.keyMap.Apply,
+		m.keyMap.AceJump,
 		m.keyMap.Cancel,
 	}
 }
@@ -75,6 +76,8 @@ func (m *Model) SetSelectedRevision(commit *jj.Commit) tea.Cmd {
 
 func (m *Model) HandleKey(msg tea.KeyMsg) tea.Cmd {
 	switch {
+	case key.Matches(msg, m.keyMap.AceJump):
+		return common.StartAceJump()
 	case key.Matches(msg, m.keyMap.ToggleSelect):
 		if m.current.GetChangeId() == m.target.GetChangeId() {
 			return nil

--- a/internal/ui/operations/squash/squash_operation.go
+++ b/internal/ui/operations/squash/squash_operation.go
@@ -58,6 +58,8 @@ func (s *Operation) View() string {
 
 func (s *Operation) HandleKey(msg tea.KeyMsg) tea.Cmd {
 	switch {
+	case key.Matches(msg, s.keyMap.AceJump):
+		return common.StartAceJump()
 	case key.Matches(msg, s.keyMap.Apply, s.keyMap.ForceApply):
 		ignoreImmutable := key.Matches(msg, s.keyMap.ForceApply)
 		args := jj.Squash(s.from, s.current.GetChangeId(), s.files, s.keepEmptied, s.useDestinationMessage, s.interactive, ignoreImmutable)
@@ -123,6 +125,7 @@ func (s *Operation) ShortHelp() []key.Binding {
 		s.keyMap.Squash.KeepEmptied,
 		s.keyMap.Squash.UseDestinationMessage,
 		s.keyMap.Squash.Interactive,
+		s.keyMap.AceJump,
 	}
 }
 

--- a/internal/ui/revisions/revisions.go
+++ b/internal/ui/revisions/revisions.go
@@ -304,6 +304,13 @@ func (m *Model) internalUpdate(msg tea.Msg) tea.Cmd {
 	case common.CloseViewMsg:
 		m.op = operations.NewDefault()
 		return m.updateSelection()
+	case common.RestoreOperationMsg:
+		if op, ok := msg.Operation.(operations.Operation); ok {
+			m.op = op
+			return m.updateSelection()
+		}
+		m.op = operations.NewDefault()
+		return m.updateSelection()
 	case common.QuickSearchMsg:
 		m.quickSearch = strings.ToLower(string(msg))
 		m.SetCursor(m.search(0))
@@ -421,9 +428,11 @@ func (m *Model) internalUpdate(msg tea.Msg) tea.Cmd {
 		case key.Matches(msg, m.keymap.JumpToWorkingCopy):
 			return m.handleIntent(intents.Navigate{Target: intents.TargetWorkingCopy})
 		case key.Matches(msg, m.keymap.AceJump):
+			parentOp := m.op
+			// Create ace jump with parent operation
 			op := ace_jump.NewOperation(m, func(index int) parser.Row {
 				return m.rows[index]
-			}, m.renderer.FirstRowIndex, m.renderer.LastRowIndex)
+			}, m.renderer.FirstRowIndex, m.renderer.LastRowIndex, parentOp)
 			m.op = op
 			return op.Init()
 		default:


### PR DESCRIPTION
**this PR is more for visibility and ideation, final implementation is to be discussed**

### enable ace jump for set_parents/duplicate/rebase/squash

While in a mode of set_parents/duplicate/rebase/squash, pressing 'f' triggers ace jump mode just like in revision view (highlighting on IDs is triggered, user can type to jump to a revision).

After completing the jump, the user returns to the original mode instead of exiting to normal mode.

User workflow:
1. Press 'r' to enter rebase mode (or 'S' for squash mode)
2. Press 'f' to activate ace jump while staying in rebase/squash mode
3. Type matching keys to jump to a revision
4. After jump completes, return to rebase/squash mode
5. Use existing rebase/squash keys to complete the operation

Closes #394


### implementation

introduce the concept of a "parent operation" when ace jump is being triggered. upon deactivation of ace jump, if parent operation is not nil, return to parent operation