### PR TITLE
fix: displaycontext_renderer elided revision rendering issue

### DIFF
--- a/internal/ui/revisions/displaycontext_renderer.go
+++ b/internal/ui/revisions/displaycontext_renderer.go
@@ -341,11 +341,6 @@ func (r *DisplayContextRenderer) renderItemToDisplayContext(
 			afterRendered = true
 		}
 
-		// Skip elided lines when we have description overlay
-		if line.Flags&parser.Elided == parser.Elided && descriptionOverlay != "" {
-			continue
-		}
-
 		// Handle description overlay
 		if descriptionOverlay != "" && !descriptionRendered &&
 			line.Flags&parser.Highlightable == parser.Highlightable &&
@@ -398,6 +393,9 @@ func (r *DisplayContextRenderer) renderItemToDisplayContext(
 
 // renderLine writes a line into a TextBuilder (helper for itemRenderer)
 func (ir *itemRenderer) renderLine(tb *render.TextBuilder, line *parser.GraphRowLine) {
+	// Only highlight lines with the Highlightable flag
+	lineIsHighlightable := line.Flags&parser.Highlightable == parser.Highlightable
+
 	// Render gutter (no tracer support for now)
 	for _, segment := range line.Gutter.Segments {
 		style := segment.Style.Inherit(ir.textStyle)
@@ -426,7 +424,7 @@ func (ir *itemRenderer) renderLine(tb *render.TextBuilder, line *parser.GraphRow
 			tb.Write(beforeCommitID)
 		}
 
-		style := ir.getSegmentStyle(*segment)
+		style := ir.getSegmentStyleForLine(*segment, lineIsHighlightable)
 		if sr, ok := ir.op.(operations.SegmentRenderer); ok {
 			rendered := sr.RenderSegment(style, segment, ir.row)
 			if rendered != "" {
@@ -434,7 +432,7 @@ func (ir *itemRenderer) renderLine(tb *render.TextBuilder, line *parser.GraphRow
 				continue
 			}
 		}
-		ir.renderSegment(tb, segment)
+		ir.renderSegmentForLine(tb, segment, lineIsHighlightable)
 	}
 
 	// Add affected marker

--- a/internal/ui/revisions/item_renderer.go
+++ b/internal/ui/revisions/item_renderer.go
@@ -23,9 +23,11 @@ type itemRenderer struct {
 	isChecked     bool
 }
 
-func (ir itemRenderer) getSegmentStyle(segment screen.Segment) lipgloss.Style {
+// getSegmentStyleForLine returns the style for a segment, considering whether the line is highlightable.
+// Only lines with the Highlightable flag should get the selected style when the row is selected.
+func (ir itemRenderer) getSegmentStyleForLine(segment screen.Segment, lineIsHighlightable bool) lipgloss.Style {
 	style := segment.Style
-	if ir.isHighlighted {
+	if ir.isHighlighted && lineIsHighlightable {
 		style = style.Inherit(ir.selectedStyle)
 	} else {
 		style = style.Inherit(ir.textStyle)
@@ -33,8 +35,9 @@ func (ir itemRenderer) getSegmentStyle(segment screen.Segment) lipgloss.Style {
 	return style
 }
 
-func (ir itemRenderer) renderSegment(tb *render.TextBuilder, segment *screen.Segment) {
-	baseStyle := ir.getSegmentStyle(*segment)
+// renderSegmentForLine renders a segment considering whether the line is highlightable.
+func (ir itemRenderer) renderSegmentForLine(tb *render.TextBuilder, segment *screen.Segment, lineIsHighlightable bool) {
+	baseStyle := ir.getSegmentStyleForLine(*segment, lineIsHighlightable)
 	if ir.SearchText == "" {
 		tb.Styled(segment.Text, baseStyle)
 		return


### PR DESCRIPTION
There're two issues with current rendering logic on `~ elided revision`:
1. `(elided revision)` lines are included in the highlighting of
   previous line
2. when inline description overlay is active, elided lines are not rendered
   at all

Fix:
remove incorrect condition that skipped rendering elided lines when a
description overlay was active. The description overlay is meant to
replace description lines only, not elided markers.

Bug details:
1. <img width="807" height="163" alt="image" src="https://github.com/user-attachments/assets/c459b27e-8307-411e-af71-50026ddd3b37" />

2. <img width="807" height="163" alt="image" src="https://github.com/user-attachments/assets/7bd8883c-ac2a-4984-90d7-890701f7963d" />
