### PR TITLE
fix(bookmarks): track new bookmarks

### DIFF
--- a/internal/jj/bookmark_parser.go
+++ b/internal/jj/bookmark_parser.go
@@ -28,6 +28,10 @@ func (b Bookmark) IsDeletable() bool {
 	return b.Local != nil
 }
 
+func (b Bookmark) IsTrackable() bool {
+	return b.Local != nil && len(b.Remotes) == 0
+}
+
 func ParseBookmarkListOutput(output string) []Bookmark {
 	lines := strings.Split(output, "\n")
 	bookmarkMap := make(map[string]*Bookmark)

--- a/internal/jj/commands.go
+++ b/internal/jj/commands.go
@@ -199,8 +199,8 @@ func BookmarkTrack(name string) CommandArgs {
 	return []string{"bookmark", "track", name}
 }
 
-func BookmarkUntrack(name string) CommandArgs {
-	return []string{"bookmark", "untrack", name}
+func BookmarkUntrack(name string, remote string) CommandArgs {
+	return []string{"bookmark", "untrack", name, "--remote", remote}
 }
 
 func Squash(from SelectedRevisions, destination string, files []string, keepEmptied bool, useDestinationMessage bool, interactive bool, ignoreImmutable bool) CommandArgs {

--- a/internal/ui/bookmarks/bookmarks.go
+++ b/internal/ui/bookmarks/bookmarks.go
@@ -152,6 +152,16 @@ func (m *Model) loadAll() tea.Msg {
 				args:     jj.BookmarkForget(b.Name),
 			})
 
+			// Track local bookmarks as they have no remotes
+			if b.IsTrackable() {
+				items = append(items, item{
+					name:     fmt.Sprintf("track '%s'", b.Name),
+					priority: trackCommand,
+					dist:     distance,
+					args:     jj.BookmarkTrack(b.Name),
+				})
+			}
+
 			for _, remote := range b.Remotes {
 				nameWithRemote := fmt.Sprintf("%s@%s", b.Name, remote.Remote)
 				if remote.Tracked {
@@ -159,7 +169,7 @@ func (m *Model) loadAll() tea.Msg {
 						name:     fmt.Sprintf("untrack '%s'", nameWithRemote),
 						priority: untrackCommand,
 						dist:     distance,
-						args:     jj.BookmarkUntrack(nameWithRemote),
+						args:     jj.BookmarkUntrack(b.Name, remote.Remote),
 					})
 				} else {
 					items = append(items, item{
@@ -170,7 +180,6 @@ func (m *Model) loadAll() tea.Msg {
 					})
 				}
 			}
-
 		}
 		return updateItemsMsg{items: items}
 	}


### PR DESCRIPTION
After the merge of #407 I noticed that we need to track local bookmark before we can push them. 

The bookmark menu doesn't show an option to track a local bookmark because it doesn't have any remotes. This change adds the option to track local bookmarks. 

The only problem is track command tracks a bookmark for all the remotes if it the remote is not specified. Currently, we cannot do this as the bookmark menu doesn't allow choosing a remote but I am hoping to address this when the bookmark list is remodelled around the discussion in #309 