### PR TITLE
status: fix exec command history not applied

### DIFF
--- a/internal/ui/status/status.go
+++ b/internal/ui/status/status.go
@@ -145,6 +145,14 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 			input := m.input.Value()
 			prompt := m.input.Prompt
 			fuzzy := m.fuzzy
+			// If there's a selected match in the fuzzy list, use that instead
+			if fuzzy != nil {
+				if selected := fuzzy_search.SelectedMatch(fuzzy); selected != "" {
+					// SelectedMatch returns the value wrapped in single quotes, remove them
+					input = strings.Trim(selected, "'")
+					m.input.SetValue(input)
+				}
+			}
 			m.saveEditingSuggestions()
 
 			m.fuzzy = nil


### PR DESCRIPTION
Previously, in `exec jj` mode, typing triggers fuzzy/regex suggestions
from command history. However, when selecting a suggestion and pressing
Enter, the command executed was still the original typed input instead
of the selected history command.

The issue was that, the input field's value isn't updated upon entry
selection in command history.
This fix checks if there's a selected match in the fuzzy suggestions
list before executing. If there is one, it:
1. Gets the selected match string
2. Strips the single quotes that SelectedMatch wraps around the value
3. Updates the input value with so it also gets saved to history
   correctly
