### PR TITLE
fix: revset/ui, suggestion overlapping main view

### DIFF
--- a/internal/ui/revset/revset.go
+++ b/internal/ui/revset/revset.go
@@ -190,6 +190,19 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 	return m.autoComplete.Update(msg)
 }
 
+func (m *Model) Height() int {
+	if !m.Editing {
+		return 1
+	}
+	// When editing, calculate height including suggestions
+	var w strings.Builder
+	w.WriteString(m.styles.promptStyle.PaddingRight(1).Render("revset:"))
+	w.WriteString(m.autoComplete.View())
+	content := w.String()
+	lines := strings.Count(content, "\n") + 1
+	return lines
+}
+
 func (m *Model) handleIntent(intent intents.Intent) tea.Cmd {
 	switch intent := intent.(type) {
 	case intents.Set:
@@ -255,6 +268,7 @@ func (m *Model) ViewRect(dl *render.DisplayContext, box layout.Box) {
 		return
 	}
 
-	overlayRect := cellbuf.Rect(box.R.Min.X, box.R.Max.Y, box.R.Dx(), overlayHeight)
+	// Draw overlay within the allocated box, starting from the second line
+	overlayRect := cellbuf.Rect(box.R.Min.X, box.R.Min.Y+1, box.R.Dx(), overlayHeight)
 	dl.AddDraw(overlayRect, overlay, 2)
 }

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -505,7 +505,8 @@ func (m *Model) renderOpLogLayout(box layout.Box) {
 }
 
 func (m *Model) renderRevisionsLayout(box layout.Box) {
-	rows := box.V(layout.Fixed(1), layout.Fill(1), layout.Fixed(1))
+	revsetHeight := m.revsetModel.Height()
+	rows := box.V(layout.Fixed(revsetHeight), layout.Fill(1), layout.Fixed(1))
 	if len(rows) < 3 {
 		return
 	}


### PR DESCRIPTION
When revset is triggered (with `L`), it pops open a suggestion view
below, which previously pushed `jj log` graph view down, but now overlaps.
It's not really a functionality issue, i've been thinking about if this
needs a "fix" for a few days and decided i prefer the previous aesthetic.

This commit adds `Height()` method to revset model, which returns 1 line
when not editing and actual height including suggestions when editing,
and it changes the overlay rectangle to start at box.R.Min.Y+1 

bug detail:
<img width="1258" height="417" alt="image" src="https://github.com/user-attachments/assets/f8f1a2fd-69e3-487e-9576-9f730b04751f" />


