### PR TITLE
feat: add $width variable for preview commands

### DIFF
--- a/internal/jj/commands.go
+++ b/internal/jj/commands.go
@@ -9,12 +9,12 @@ import (
 )
 
 const (
-	ChangeIdPlaceholder    = "$change_id"
-	CommitIdPlaceholder    = "$commit_id"
-	FilePlaceholder        = "$file"
-	OperationIdPlaceholder = "$operation_id"
-	RevsetPlaceholder      = "$revset"
-	WidthPlaceholder       = "$width"
+	ChangeIdPlaceholder     = "$change_id"
+	CommitIdPlaceholder     = "$commit_id"
+	FilePlaceholder         = "$file"
+	OperationIdPlaceholder  = "$operation_id"
+	RevsetPlaceholder       = "$revset"
+	PreviewWidthPlaceholder = "$preview_width"
 
 	// user checked file names, separated by `\t` tab.
 	// tab is a lot less common than spaces on filenames,

--- a/internal/ui/preview/preview.go
+++ b/internal/ui/preview/preview.go
@@ -226,24 +226,24 @@ func (m *Model) refreshPreview() tea.Cmd {
 		switch msg := m.context.SelectedItem.(type) {
 		case context.SelectedFile:
 			args = jj.TemplatedArgs(config.Current.Preview.FileCommand, map[string]string{
-				jj.RevsetPlaceholder:   m.context.CurrentRevset,
-				jj.ChangeIdPlaceholder: msg.ChangeId,
-				jj.CommitIdPlaceholder: msg.CommitId,
-				jj.FilePlaceholder:     msg.File,
-				jj.WidthPlaceholder:    previewWidth,
+				jj.RevsetPlaceholder:       m.context.CurrentRevset,
+				jj.ChangeIdPlaceholder:     msg.ChangeId,
+				jj.CommitIdPlaceholder:     msg.CommitId,
+				jj.FilePlaceholder:         msg.File,
+				jj.PreviewWidthPlaceholder: previewWidth,
 			})
 		case context.SelectedRevision:
 			args = jj.TemplatedArgs(config.Current.Preview.RevisionCommand, map[string]string{
-				jj.RevsetPlaceholder:   m.context.CurrentRevset,
-				jj.ChangeIdPlaceholder: msg.ChangeId,
-				jj.CommitIdPlaceholder: msg.CommitId,
-				jj.WidthPlaceholder:    previewWidth,
+				jj.RevsetPlaceholder:       m.context.CurrentRevset,
+				jj.ChangeIdPlaceholder:     msg.ChangeId,
+				jj.CommitIdPlaceholder:     msg.CommitId,
+				jj.PreviewWidthPlaceholder: previewWidth,
 			})
 		case context.SelectedOperation:
 			args = jj.TemplatedArgs(config.Current.Preview.OplogCommand, map[string]string{
-				jj.RevsetPlaceholder:      m.context.CurrentRevset,
-				jj.OperationIdPlaceholder: msg.OperationId,
-				jj.WidthPlaceholder:       previewWidth,
+				jj.RevsetPlaceholder:       m.context.CurrentRevset,
+				jj.OperationIdPlaceholder:  msg.OperationId,
+				jj.PreviewWidthPlaceholder: previewWidth,
 			})
 		}
 


### PR DESCRIPTION
## Summary
- Add a new `$width` placeholder variable that exposes the actual view width (in columns) to preview commands
- Enables tools like delta to use `--side-by-side` with the correct width
- Width updates dynamically when the preview pane is resized

## Motivation

When using delta with `--side-by-side` in preview commands, there's no way to pass the correct width because jjui pipes command output to an internal buffer (no TTY). This is similar to [Discussion #163](https://github.com/idursun/jjui/discussions/163).

Similar to how fzf exposes `$FZF_PREVIEW_COLUMNS`, this adds a `$width` variable.

## Example usage

```toml
[preview]
revision_command = ["util", "exec", "--", "bash", "-c",
  """jj show --color always --git -r $change_id | delta --side-by-side --width $width"""]
```