### PR TITLE
feat: add "no edit" option when splitting to skip editing messages

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -26,6 +26,11 @@ type Config struct {
 	Limit     int               `toml:"limit"`
 	Git       GitConfig         `toml:"git"`
 	Ssh       SshConfig         `toml:"ssh"`
+	Split     SplitConfig       `toml:"split"`
+}
+
+type SplitConfig struct {
+	NoEdit bool `toml:"no_edit"`
 }
 
 type Color struct {

--- a/internal/config/default/config.toml
+++ b/internal/config/default/config.toml
@@ -152,3 +152,6 @@ limit = 0
 
 [ssh]
   hijack_askpass = false
+
+[split]
+  no_edit = false

--- a/internal/jj/commands.go
+++ b/internal/jj/commands.go
@@ -80,6 +80,10 @@ func DiffEdit(changeId string) CommandArgs {
 
 func Split(revision string, files []string, parallel bool) CommandArgs {
 	args := []string{"split", "-r", revision}
+	if config.Current.Split.NoEdit {
+		args = append(args, "--message")
+		args = append(args, "")
+	}
 	if parallel {
 		args = append(args, "--parallel")
 	}


### PR DESCRIPTION
I would like to avoid editing descriptions whenever I am splitting commits.

This is my take at solving this. 

Apologies for skipping issue creation as per contribution guidelines, this was more natural for me for this small change.

### CHANGES

- Add a `split.no_edit` configuration option.
- Prevent editor from opening when splitting commits.
- Set default `no_edit` value to `false`.