### PR TITLE
Nix build warning (harmless for now; use deprecated)

### DIFF
--- a/nix/overlays.nix
+++ b/nix/overlays.nix
@@ -1,6 +1,6 @@
 { inputs, ... }:
 {
   flake.overlays.default = final: _prev: {
-    jjui = inputs.self.packages.${final.system}.jjui;
+    jjui = inputs.self.packages.${final.stdenv.hostPlatform.system}.jjui;
   };
 }


### PR DESCRIPTION
# Summary

**Source of warning**: jjui-flake input (github:idursun/jjui/v0.9.10)
**File**: nix/overlays.nix in the jjui repository
**Problem line**:
`jjui = inputs.self.packages.${final.system}.jjui;`
**Fix required**: The upstream jjui flake needs to change to:
`jjui = inputs.self.packages.${final.stdenv.hostPlatform.system}.jjui;`
