### PR TITLE
fix: set description from stdin to allow messages starting with minus

### DIFF
--- a/internal/jj/commands.go
+++ b/internal/jj/commands.go
@@ -30,6 +30,10 @@ const (
 )
 
 type CommandArgs []string
+type CommandWithStdin struct {
+	Args  CommandArgs
+	Input string
+}
 
 func ConfigListAll() CommandArgs {
 	return []string{"config", "list", "--color", "never", "--include-defaults", "--ignore-working-copy"}
@@ -97,8 +101,11 @@ func Describe(revisions SelectedRevisions) CommandArgs {
 	return args
 }
 
-func SetDescription(revision string, description string) CommandArgs {
-	return []string{"describe", "-r", revision, "-m", description}
+func SetDescription(revision string, description string) CommandWithStdin {
+	return CommandWithStdin{
+		Args:  []string{"describe", "-r", revision, "--stdin"},
+		Input: description,
+	}
 }
 
 func GetDescription(revision string) CommandArgs {

--- a/internal/ui/operations/describe/describe.go
+++ b/internal/ui/operations/describe/describe.go
@@ -135,15 +135,17 @@ func (o *Operation) handleIntent(intent intents.Intent) tea.Cmd {
 
 func (o *Operation) runInlineDescribeEditor() tea.Cmd {
 	selectedRevisions := jj.NewSelectedRevisions(o.revision)
-	return o.context.RunCommand(
-		jj.SetDescription(o.revision.GetChangeId(), o.input.Value()),
+	cmd := jj.SetDescription(o.revision.GetChangeId(), o.input.Value())
+	return o.context.RunCommandWithInput(
+		cmd.Args, cmd.Input,
 		common.CloseApplied,
 		o.context.RunInteractiveCommand(jj.Describe(selectedRevisions), common.Refresh),
 	)
 }
 
 func (o *Operation) runInlineDescribeAccept() tea.Cmd {
-	return o.context.RunCommand(jj.SetDescription(o.revision.GetChangeId(), o.input.Value()), common.CloseApplied, common.Refresh)
+	cmd := jj.SetDescription(o.revision.GetChangeId(), o.input.Value())
+	return o.context.RunCommandWithInput(cmd.Args, cmd.Input, common.CloseApplied, common.Refresh)
 }
 
 func (o *Operation) Init() tea.Cmd {

--- a/test/test_command_runner.go
+++ b/test/test_command_runner.go
@@ -67,6 +67,16 @@ func (t *CommandRunner) RunCommandStreaming(_ context.Context, args []string) (*
 	}, err
 }
 
+func (t *CommandRunner) RunCommandWithInput(args []string, input string, continuations ...tea.Cmd) tea.Cmd {
+	cmds := make([]tea.Cmd, 0)
+	cmds = append(cmds, func() tea.Msg {
+		output, err := t.RunCommandImmediate(args)
+		return common.CommandCompletedMsg{Output: string(output), Err: err}
+	})
+	cmds = append(cmds, continuations...)
+	return tea.Batch(cmds...)
+}
+
 func (t *CommandRunner) RunCommand(args []string, continuations ...tea.Cmd) tea.Cmd {
 	cmds := make([]tea.Cmd, 0)
 	cmds = append(cmds, func() tea.Msg {


### PR DESCRIPTION
Setting the description from stdin avoids command line parsing issues when the message cannot be properly quoted.

E.g. `jj describe -m -foo` gives the error `error: unexpected argument '-f' found`.

This fixes #315.