### PR TITLE
revset,ui: fix ShortHelp display for revset

### DIFF
--- a/internal/ui/revset/revset.go
+++ b/internal/ui/revset/revset.go
@@ -35,7 +35,6 @@ func RevsetCmd(msg tea.Msg) tea.Cmd {
 type Model struct {
 	Editing         bool
 	autoComplete    *autocompletion.AutoCompletionInput
-	keymap          keymap
 	History         []string
 	historyIndex    int
 	currentInput    string
@@ -54,20 +53,19 @@ func (m *Model) IsFocused() bool {
 	return m.Editing
 }
 
-type keymap struct{}
-
-func (k keymap) ShortHelp() []key.Binding {
+func (m *Model) ShortHelp() []key.Binding {
 	return []key.Binding{
 		key.NewBinding(key.WithKeys("tab"), key.WithHelp("tab", "complete")),
 		key.NewBinding(key.WithKeys("ctrl+n"), key.WithHelp("ctrl+n", "next")),
 		key.NewBinding(key.WithKeys("ctrl+p"), key.WithHelp("ctrl+p", "prev")),
 		key.NewBinding(key.WithKeys("enter"), key.WithHelp("enter", "accept")),
 		key.NewBinding(key.WithKeys("esc"), key.WithHelp("esc", "quit")),
+		key.NewBinding(key.WithKeys("up/down"), key.WithHelp("↑/↓", "history")),
 	}
 }
 
-func (k keymap) FullHelp() [][]key.Binding {
-	return [][]key.Binding{k.ShortHelp()}
+func (m *Model) FullHelp() [][]key.Binding {
+	return [][]key.Binding{m.ShortHelp()}
 }
 
 func New(context *appContext.MainContext) *Model {
@@ -86,7 +84,6 @@ func New(context *appContext.MainContext) *Model {
 	return &Model{
 		context:         context,
 		Editing:         false,
-		keymap:          keymap{},
 		autoComplete:    autoComplete,
 		History:         []string{},
 		historyIndex:    -1,

--- a/internal/ui/status/status.go
+++ b/internal/ui/status/status.go
@@ -261,10 +261,18 @@ func (m *Model) SetHelp(keyMap help.KeyMap) {
 	m.keyMap = keyMap
 }
 
+func (m *Model) Help() help.KeyMap {
+	return m.keyMap
+}
+
 func (m *Model) SetMode(mode string) {
 	if !m.IsFocused() {
 		m.mode = mode
 	}
+}
+
+func (m *Model) Mode() string {
+	return m.mode
 }
 
 func (m *Model) helpView(keyMap help.KeyMap) string {

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -431,6 +431,9 @@ func (m *Model) updateStatus() {
 	case m.leader != nil:
 		m.status.SetMode("leader")
 		m.status.SetHelp(m.leader)
+	case m.revsetModel.Editing:
+		m.status.SetMode("revset")
+		m.status.SetHelp(m.revsetModel)
 	default:
 		m.status.SetHelp(m.revisions)
 		m.status.SetMode(m.revisions.CurrentOperation().Name())

--- a/internal/ui/ui_test.go
+++ b/internal/ui/ui_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/charmbracelet/x/cellbuf"
 	"github.com/idursun/jjui/internal/ui/layout"
 	"github.com/idursun/jjui/internal/ui/render"
+	"github.com/idursun/jjui/internal/ui/revset"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/idursun/jjui/internal/ui/common"
@@ -129,4 +130,20 @@ func Test_Update_PreviewResizeKeysWorkWhenVisible(t *testing.T) {
 			}
 		})
 	}
+}
+
+func Test_UpdateStatus_RevsetEditingShowsRevsetHelp(t *testing.T) {
+	commandRunner := test.NewTestCommandRunner(t)
+	ctx := test.NewTestContext(commandRunner)
+
+	model := NewUI(ctx)
+
+	// Activate revset editing
+	model.revsetModel.Update(revset.EditRevSetMsg{})
+	assert.True(t, model.revsetModel.Editing, "revset should be in editing mode")
+
+	// Trigger status update
+	model.updateStatus()
+	assert.Equal(t, "revset", model.status.Mode(), "status mode should be 'revset'")
+	assert.Equal(t, model.revsetModel, model.status.Help(), "status help should be set to revset model")
 }


### PR DESCRIPTION
Previously, when revset is activated, its ShortHelp content isn't displayed on the footer. 

Added a case in updateStatus() in `ui.go` to set the status mode to "revset" and set the help from m.revsetModel when m.revsetModel.Editing is true

Removed the standalone type keymap struct{} in
`internal/ui/revset/revset.go` to be consistent with other model implementation.
Also added ↑/↓ history binding to the help

Related to #488