### PR TITLE
ui,preview: fix preview pane ctrl-u/d scrolling

### DIFF
--- a/internal/ui/preview/preview.go
+++ b/internal/ui/preview/preview.go
@@ -110,6 +110,10 @@ func (m *Model) WindowPercentage() float64 {
 	return m.previewWindowPercentage
 }
 
+func (m *Model) YOffset() int {
+	return m.view.YOffset
+}
+
 func (m *Model) Scroll(delta int) tea.Cmd {
 	if delta > 0 {
 		m.view.ScrollDown(delta)
@@ -204,6 +208,10 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 			m.view.HalfPageDown()
 		case key.Matches(msg, m.keyMap.Preview.HalfPageUp):
 			m.view.HalfPageUp()
+		case key.Matches(msg, m.keyMap.Preview.Expand):
+			m.Expand()
+		case key.Matches(msg, m.keyMap.Preview.Shrink):
+			m.Shrink()
 		}
 	}
 	return nil

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -274,11 +274,15 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 			m.previewModel.ToggleVisible()
 			cmds = append(cmds, common.SelectionChanged(m.context.SelectedItem))
 			return tea.Batch(cmds...)
-		case key.Matches(msg, m.keyMap.Preview.Expand) && m.previewModel.Visible():
-			m.previewModel.Expand()
-			return tea.Batch(cmds...)
-		case key.Matches(msg, m.keyMap.Preview.Shrink) && m.previewModel.Visible():
-			m.previewModel.Shrink()
+		case m.previewModel.Visible() && key.Matches(msg,
+			m.keyMap.Preview.Expand,
+			m.keyMap.Preview.Shrink,
+			m.keyMap.Preview.HalfPageDown,
+			m.keyMap.Preview.HalfPageUp,
+			m.keyMap.Preview.ScrollDown,
+			m.keyMap.Preview.ScrollUp):
+			cmd := m.previewModel.Update(msg)
+			cmds = append(cmds, cmd)
 			return tea.Batch(cmds...)
 		case key.Matches(msg, m.keyMap.CustomCommands):
 			model := customcommands.NewModel(m.context)


### PR DESCRIPTION
Commit 8481b92 broke ctrl-u/d scrolling in the preview pane, see below
code:
```
if common.IsInputMessage(msg) {
    if m.oplog != nil {
        cmds = append(cmds, m.oplog.Update(msg))
    } else {
        cmds = append(cmds, m.revisions.Update(msg))
    }
    return tea.Batch(cmds...)
}
```
This causes unhandled key messages to be routed only to oplog or
revisions, and then returns early, so they never reach the preview
model's Update() call which happens later in the function.


This fix groups preview related commands and make sure they are always
handled.

Also, added a YOffset() method to internal/ui/preview/preview.go to expose
the viewport's Y offset for testing purposes.
