### PR TITLE
fix: replace deprecated --edit with --editor in describe command

### DIFF
--- a/internal/jj/commands.go
+++ b/internal/jj/commands.go
@@ -102,7 +102,7 @@ func SquashFiles(from string, into string, files []string) CommandArgs {
 }
 
 func Describe(revisions SelectedRevisions) CommandArgs {
-	args := []string{"describe", "--edit"}
+	args := []string{"describe", "--editor"}
 	args = append(args, revisions.AsArgs()...)
 	return args
 }


### PR DESCRIPTION
Replace deprecated `jj describe --edit` usage with `--editor` to match current jj CLI behavior.

<img width="810" height="124" alt="image" src="https://github.com/user-attachments/assets/21e1a50e-ea5d-41d3-a6b7-d1a29e644b1d" />
