### PR TITLE
feat: make flash message display time configurable

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"path"
 	"strings"
+	"time"
 )
 
 //go:embed default/*.toml
@@ -125,8 +126,13 @@ type UIConfig struct {
 	Colors map[string]Color `toml:"colors"`
 	// TODO(ilyagr): It might make sense to rename this to `auto_refresh_period` to match `--period` option
 	// once we have a mechanism to deprecate the old name softly.
-	AutoRefreshInterval int          `toml:"auto_refresh_interval"`
-	Tracer              TracerConfig `toml:"tracer"`
+	AutoRefreshInterval        int          `toml:"auto_refresh_interval"`
+	FlashMessageDisplaySeconds int          `toml:"flash_message_display_seconds"`
+	Tracer                     TracerConfig `toml:"tracer"`
+}
+
+func GetExpiringFlashMessageTimeout(c *Config) time.Duration {
+	return time.Duration(c.UI.FlashMessageDisplaySeconds) * time.Second
 }
 
 type RevisionsConfig struct {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -55,6 +56,18 @@ auto_refresh_interval = 5000
 	err := config.Load(content)
 	assert.NoError(t, err)
 	assert.Equal(t, 5000, config.UI.AutoRefreshInterval)
+}
+
+func TestLoad_FlashMessageDisplaySeconds(t *testing.T) {
+	content := `
+[ui]
+flash_message_display_seconds = 10
+`
+	config := &Config{}
+	err := config.Load(content)
+	assert.NoError(t, err)
+	assert.Equal(t, 10, config.UI.FlashMessageDisplaySeconds)
+	assert.Equal(t, 10*time.Second, GetExpiringFlashMessageTimeout(config))
 }
 
 func TestLoad_Colors_StringAndObject(t *testing.T) {

--- a/internal/config/default/config.toml
+++ b/internal/config/default/config.toml
@@ -119,6 +119,7 @@ limit = 0
 [ui]
   theme = ""
   auto_refresh_interval = 0
+  flash_message_display_seconds = 4 # 0 means display until manually dismissed
   [ui.tracer]
     enabled = false
   [ui.colors]


### PR DESCRIPTION
Replace the hard-coded display time of four seconds for informational flash messages with a configurable display time.  The config key is `ui.flash_message_display_seconds`, defaulting to `4` for consistency with the previous behavior.  The special value of `0` means display messages until manually dismissed.

fixes #455 