### PR TITLE
Add yank to clipboard feature for file paths

### DIFF
--- a/internal/config/default/config.toml
+++ b/internal/config/default/config.toml
@@ -75,6 +75,7 @@ limit = 0
     diff = ["d"]
     select = ["m", " "]
     revisions_changing_file = ["*"]
+    yank = ["y"]
   [keys.evolog]
     mode = ["v"]
     diff = ["d"]

--- a/internal/config/keys.go
+++ b/internal/config/keys.go
@@ -91,6 +91,7 @@ func Convert(m KeyMappings[keys]) KeyMappings[key.Binding] {
 			Diff:                  key.NewBinding(key.WithKeys(m.Details.Diff...), key.WithHelp(JoinKeys(m.Details.Diff), "diff")),
 			ToggleSelect:          key.NewBinding(key.WithKeys(m.Details.ToggleSelect...), key.WithHelp(JoinKeys(m.Details.ToggleSelect), "details toggle select")),
 			RevisionsChangingFile: key.NewBinding(key.WithKeys(m.Details.RevisionsChangingFile...), key.WithHelp(JoinKeys(m.Details.RevisionsChangingFile), "show revisions changing file")),
+			Yank:                  key.NewBinding(key.WithKeys(m.Details.Yank...), key.WithHelp(JoinKeys(m.Details.Yank), "yank")),
 		},
 		Bookmark: bookmarkModeKeys[key.Binding]{
 			Mode:    key.NewBinding(key.WithKeys(m.Bookmark.Mode...), key.WithHelp(JoinKeys(m.Bookmark.Mode), "bookmarks")),
@@ -272,6 +273,7 @@ type detailsModeKeys[T any] struct {
 	Diff                  T `toml:"diff"`
 	ToggleSelect          T `toml:"select"`
 	RevisionsChangingFile T `toml:"revisions_changing_file"`
+	Yank                  T `toml:"yank"`
 }
 
 type gitModeKeys[T any] struct {

--- a/internal/ui/helppage/help_item_groups.go
+++ b/internal/ui/helppage/help_item_groups.go
@@ -138,6 +138,7 @@ func (h *Model) buildMiddleGroups() menuColumn {
 			h.newBindingItem(h.keyMap.Details.Squash),
 			h.newBindingItem(h.keyMap.Details.Diff),
 			h.newBindingItem(h.keyMap.Details.RevisionsChangingFile),
+			h.newBindingItem(h.keyMap.Details.Yank),
 			helpItem{"", ""},
 		},
 		itemGroup{


### PR DESCRIPTION
Allows you to copy files to paste/use in other apps. 

https://github.com/zellij-org/zellij 's mouse selection doesn't work that well with jjui, likely from how the TUI library works, but tapping 'y' is easier than clicking