### PR TITLE
menu: calculate height before pagination render

### DIFF
--- a/internal/ui/common/menu/menu.go
+++ b/internal/ui/common/menu/menu.go
@@ -169,15 +169,22 @@ func (m *Menu) renderTitle() []string {
 
 func (m *Menu) View() string {
 	views := m.renderTitle()
-	views = append(views, "", m.renderFilterView())
+	// one empty line for padding between title and content
+	views = append(views, "")
+
+	// Calculate remaining height for the list
 	remainingHeight := m.Height
 	for i := range views {
 		remainingHeight -= lipgloss.Height(views[i])
 	}
+	// reserve space for filter view
+	remainingHeight -= 1
 
+	// set list dimensions before rendering filter view so pagination calculates correctly
 	m.List.SetWidth(m.Width - 2)
 	m.List.SetHeight(remainingHeight)
 
+	views = append(views, m.renderFilterView())
 	views = append(views, m.List.View())
 	content := lipgloss.JoinVertical(0, views...)
 	content = lipgloss.Place(m.Width, m.Height, 0, 0, content)

--- a/internal/ui/git/git.go
+++ b/internal/ui/git/git.go
@@ -74,6 +74,9 @@ func (m *Model) ShortHelp() []key.Binding {
 		m.keymap.Git.Push,
 		m.keymap.Git.Fetch,
 		m.menu.List.KeyMap.Filter,
+		key.NewBinding(
+			key.WithKeys("tab/shift+tab"),
+			key.WithHelp("tab/shift+tab", "cycle remotes")),
 	}
 }
 


### PR DESCRIPTION
### menu: calculate height before pagination render

Fix `%d/%d` incorrect display issue.

pagination count is calculated by the list's `Paginator`, based on how many items can fit in the available height. Since the height was still 0 when pagination was rendered, it showed incorrect total pages.

Also, added `tap/shift+tab` to short help menu. 

Fixes #444