### PR TITLE
refactor: centralize z-index constants in render/zindex.go

### DIFF
--- a/internal/ui/bookmarks/bookmarks.go
+++ b/internal/ui/bookmarks/bookmarks.go
@@ -70,13 +70,6 @@ const (
 	filterApplied
 )
 
-// Z-index constants for menu overlays.
-// Menu overlays render above main content (z=0-1) to ensure visibility.
-const (
-	zIndexBorder  = 100 // Z-index for menu border
-	zIndexContent = 101 // Z-index for menu content
-)
-
 var _ common.ImmediateModel = (*Model)(nil)
 
 type Model struct {
@@ -484,7 +477,7 @@ func (m *Model) ViewRect(dl *render.DisplayContext, box layout.Box) {
 	menuHeight := max(contentHeight+2, 0)
 	frame := box.Center(menuWidth, menuHeight)
 	if len(m.visibleItems()) == 0 {
-		dl.AddFill(frame.R.Inset(1), ' ', lipgloss.NewStyle(), zIndexContent)
+		dl.AddFill(frame.R.Inset(1), ' ', lipgloss.NewStyle(), render.ZMenuContent)
 	}
 	if frame.R.Dx() <= 0 || frame.R.Dy() <= 0 {
 		return
@@ -497,10 +490,10 @@ func (m *Model) ViewRect(dl *render.DisplayContext, box layout.Box) {
 	}
 
 	borderBase := lipgloss.NewStyle().Width(contentBox.R.Dx()).Height(contentBox.R.Dy()).Render("")
-	window.AddDraw(frame.R, m.menuStyles.border.Render(borderBase), zIndexBorder)
+	window.AddDraw(frame.R, m.menuStyles.border.Render(borderBase), render.ZMenuBorder)
 
 	titleBox, contentBox := contentBox.CutTop(1)
-	window.AddDraw(titleBox.R, m.menuStyles.title.Render(m.title), zIndexContent)
+	window.AddDraw(titleBox.R, m.menuStyles.title.Render(m.title), render.ZMenuContent)
 
 	_, contentBox = contentBox.CutTop(1)
 	remoteBox, contentBox := contentBox.CutTop(1)
@@ -510,7 +503,7 @@ func (m *Model) ViewRect(dl *render.DisplayContext, box layout.Box) {
 	filterBox, contentBox := contentBox.CutTop(1)
 	if m.filterState == filterEditing {
 		m.filterInput.Width = max(contentBox.R.Dx()-2, 0)
-		window.AddDraw(filterBox.R, m.filterInput.View(), zIndexContent)
+		window.AddDraw(filterBox.R, m.filterInput.View(), render.ZMenuContent)
 	} else {
 		m.renderFilterView(window, filterBox)
 	}
@@ -525,10 +518,10 @@ func (m *Model) renderRemotes(dl *render.DisplayContext, lineBox layout.Box) {
 	if lineBox.R.Dx() <= 0 || lineBox.R.Dy() <= 0 {
 		return
 	}
-	windowedDl := dl.Window(lineBox.R, zIndexContent)
+	windowedDl := dl.Window(lineBox.R, render.ZMenuContent)
 
 	// Render above menu content
-	tb := windowedDl.Text(lineBox.R.Min.X, lineBox.R.Min.Y, zIndexContent+1).
+	tb := windowedDl.Text(lineBox.R.Min.X, lineBox.R.Min.Y, render.ZMenuContent+1).
 		Space(1).
 		Styled("Remotes: ", m.remoteStyles.promptStyle)
 
@@ -784,7 +777,7 @@ func (m *Model) renderFilterView(dl *render.DisplayContext, box layout.Box) {
 		)
 	}
 
-	dl.AddDraw(box.R, m.menuStyles.text.Width(width).Render(lipgloss.JoinHorizontal(0, parts...)), zIndexContent)
+	dl.AddDraw(box.R, m.menuStyles.text.Width(width).Render(lipgloss.JoinHorizontal(0, parts...)), render.ZMenuContent)
 }
 
 func (m *Model) renderList(dl *render.DisplayContext, listBox layout.Box) {
@@ -876,7 +869,7 @@ func renderItem(dl *render.DisplayContext, rect cellbuf.Rectangle, width int, st
 	if content == "" {
 		return
 	}
-	dl.AddDraw(rect, content, zIndexContent)
+	dl.AddDraw(rect, content, render.ZMenuContent)
 }
 
 func calcDistanceMap(current string, commitIds []string) map[string]int {

--- a/internal/ui/bookmarks/bookmarks_test.go
+++ b/internal/ui/bookmarks/bookmarks_test.go
@@ -56,7 +56,7 @@ func Test_Sorting_MixedCommands(t *testing.T) {
 }
 
 // TestBookmarks_ZIndex_RendersAboveMainContent verifies that the bookmarks
-// overlay renders at z-index >= zIndexBorder. This ensures the bookmarks
+// overlay renders at z-index >= render.ZMenuBorder. This ensures the bookmarks
 // operations menu renders above the main revision list content.
 func TestBookmarks_ZIndex_RendersAboveMainContent(t *testing.T) {
 	commandRunner := test.NewTestCommandRunner(t)
@@ -77,7 +77,7 @@ func TestBookmarks_ZIndex_RendersAboveMainContent(t *testing.T) {
 	for i, draw := range draws {
 		msg := fmt.Sprintf("Draw operation %d has z-index %d, expected >= %d. "+
 			"Bookmarks overlay must render above main content.",
-			i, draw.Z, zIndexBorder)
-		assert.GreaterOrEqual(t, draw.Z, zIndexBorder, msg)
+			i, draw.Z, render.ZMenuBorder)
+		assert.GreaterOrEqual(t, draw.Z, render.ZMenuBorder, msg)
 	}
 }

--- a/internal/ui/choose/choose.go
+++ b/internal/ui/choose/choose.go
@@ -55,11 +55,7 @@ type styles struct {
 	selected lipgloss.Style
 }
 
-const (
-	zIndexBorder    = 100
-	zIndexContent   = 101
-	maxVisibleItems = 20
-)
+const maxVisibleItems = 20
 
 func New(options []string) *Model {
 	return NewWithTitle(options, "")
@@ -187,20 +183,20 @@ func (m *Model) ViewRect(dl *render.DisplayContext, box layout.Box) {
 		return
 	}
 
-	window := dl.Window(frame.R, zIndexContent)
+	window := dl.Window(frame.R, render.ZMenuContent)
 	contentBox := frame.Inset(1)
 	if contentBox.R.Dx() <= 0 || contentBox.R.Dy() <= 0 {
 		return
 	}
 
 	borderBase := lipgloss.NewStyle().Width(contentBox.R.Dx()).Height(contentBox.R.Dy()).Render("")
-	window.AddDraw(frame.R, m.styles.border.Render(borderBase), zIndexBorder)
+	window.AddDraw(frame.R, m.styles.border.Render(borderBase), render.ZMenuBorder)
 
 	listBox := contentBox
 	if titleHeight > 0 {
 		var titleBox layout.Box
 		titleBox, listBox = contentBox.CutTop(1)
-		window.AddDraw(titleBox.R, m.styles.title.Render(m.title), zIndexContent)
+		window.AddDraw(titleBox.R, m.styles.title.Render(m.title), render.ZMenuContent)
 	}
 
 	if listBox.R.Dx() <= 0 || listBox.R.Dy() <= 0 {
@@ -226,7 +222,7 @@ func (m *Model) ViewRect(dl *render.DisplayContext, box layout.Box) {
 				style = m.styles.selected
 			}
 			line := style.Padding(0, 1).Width(rect.Dx()).Render(m.options[index])
-			dl.AddDraw(rect, line, zIndexContent)
+			dl.AddDraw(rect, line, render.ZMenuContent)
 		},
 		func(index int) tea.Msg { return itemClickMsg{Index: index} },
 	)

--- a/internal/ui/confirmation/confirmation.go
+++ b/internal/ui/confirmation/confirmation.go
@@ -44,6 +44,7 @@ type Model struct {
 	Styles      Styles
 	messages    []string
 	stylePrefix string
+	zIndex      int
 }
 
 func (m *Model) ShortHelp() []key.Binding {
@@ -92,6 +93,13 @@ func WithOption(label string, cmd tea.Cmd, keyBinding key.Binding) Option {
 func WithAltOption(label string, cmd tea.Cmd, altCmd tea.Cmd, keyBinding key.Binding) Option {
 	return func(m *Model) {
 		m.options = append(m.options, option{label, cmd, keyBinding, altCmd})
+	}
+}
+
+// WithZIndex sets the z-index for rendering
+func WithZIndex(z int) Option {
+	return func(m *Model) {
+		m.zIndex = z
 	}
 }
 
@@ -165,6 +173,8 @@ func (m *Model) ViewRect(dl *render.DisplayContext, box layout.Box) {
 		return
 	}
 
+	z := m.zIndex
+
 	measure := dl.Text(0, 0, 0)
 	m.buildContent(measure)
 	contentWidth, contentHeight := measure.Measure()
@@ -183,8 +193,8 @@ func (m *Model) ViewRect(dl *render.DisplayContext, box layout.Box) {
 	sy := box.R.Min.Y
 
 	frame := cellbuf.Rect(sx, sy, bw, bh)
-	window := dl.Window(frame, 10)
-	window.AddDraw(frame, bordered, 0)
+	window := dl.Window(frame, z)
+	window.AddDraw(frame, bordered, z)
 
 	mt, mr, mb, ml := m.Styles.Border.GetMargin()
 	pt, pr, pb, pl := m.Styles.Border.GetPadding()
@@ -204,9 +214,9 @@ func (m *Model) ViewRect(dl *render.DisplayContext, box layout.Box) {
 	}
 
 	background := lipgloss.NewStyle().Background(m.Styles.Text.GetBackground())
-	window.AddFill(contentRect, ' ', background, 1)
+	window.AddFill(contentRect, ' ', background, z+1)
 
-	tb := window.Text(contentRect.Min.X, contentRect.Min.Y, 2)
+	tb := window.Text(contentRect.Min.X, contentRect.Min.Y, z+2)
 	m.buildContent(tb)
 	tb.Done()
 }

--- a/internal/ui/custom_commands/custom_commands.go
+++ b/internal/ui/custom_commands/custom_commands.go
@@ -83,13 +83,6 @@ const (
 	filterApplied
 )
 
-// Z-index constants for menu overlays.
-// Menu overlays render above main content (z=0-1) to ensure visibility.
-const (
-	zIndexBorder  = 100 // Z-index for menu border
-	zIndexContent = 101 // Z-index for menu content
-)
-
 var _ common.ImmediateModel = (*Model)(nil)
 
 // SortedCustomCommands returns commands ordered by name for deterministic iteration.
@@ -243,16 +236,16 @@ func (m *Model) ViewRect(dl *render.DisplayContext, box layout.Box) {
 	}
 
 	borderBase := lipgloss.NewStyle().Width(contentBox.R.Dx()).Height(contentBox.R.Dy()).Render("")
-	window.AddDraw(frame.R, m.styles.border.Render(borderBase), zIndexBorder)
+	window.AddDraw(frame.R, m.styles.border.Render(borderBase), render.ZMenuBorder)
 
 	titleBox, contentBox := contentBox.CutTop(1)
-	window.AddDraw(titleBox.R, m.styles.title.Render("Custom Commands"), zIndexContent)
+	window.AddDraw(titleBox.R, m.styles.title.Render("Custom Commands"), render.ZMenuContent)
 
 	_, contentBox = contentBox.CutTop(1)
 	filterBox, contentBox := contentBox.CutTop(1)
 	if m.filterState == filterEditing {
 		m.filterInput.Width = max(contentBox.R.Dx()-2, 0)
-		window.AddDraw(filterBox.R, m.filterInput.View(), zIndexContent)
+		window.AddDraw(filterBox.R, m.filterInput.View(), render.ZMenuContent)
 	} else {
 		m.renderFilterView(window, filterBox)
 	}
@@ -415,7 +408,7 @@ func (m *Model) renderFilterView(dl *render.DisplayContext, box layout.Box) {
 	if m.categoryFilter != "" {
 		filterView = lipgloss.JoinHorizontal(0, filterStyle.Render("Showing only "), filterValueStyle.Render(m.categoryFilter))
 	}
-	dl.AddDraw(box.R, m.styles.text.Width(width).Render(filterView), zIndexContent)
+	dl.AddDraw(box.R, m.styles.text.Width(width).Render(filterView), render.ZMenuContent)
 }
 
 func (m *Model) renderList(dl *render.DisplayContext, listBox layout.Box) {
@@ -507,5 +500,5 @@ func renderItem(dl *render.DisplayContext, rect cellbuf.Rectangle, width int, st
 	if content == "" {
 		return
 	}
-	dl.AddDraw(rect, content, zIndexContent)
+	dl.AddDraw(rect, content, render.ZMenuContent)
 }

--- a/internal/ui/custom_commands/sequence_overlay.go
+++ b/internal/ui/custom_commands/sequence_overlay.go
@@ -182,7 +182,7 @@ func (s *SequenceOverlay) ViewRect(dl *render.DisplayContext, box layout.Box) {
 	sy := area.Max.Y - h - 1
 
 	rect := cellbuf.Rect(area.Min.X, sy, w, h)
-	dl.AddDraw(rect, content, 200)
+	dl.AddDraw(rect, content, render.ZOverlay)
 }
 
 func (s *SequenceOverlay) advance(msg tea.KeyMsg) ([]SequenceCandidate, SequenceResult) {

--- a/internal/ui/flash/flash.go
+++ b/internal/ui/flash/flash.go
@@ -135,9 +135,8 @@ func (m *Model) ViewRect(dl *render.DisplayContext, box layout.Box) {
 			y -= h
 		}
 
-		// Use z-index 1 for overlay rendering (flash messages appear above other content)
 		rect := cellbuf.Rect(area.Max.X-w, y, w, h)
-		dl.AddDraw(rect, content, 200)
+		dl.AddDraw(rect, content, render.ZOverlay)
 	}
 }
 

--- a/internal/ui/fuzzy_files/fuzzy_files.go
+++ b/internal/ui/fuzzy_files/fuzzy_files.go
@@ -249,7 +249,7 @@ func (fzf *fuzzyFiles) ViewRect(dl *render.DisplayContext, box layout.Box) {
 	}
 	_, h := lipgloss.Size(content)
 	rect := cellbuf.Rect(box.R.Min.X, box.R.Max.Y-h, box.R.Dx(), h)
-	dl.AddDraw(rect, content, 1)
+	dl.AddDraw(rect, content, render.ZFuzzyInput)
 }
 
 func (fzf *fuzzyFiles) viewContent() string {

--- a/internal/ui/fuzzy_input/fuzzy_input.go
+++ b/internal/ui/fuzzy_input/fuzzy_input.go
@@ -204,7 +204,7 @@ func (fzf *model) ViewRect(dl *render.DisplayContext, box layout.Box) {
 	}
 	_, h := lipgloss.Size(content)
 	rect := cellbuf.Rect(box.R.Min.X, box.R.Max.Y-h, box.R.Dx(), h)
-	dl.AddDraw(rect, content, 1)
+	dl.AddDraw(rect, content, render.ZFuzzyInput)
 }
 
 func (fzf *model) viewContent() string {

--- a/internal/ui/git/git.go
+++ b/internal/ui/git/git.go
@@ -95,13 +95,6 @@ const (
 	filterApplied
 )
 
-// Z-index constants for menu overlays.
-// Menu overlays render above main content (z=0-1) to ensure visibility.
-const (
-	zIndexBorder  = 100 // Z-index for menu border
-	zIndexContent = 101 // Z-index for menu content
-)
-
 var _ common.ImmediateModel = (*Model)(nil)
 
 type Model struct {
@@ -308,7 +301,7 @@ func (m *Model) ViewRect(dl *render.DisplayContext, box layout.Box) {
 	menuHeight := max(contentHeight+2, 0)
 	frame := box.Center(menuWidth, menuHeight)
 	if len(m.visibleItems()) == 0 {
-		dl.AddFill(frame.R.Inset(1), ' ', lipgloss.NewStyle(), zIndexContent)
+		dl.AddFill(frame.R.Inset(1), ' ', lipgloss.NewStyle(), render.ZMenuContent)
 	}
 	if frame.R.Dx() <= 0 || frame.R.Dy() <= 0 {
 		return
@@ -321,10 +314,10 @@ func (m *Model) ViewRect(dl *render.DisplayContext, box layout.Box) {
 	}
 
 	borderBase := lipgloss.NewStyle().Width(contentBox.R.Dx()).Height(contentBox.R.Dy()).Render("")
-	window.AddDraw(frame.R, m.menuStyles.border.Render(borderBase), zIndexBorder)
+	window.AddDraw(frame.R, m.menuStyles.border.Render(borderBase), render.ZMenuBorder)
 
 	titleBox, contentBox := contentBox.CutTop(1)
-	window.AddDraw(titleBox.R, m.menuStyles.title.Render(m.title), zIndexContent)
+	window.AddDraw(titleBox.R, m.menuStyles.title.Render(m.title), render.ZMenuContent)
 
 	_, contentBox = contentBox.CutTop(1)
 	remoteBox, contentBox := contentBox.CutTop(1)
@@ -334,7 +327,7 @@ func (m *Model) ViewRect(dl *render.DisplayContext, box layout.Box) {
 	filterBox, contentBox := contentBox.CutTop(1)
 	if m.filterState == filterEditing {
 		m.filterInput.Width = max(contentBox.R.Dx()-2, 0)
-		window.AddDraw(filterBox.R, m.filterInput.View(), zIndexContent)
+		window.AddDraw(filterBox.R, m.filterInput.View(), render.ZMenuContent)
 	} else {
 		m.renderFilterView(window, filterBox)
 	}
@@ -349,10 +342,10 @@ func (m *Model) renderRemotes(dl *render.DisplayContext, lineBox layout.Box) {
 	if lineBox.R.Dx() <= 0 || lineBox.R.Dy() <= 0 {
 		return
 	}
-	windowedDl := dl.Window(lineBox.R, zIndexContent)
+	windowedDl := dl.Window(lineBox.R, render.ZMenuContent)
 
 	// Render above menu content
-	tb := windowedDl.Text(lineBox.R.Min.X, lineBox.R.Min.Y, zIndexContent+1).
+	tb := windowedDl.Text(lineBox.R.Min.X, lineBox.R.Min.Y, render.ZMenuContent+1).
 		Space(1).
 		Styled("Remotes: ", m.remoteStyles.promptStyle)
 
@@ -559,7 +552,7 @@ func (m *Model) renderFilterView(dl *render.DisplayContext, box layout.Box) {
 	if m.categoryFilter != "" {
 		filterView = lipgloss.JoinHorizontal(0, filterStyle.Render("Showing only "), filterValueStyle.Render(m.categoryFilter))
 	}
-	dl.AddDraw(box.R, m.menuStyles.text.Width(width).Render(filterView), zIndexContent)
+	dl.AddDraw(box.R, m.menuStyles.text.Width(width).Render(filterView), render.ZMenuContent)
 }
 
 func (m *Model) renderList(dl *render.DisplayContext, listBox layout.Box) {
@@ -651,7 +644,7 @@ func renderItem(dl *render.DisplayContext, rect cellbuf.Rectangle, width int, st
 	if content == "" {
 		return
 	}
-	dl.AddDraw(rect, content, zIndexContent)
+	dl.AddDraw(rect, content, render.ZMenuContent)
 }
 
 func (m *Model) createMenuItems() []item {

--- a/internal/ui/git/git_test.go
+++ b/internal/ui/git/git_test.go
@@ -76,7 +76,7 @@ func Test_PushChange(t *testing.T) {
 }
 
 // TestGit_ZIndex_RendersAboveMainContent verifies that the git overlay renders
-// at z-index >= zIndexBorder. This ensures the git operations menu
+// at z-index >= render.ZMenuBorder. This ensures the git operations menu
 // renders above the main revision list content.
 func TestGit_ZIndex_RendersAboveMainContent(t *testing.T) {
 	commandRunner := test.NewTestCommandRunner(t)
@@ -95,7 +95,7 @@ func TestGit_ZIndex_RendersAboveMainContent(t *testing.T) {
 	for i, draw := range draws {
 		msg := fmt.Sprintf("Draw operation %d has z-index %d, expected >= %d. "+
 			"Git overlay must render above main content.",
-			i, draw.Z, zIndexBorder)
-		assert.GreaterOrEqual(t, draw.Z, zIndexBorder, msg)
+			i, draw.Z, render.ZMenuBorder)
+		assert.GreaterOrEqual(t, draw.Z, render.ZMenuBorder, msg)
 	}
 }

--- a/internal/ui/helppage/help.go
+++ b/internal/ui/helppage/help.go
@@ -85,7 +85,7 @@ func (h *Model) ViewRect(dl *render.DisplayContext, box layout.Box) {
 	v := h.styles.border.Render(h.searchQuery.View(), content)
 	w, height := lipgloss.Size(v)
 	box = box.Center(w, height)
-	dl.AddDraw(box.R, v, 3)
+	dl.AddDraw(box.R, v, render.ZHelpPage)
 }
 
 func (h *Model) filterMenu() {

--- a/internal/ui/input/input.go
+++ b/internal/ui/input/input.go
@@ -105,8 +105,8 @@ func (m *Model) ViewRect(dl *render.DisplayContext, box layout.Box) {
 	content := lipgloss.JoinVertical(0, rows...)
 	content = m.styles.border.Padding(0, 1).Render(content)
 	box = box.Center(lipgloss.Size(content))
-	window := dl.Window(box.R, 10)
-	window.AddDraw(box.R, content, 1)
+	window := dl.Window(box.R, render.ZDialogs)
+	window.AddDraw(box.R, content, render.ZDialogs)
 }
 
 func (m *Model) ShortHelp() []key.Binding {

--- a/internal/ui/operations/target_picker/target_picker.go
+++ b/internal/ui/operations/target_picker/target_picker.go
@@ -176,14 +176,14 @@ func (m *Model) ViewRect(dl *render.DisplayContext, box layout.Box) {
 	centeredBox := box.Center(maxW, maxH)
 
 	borderContent := m.styles.border.Width(centeredBox.R.Dx() - 2).Height(centeredBox.R.Dy() - 2).Render("")
-	window := dl.Window(centeredBox.R, 100)
-	window.AddDraw(centeredBox.R, borderContent, 100)
+	window := dl.Window(centeredBox.R, render.ZMenuBorder)
+	window.AddDraw(centeredBox.R, borderContent, render.ZMenuBorder)
 	centeredBox = centeredBox.Inset(1)
 
 	inputBox, listBox := centeredBox.CutTop(1)
 	m.input.Width = inputBox.R.Dx()
 
-	window.AddDraw(inputBox.R, m.input.View(), 101)
+	window.AddDraw(inputBox.R, m.input.View(), render.ZMenuContent)
 
 	m.listRenderer.Render(
 		window,
@@ -202,20 +202,20 @@ func (m *Model) ViewRect(dl *render.DisplayContext, box layout.Box) {
 
 			pillText := m.renderPill(item.Kind)
 			pillRect := cellbuf.Rect(rect.Min.X, y, pillWidth, 1)
-			window.AddDraw(pillRect, pillText, 101)
+			window.AddDraw(pillRect, pillText, render.ZMenuContent)
 
 			isSelected := index == m.cursor
 			lineStyle := m.styles.bookmarkPill
 			matchStyle := m.styles.matchStyle
 			if isSelected {
-				window.AddHighlight(rect, m.styles.selected, 102)
+				window.AddHighlight(rect, m.styles.selected, render.ZMenuContent+1)
 			} else {
 				matchStyle = matchStyle.Inherit(lineStyle)
 			}
 			nameContent := fuzzy_search.HighlightMatched(item.Name, match, lineStyle, matchStyle)
 			nameX := rect.Min.X + pillWidth + 1
 			nameRect := cellbuf.Rect(nameX, y, rect.Dx()-pillWidth-1, 1)
-			window.AddDraw(nameRect, nameContent, 101)
+			window.AddDraw(nameRect, nameContent, render.ZMenuContent)
 		},
 		func(index int) tea.Msg { return itemClickedMsg{index: index} },
 	)

--- a/internal/ui/password/password.go
+++ b/internal/ui/password/password.go
@@ -69,5 +69,5 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 func (m *Model) ViewRect(dl *render.DisplayContext, box layout.Box) {
 	v := m.styles.border.Width(max(box.R.Dx()-2, 0)).Render(m.textInput.View())
 	box = box.Center(lipgloss.Size(v))
-	dl.AddDraw(box.R, v, 300)
+	dl.AddDraw(box.R, v, render.ZPassword)
 }

--- a/internal/ui/preview/preview.go
+++ b/internal/ui/preview/preview.go
@@ -167,10 +167,10 @@ func (m *Model) SetContent(content string) {
 func (m *Model) ViewRect(dl *render.DisplayContext, box layout.Box) {
 	m.view.Width = box.R.Dx()
 	m.view.Height = box.R.Dy()
-	dl.AddDraw(box.R, m.view.View(), 0)
+	dl.AddDraw(box.R, m.view.View(), render.ZPreview)
 
 	scrollRect := cellbuf.Rect(box.R.Min.X, box.R.Min.Y, box.R.Dx(), box.R.Dy())
-	dl.AddInteraction(scrollRect, ScrollMsg{}, render.InteractionScroll, 0)
+	dl.AddInteraction(scrollRect, ScrollMsg{}, render.InteractionScroll, render.ZPreview)
 }
 
 func (m *Model) reset() {

--- a/internal/ui/redo/redo.go
+++ b/internal/ui/redo/redo.go
@@ -51,6 +51,7 @@ func NewModel(context *context.MainContext) *Model {
 	model := confirmation.New(
 		[]string{lastOperation, "Are you sure you want to redo last change?"},
 		confirmation.WithStylePrefix("redo"),
+		confirmation.WithZIndex(render.ZDialogs),
 		confirmation.WithOption("Yes", context.RunCommand(jj.Redo(), common.Refresh, common.Close), key.NewBinding(key.WithKeys("y"), key.WithHelp("y", "yes"))),
 		confirmation.WithOption("No", common.Close, key.NewBinding(key.WithKeys("n", "esc"), key.WithHelp("n/esc", "no"))),
 	)

--- a/internal/ui/render/zindex.go
+++ b/internal/ui/render/zindex.go
@@ -1,0 +1,37 @@
+package render
+
+// Z-index constants for layered rendering. Higher values render on top.
+// Components should use these named constants instead of magic numbers.
+const (
+	// ZBase is for base content:
+	// revisions list, diff view, oplog, details, describe, bookmark operations
+	ZBase = 0
+
+	// ZFuzzyInput is for fuzzy input fields, text inputs, and revset list items
+	ZFuzzyInput = 1
+
+	// ZRevsetOverlay is for revset overlay content
+	ZRevsetOverlay = 2
+
+	// ZPreview is for preview panels and split views
+	ZPreview = 10
+
+	// ZDialogs is for dialogs (undo/redo confirmation, input fields)
+	// that should appear above the preview panel
+	ZDialogs = 50
+
+	// ZMenuBorder is for menu borders (git, bookmarks, choose, custom_commands)
+	ZMenuBorder = 100
+
+	// ZMenuContent is for menu content items
+	ZMenuContent = 101
+
+	// ZOverlay is for overlays like sequence overlay and flash messages
+	ZOverlay = 200
+
+	// ZHelpPage is for the help page overlay
+	ZHelpPage = 250
+
+	// ZPassword is for password input (highest priority modal)
+	ZPassword = 300
+)

--- a/internal/ui/revset/revset.go
+++ b/internal/ui/revset/revset.go
@@ -240,7 +240,7 @@ func (m *Model) ViewRect(dl *render.DisplayContext, box layout.Box) {
 	content := w.String()
 	parts := strings.SplitN(content, "\n", 2)
 	line := parts[0]
-	dl.AddDraw(box.R, line, 1)
+	dl.AddDraw(box.R, line, render.ZFuzzyInput)
 
 	if !m.Editing || len(parts) < 2 {
 		return
@@ -253,5 +253,5 @@ func (m *Model) ViewRect(dl *render.DisplayContext, box layout.Box) {
 	}
 
 	overlayRect := cellbuf.Rect(box.R.Min.X, box.R.Max.Y, box.R.Dx(), overlayHeight)
-	dl.AddDraw(overlayRect, overlay, 2)
+	dl.AddDraw(overlayRect, overlay, render.ZRevsetOverlay)
 }

--- a/internal/ui/split.go
+++ b/internal/ui/split.go
@@ -141,7 +141,7 @@ func (s *split) renderBoth(dl *render.DisplayContext, box layout.Box) {
 			dl.AddInteraction(sepRect, SplitDragMsg{Split: s}, render.InteractionDrag, 0)
 			drawRect, content := separatorContent(sepRect, s.Vertical)
 			if drawRect.Dx() > 0 && drawRect.Dy() > 0 && content != "" {
-				dl.AddDraw(drawRect, content, 1)
+				dl.AddDraw(drawRect, content, render.ZPreview)
 			}
 			return
 		}
@@ -175,7 +175,7 @@ func (s *split) renderBoth(dl *render.DisplayContext, box layout.Box) {
 		dl.AddInteraction(sepRect, SplitDragMsg{Split: s}, render.InteractionDrag, 0)
 		drawRect, content := separatorContent(sepRect, s.Vertical)
 		if drawRect.Dx() > 0 && drawRect.Dy() > 0 && content != "" {
-			dl.AddDraw(drawRect, content, 1)
+			dl.AddDraw(drawRect, content, render.ZPreview)
 		}
 		return
 	}

--- a/internal/ui/undo/undo.go
+++ b/internal/ui/undo/undo.go
@@ -51,6 +51,7 @@ func NewModel(context *context.MainContext) *Model {
 	model := confirmation.New(
 		[]string{lastOperation, "Are you sure you want to undo last change?"},
 		confirmation.WithStylePrefix("undo"),
+		confirmation.WithZIndex(render.ZDialogs),
 		confirmation.WithOption("Yes", context.RunCommand(jj.Undo(), common.Refresh, common.Close), key.NewBinding(key.WithKeys("y"), key.WithHelp("y", "yes"))),
 		confirmation.WithOption("No", common.Close, key.NewBinding(key.WithKeys("n", "esc"), key.WithHelp("n/esc", "no"))),
 	)

--- a/internal/ui/undo/undo_test.go
+++ b/internal/ui/undo/undo_test.go
@@ -4,7 +4,10 @@ import (
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/x/cellbuf"
 	"github.com/idursun/jjui/internal/jj"
+	"github.com/idursun/jjui/internal/ui/layout"
+	"github.com/idursun/jjui/internal/ui/render"
 	"github.com/idursun/jjui/test"
 	"github.com/stretchr/testify/assert"
 )
@@ -32,4 +35,24 @@ func TestCancel(t *testing.T) {
 	assert.Contains(t, test.RenderImmediate(model, 100, 20), "undo")
 
 	test.SimulateModel(model, test.Press(tea.KeyEsc))
+}
+
+func TestUndo_ZIndex_RendersAbovePreview(t *testing.T) {
+	commandRunner := test.NewTestCommandRunner(t)
+	commandRunner.Expect(jj.OpLog(1))
+
+	model := NewModel(test.NewTestContext(commandRunner))
+	test.SimulateModel(model, model.Init())
+
+	dl := render.NewDisplayContext()
+	box := layout.Box{R: cellbuf.Rect(0, 0, 100, 40)}
+	model.ViewRect(dl, box)
+
+	draws := dl.DrawList()
+	assert.NotEmpty(t, draws, "Expected undo confirmation to produce draw operations")
+
+	for _, draw := range draws {
+		assert.GreaterOrEqual(t, draw.Z, render.ZDialogs,
+			"Undo confirmation must render above preview panel (ZDialogs)")
+	}
 }


### PR DESCRIPTION
Replace scattered magic numbers with centralized `render.Z*` constants:
- ZBase (0): base content (revisions, diff, oplog, details)
- ZFuzzyInput (1): fuzzy inputs, revset list
- ZRevsetOverlay (2): revset overlay
- ZPreview (10): preview/split views
- ZDialogs (50): modal dialogs (undo/redo, input fields) - above preview
- ZMenuBorder/ZMenuContent (100/101): menus
- ZOverlay (200): flash/sequence overlays
- ZHelpPage (250): help page
- ZPassword (300): password modal

Also, in order to deal with confirmation in different render (`details`
vs `undo/redo`), WithZIndex is added for caller-specified z-index.
- Undo/redo use WithZIndex(ZDialogs) to render above preview.
- Details confirmation uses default ZBase to stay below preview.


This also fixes an issue with `confirmation` menu overlapping on preview:
<img width="1578" height="758" alt="image" src="https://github.com/user-attachments/assets/310e22bf-2a01-45ad-a035-77476716d48b" />
