### PR TITLE
preview: reset preview offset after revision change

### DIFF
--- a/internal/ui/preview/preview.go
+++ b/internal/ui/preview/preview.go
@@ -162,6 +162,7 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 }
 
 func (m *Model) SetContent(content string) {
+	m.reset()
 	m.content = strings.ReplaceAll(content, "\r", "")
 	m.view.SetContent(content)
 }


### PR DESCRIPTION
Previously, if a revision change occurred while a preview was open, the
preview offset stays the same, which causes new preview to be shown at
an unexpected position. This commit resets the preview offset to 0.

see below for bug details:
![jjui-preview-scrolling-offset](https://github.com/user-attachments/assets/d9230ee7-2319-4dd4-8cc6-d8eab0272d4d)
