### PR TITLE
revisions: fix displaycontext_renderer to render details before elided marker

### DIFF
--- a/internal/ui/revisions/displaycontext_renderer_test.go
+++ b/internal/ui/revisions/displaycontext_renderer_test.go
@@ -1,0 +1,66 @@
+package revisions
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/cellbuf"
+	"github.com/idursun/jjui/internal/jj"
+	"github.com/idursun/jjui/internal/parser"
+	"github.com/idursun/jjui/internal/ui/layout"
+	"github.com/idursun/jjui/internal/ui/operations/details"
+	"github.com/idursun/jjui/internal/ui/render"
+	"github.com/idursun/jjui/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDisplayContextRenderer_DetailsRendersBeforeElidedMarker(t *testing.T) {
+	f, err := os.Open("testdata/jj-log-with-elided.log")
+	require.NoError(t, err)
+	defer func() { _ = f.Close() }()
+
+	rows := parser.ParseRows(f)
+	require.NotEmpty(t, rows)
+
+	// rows[1] in `jj-log-with-elided.log` has (~ elided revision) below
+	targetRow := rows[1]
+	require.NotNil(t, targetRow.Commit)
+
+	// Prepare details operation with a file list.
+	const statusOutput = "false $\nM file.txt\n"
+	commandRunner := test.NewTestCommandRunner(t)
+	commandRunner.Expect(jj.Snapshot())
+	commandRunner.Expect(jj.Status(targetRow.Commit.GetChangeId())).SetOutput([]byte(statusOutput))
+	defer commandRunner.Verify()
+
+	ctx := test.NewTestContext(commandRunner)
+	op := details.NewOperation(ctx, targetRow.Commit)
+	// Details only renders for the selected commit when Current matches it.
+	_ = op.SetSelectedRevision(targetRow.Commit)
+	test.SimulateModel(op, op.Init())
+
+	// Render just the target row with the details operation active.
+	r := NewDisplayContextRenderer(lipgloss.NewStyle(), lipgloss.NewStyle(), lipgloss.NewStyle(), lipgloss.NewStyle())
+	r.SetSelections(nil)
+
+	width, height := 100, 15
+	dl := render.NewDisplayContext()
+	viewRect := layout.NewBox(cellbuf.Rect(0, 0, width, height))
+	r.Render(dl, []parser.Row{targetRow}, 0, viewRect, op, true)
+
+	screen := cellbuf.NewBuffer(width, height)
+	dl.Render(screen)
+	out := cellbuf.Render(screen)
+
+	// Regression: details list should appear *before* the elided marker line,
+	// keeping the marker visually "between" commits rather than above the
+	// details list.
+	filePos := strings.Index(out, "file.txt")
+	elidedPos := strings.Index(out, "elided revisions")
+	assert.NotEqual(t, -1, filePos, "expected details list to render file.txt")
+	assert.NotEqual(t, -1, elidedPos, "expected fixture to render elided revisions marker")
+	assert.Less(t, filePos, elidedPos, "expected details list to render before elided marker")
+}

--- a/internal/ui/revisions/testdata/jj-log-with-elided.log
+++ b/internal/ui/revisions/testdata/jj-log-with-elided.log
@@ -1,0 +1,9 @@
+[1m[38;5;2m@[0m  _PREFIX:vzv_PREFIX:19_PREFIX:false [1m[38;5;13mvzv[38;5;8mklxpm[39m [38;5;3mibrahim@dursun.cc[39m [38;5;14m2025-03-15 23:36:03[39m [38;5;13mexp/log-parser[39m [38;5;12m19[38;5;8ma58c40[39m[0m
+│  [1mrefactor: add notemplate_parser[0m
+[1m[38;5;14m◆[0m  _PREFIX:u_PREFIX:9_PREFIX:false [1m[38;5;5mu[0m[38;5;8mzlqpksu[39m [38;5;3mibrahim@dursun.cc[39m [38;5;6m2025-03-15 22:42:14[39m [38;5;5mmain[39m [1m[38;5;4m9[0m[38;5;8m0d3c3f5[39m
+│  feat(absorb): support `jj absorb`
+[38;5;8m~[39m  [38;5;8m(elided revisions)[39m
+│ ○  _PREFIX:o_PREFIX:b3_PREFIX:false [1m[38;5;5mo[0m[38;5;8mwvurkmm[39m [38;5;3mibrahim@dursun.cc[39m [38;5;6m2025-03-15 12:16:34[39m [1m[38;5;4mb3[0m[38;5;8md83572[39m
+│ │  [38;5;3m(no description set)[39m
+│ ○  _PREFIX:m_PREFIX:3_PREFIX:false [1m[38;5;5mm[0m[38;5;8mxnulzmt[39m [38;5;3mibrahim@dursun.cc[39m [38;5;6m2025-03-14 21:07:40[39m [1m[38;5;4m3[0m[38;5;8m1787156[39m
+│ │  refactor: remove selection tracking code


### PR DESCRIPTION
Currently, if a revision is followed by a elided revision, files in
details view are being rendered **after** the elided mark. to reproduce,
run `jjui -r main..`, bug details see:
[![asciicast](https://asciinema.org/a/769259.svg)](https://asciinema.org/a/769259) 

Fix:
When a selected revision has an elided marker line "~", render the
details "after" content before the marker so the marker stays between
revisions.

Also, add renderer regression tests to prevent blank gaps when the next
item exists.
