### PR TITLE
feat: add create pull request feature to git menu

### DIFF
--- a/internal/browser/browser.go
+++ b/internal/browser/browser.go
@@ -1,0 +1,24 @@
+package browser
+
+import (
+	"os/exec"
+	"runtime"
+)
+
+func Open(url string) error {
+	var cmd *exec.Cmd
+
+	switch runtime.GOOS {
+	case "darwin":
+		cmd = exec.Command("open", url)
+	case "linux":
+		cmd = exec.Command("xdg-open", url)
+	case "windows":
+		cmd = exec.Command("cmd", "/c", "start", url)
+	default:
+		// Fall back to xdg-open for other Unix-like systems
+		cmd = exec.Command("xdg-open", url)
+	}
+
+	return cmd.Start()
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -281,7 +281,8 @@ func GetSuggestExecMode(c *Config) (SuggestMode, error) {
 }
 
 type GitConfig struct {
-	DefaultRemote string `toml:"default_remote"`
+	DefaultRemote       string `toml:"default_remote"`
+	DefaultTargetBranch string `toml:"default_target_branch"`
 }
 
 func GetGitDefaultRemote(c *Config) string {
@@ -290,6 +291,14 @@ func GetGitDefaultRemote(c *Config) string {
 		return "origin"
 	}
 	return remote
+}
+
+func GetGitDefaultTargetBranch(c *Config) string {
+	branch := c.Git.DefaultTargetBranch
+	if strings.TrimSpace(branch) == "" {
+		return "main"
+	}
+	return branch
 }
 
 type SshConfig struct {

--- a/internal/config/default/config.toml
+++ b/internal/config/default/config.toml
@@ -108,6 +108,7 @@ limit = 0
     mode = ["g"]
     push = ["p"]
     fetch = ["f"]
+    create_pr = ["r"]
   [keys.oplog]
     mode = ["o"]
     restore = ["r"]
@@ -153,6 +154,7 @@ limit = 0
 
 [git]
   default_remote = "origin"
+  default_target_branch = "main"
 
 [ssh]
   hijack_askpass = false

--- a/internal/config/keys.go
+++ b/internal/config/keys.go
@@ -116,9 +116,10 @@ func Convert(m KeyMappings[keys]) KeyMappings[key.Binding] {
 			Shrink:       key.NewBinding(key.WithKeys(m.Preview.Shrink...), key.WithHelp(JoinKeys(m.Preview.Shrink), "shrink width")),
 		},
 		Git: gitModeKeys[key.Binding]{
-			Mode:  key.NewBinding(key.WithKeys(m.Git.Mode...), key.WithHelp(JoinKeys(m.Git.Mode), "git")),
-			Push:  key.NewBinding(key.WithKeys(m.Git.Push...), key.WithHelp(JoinKeys(m.Git.Push), "git push")),
-			Fetch: key.NewBinding(key.WithKeys(m.Git.Fetch...), key.WithHelp(JoinKeys(m.Git.Fetch), "git fetch")),
+			Mode:     key.NewBinding(key.WithKeys(m.Git.Mode...), key.WithHelp(JoinKeys(m.Git.Mode), "git")),
+			Push:     key.NewBinding(key.WithKeys(m.Git.Push...), key.WithHelp(JoinKeys(m.Git.Push), "git push")),
+			Fetch:    key.NewBinding(key.WithKeys(m.Git.Fetch...), key.WithHelp(JoinKeys(m.Git.Fetch), "git fetch")),
+			CreatePR: key.NewBinding(key.WithKeys(m.Git.CreatePR...), key.WithHelp(JoinKeys(m.Git.CreatePR), "create PR")),
 		},
 		OpLog: opLogModeKeys[key.Binding]{
 			Mode:    key.NewBinding(key.WithKeys(m.OpLog.Mode...), key.WithHelp(JoinKeys(m.OpLog.Mode), "oplog")),
@@ -283,9 +284,10 @@ type detailsModeKeys[T any] struct {
 }
 
 type gitModeKeys[T any] struct {
-	Mode  T `toml:"mode"`
-	Push  T `toml:"push"`
-	Fetch T `toml:"fetch"`
+	Mode     T `toml:"mode"`
+	Push     T `toml:"push"`
+	Fetch    T `toml:"fetch"`
+	CreatePR T `toml:"create_pr"`
 }
 
 type previewModeKeys[T any] struct {

--- a/internal/git/provider/provider.go
+++ b/internal/git/provider/provider.go
@@ -1,0 +1,117 @@
+package provider
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+// BuildPRURL constructs a PR/MR creation URL for the given remote and branch.
+// Supports GitHub, GitLab, and Bitbucket. Returns empty string for unknown providers.
+func BuildPRURL(remoteURL, sourceBranch, targetBranch string) string {
+	host, owner, repo, ok := parseGitURL(remoteURL)
+	if !ok || sourceBranch == "" {
+		return ""
+	}
+	if targetBranch == "" {
+		targetBranch = "main"
+	}
+
+	baseURL := "https://" + host
+	hostLower := strings.ToLower(host)
+
+	switch {
+	case strings.Contains(hostLower, "github"):
+		return fmt.Sprintf("%s/%s/%s/compare/%s...%s?expand=1",
+			baseURL, owner, repo,
+			url.PathEscape(targetBranch),
+			url.PathEscape(sourceBranch))
+
+	case strings.Contains(hostLower, "gitlab"):
+		return fmt.Sprintf("%s/%s/%s/-/merge_requests/new?merge_request[source_branch]=%s&merge_request[target_branch]=%s",
+			baseURL, owner, repo,
+			url.QueryEscape(sourceBranch),
+			url.QueryEscape(targetBranch))
+
+	case strings.Contains(hostLower, "bitbucket"):
+		return fmt.Sprintf("%s/%s/%s/pull-requests/new?source=%s&dest=%s",
+			baseURL, owner, repo,
+			url.QueryEscape(sourceBranch),
+			url.QueryEscape(targetBranch))
+
+	default:
+		return ""
+	}
+}
+
+func ProviderName(remoteURL string) string {
+	host, _, _, ok := parseGitURL(remoteURL)
+	if !ok {
+		return ""
+	}
+	hostLower := strings.ToLower(host)
+
+	switch {
+	case strings.Contains(hostLower, "github"):
+		return "GitHub"
+	case strings.Contains(hostLower, "gitlab"):
+		return "GitLab"
+	case strings.Contains(hostLower, "bitbucket"):
+		return "Bitbucket"
+	default:
+		return ""
+	}
+}
+
+func parseGitURL(remoteURL string) (host, owner, repo string, ok bool) {
+	remoteURL = strings.TrimSpace(remoteURL)
+	if remoteURL == "" {
+		return "", "", "", false
+	}
+
+	// Detect SSH vs HTTPS: SSH has ":" but not "://"
+	if strings.Contains(remoteURL, ":") && !strings.Contains(remoteURL, "://") {
+		return parseSSHURL(remoteURL)
+	}
+	return parseHTTPSURL(remoteURL)
+}
+
+// parseSSHURL parses SSH-style URLs: [user@]host:owner/repo[.git]
+func parseSSHURL(remoteURL string) (host, owner, repo string, ok bool) {
+	parts := strings.SplitN(remoteURL, ":", 2)
+	if len(parts) != 2 {
+		return "", "", "", false
+	}
+
+	host = parts[0]
+	if idx := strings.LastIndex(host, "@"); idx != -1 {
+		host = host[idx+1:]
+	}
+
+	path := strings.TrimSuffix(parts[1], ".git")
+	pathParts := strings.Split(path, "/")
+	if len(pathParts) < 2 {
+		return "", "", "", false
+	}
+
+	return host, pathParts[0], pathParts[1], true
+}
+
+// parseHTTPSURL parses HTTPS-style URLs: https://host/owner/repo[.git]
+func parseHTTPSURL(remoteURL string) (host, owner, repo string, ok bool) {
+	parsed, err := url.Parse(remoteURL)
+	if err != nil {
+		return "", "", "", false
+	}
+
+	host = parsed.Host
+	path := strings.TrimPrefix(parsed.Path, "/")
+	path = strings.TrimSuffix(path, ".git")
+	parts := strings.Split(path, "/")
+
+	if len(parts) < 2 {
+		return "", "", "", false
+	}
+
+	return host, parts[0], parts[1], true
+}

--- a/internal/git/provider/provider_test.go
+++ b/internal/git/provider/provider_test.go
@@ -1,0 +1,166 @@
+package provider
+
+import (
+	"testing"
+)
+
+func TestBuildPRURL(t *testing.T) {
+	tests := []struct {
+		name         string
+		remoteURL    string
+		sourceBranch string
+		targetBranch string
+		expected     string
+	}{
+		{
+			name:         "GitHub SSH",
+			remoteURL:    "git@github.com:owner/repo.git",
+			sourceBranch: "feature",
+			targetBranch: "main",
+			expected:     "https://github.com/owner/repo/compare/main...feature?expand=1",
+		},
+		{
+			name:         "GitHub HTTPS",
+			remoteURL:    "https://github.com/owner/repo.git",
+			sourceBranch: "feature",
+			targetBranch: "main",
+			expected:     "https://github.com/owner/repo/compare/main...feature?expand=1",
+		},
+		{
+			name:         "GitHub default target branch",
+			remoteURL:    "git@github.com:owner/repo.git",
+			sourceBranch: "feature",
+			targetBranch: "",
+			expected:     "https://github.com/owner/repo/compare/main...feature?expand=1",
+		},
+		{
+			name:         "GitLab SSH",
+			remoteURL:    "git@gitlab.com:owner/repo.git",
+			sourceBranch: "feature",
+			targetBranch: "main",
+			expected:     "https://gitlab.com/owner/repo/-/merge_requests/new?merge_request[source_branch]=feature&merge_request[target_branch]=main",
+		},
+		{
+			name:         "GitLab HTTPS",
+			remoteURL:    "https://gitlab.com/owner/repo.git",
+			sourceBranch: "feature",
+			targetBranch: "main",
+			expected:     "https://gitlab.com/owner/repo/-/merge_requests/new?merge_request[source_branch]=feature&merge_request[target_branch]=main",
+		},
+		{
+			name:         "Bitbucket SSH",
+			remoteURL:    "git@bitbucket.org:owner/repo.git",
+			sourceBranch: "feature",
+			targetBranch: "main",
+			expected:     "https://bitbucket.org/owner/repo/pull-requests/new?source=feature&dest=main",
+		},
+		{
+			name:         "Bitbucket HTTPS",
+			remoteURL:    "https://bitbucket.org/owner/repo.git",
+			sourceBranch: "feature",
+			targetBranch: "main",
+			expected:     "https://bitbucket.org/owner/repo/pull-requests/new?source=feature&dest=main",
+		},
+		{
+			name:         "Branch with slash",
+			remoteURL:    "git@github.com:owner/repo.git",
+			sourceBranch: "feature/my-feature",
+			targetBranch: "main",
+			expected:     "https://github.com/owner/repo/compare/main...feature%2Fmy-feature?expand=1",
+		},
+		{
+			name:         "Unknown provider",
+			remoteURL:    "git@example.com:owner/repo.git",
+			sourceBranch: "feature",
+			targetBranch: "main",
+			expected:     "",
+		},
+		{
+			name:         "Empty remote URL",
+			remoteURL:    "",
+			sourceBranch: "feature",
+			targetBranch: "main",
+			expected:     "",
+		},
+		{
+			name:         "Empty source branch",
+			remoteURL:    "git@github.com:owner/repo.git",
+			sourceBranch: "",
+			targetBranch: "main",
+			expected:     "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := BuildPRURL(tt.remoteURL, tt.sourceBranch, tt.targetBranch)
+			if result != tt.expected {
+				t.Errorf("BuildPRURL() = %q, want %q", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestProviderName(t *testing.T) {
+	tests := []struct {
+		name      string
+		remoteURL string
+		expected  string
+	}{
+		{"GitHub SSH", "git@github.com:owner/repo.git", "GitHub"},
+		{"GitHub HTTPS", "https://github.com/owner/repo.git", "GitHub"},
+		{"GitHub Enterprise", "git@github.mycompany.com:owner/repo.git", "GitHub"},
+		{"GitLab SSH", "git@gitlab.com:owner/repo.git", "GitLab"},
+		{"GitLab HTTPS", "https://gitlab.com/owner/repo.git", "GitLab"},
+		{"Bitbucket SSH", "git@bitbucket.org:owner/repo.git", "Bitbucket"},
+		{"Bitbucket HTTPS", "https://bitbucket.org/owner/repo.git", "Bitbucket"},
+		{"Unknown", "git@example.com:owner/repo.git", ""},
+		{"Empty", "", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ProviderName(tt.remoteURL)
+			if result != tt.expected {
+				t.Errorf("ProviderName() = %q, want %q", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestParseGitURL(t *testing.T) {
+	tests := []struct {
+		name          string
+		url           string
+		expectedHost  string
+		expectedOwner string
+		expectedRepo  string
+		expectOk      bool
+	}{
+		{"GitHub SSH", "git@github.com:owner/repo.git", "github.com", "owner", "repo", true},
+		{"GitHub SSH no .git", "git@github.com:owner/repo", "github.com", "owner", "repo", true},
+		{"GitHub HTTPS", "https://github.com/owner/repo.git", "github.com", "owner", "repo", true},
+		{"GitHub HTTPS no .git", "https://github.com/owner/repo", "github.com", "owner", "repo", true},
+		{"With dashes", "git@github.com:my-org/my-repo.git", "github.com", "my-org", "my-repo", true},
+		{"Empty URL", "", "", "", "", false},
+		{"Invalid URL", "not-a-url", "", "", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			host, owner, repo, ok := parseGitURL(tt.url)
+			if ok != tt.expectOk {
+				t.Errorf("parseGitURL() ok = %v, want %v", ok, tt.expectOk)
+			}
+			if host != tt.expectedHost {
+				t.Errorf("parseGitURL() host = %q, want %q", host, tt.expectedHost)
+			}
+			if owner != tt.expectedOwner {
+				t.Errorf("parseGitURL() owner = %q, want %q", owner, tt.expectedOwner)
+			}
+			if repo != tt.expectedRepo {
+				t.Errorf("parseGitURL() repo = %q, want %q", repo, tt.expectedRepo)
+			}
+		})
+	}
+}

--- a/internal/jj/remote_parser.go
+++ b/internal/jj/remote_parser.go
@@ -7,6 +7,11 @@ import (
 	"github.com/idursun/jjui/internal/config"
 )
 
+type RemoteInfo struct {
+	Name string
+	URL  string
+}
+
 func ParseRemoteListOutput(output string) []string {
 	defaultRemote := config.GetGitDefaultRemote(config.Current)
 	remotes := []string{}
@@ -18,6 +23,42 @@ func ParseRemoteListOutput(output string) []string {
 	// Move defaultRemote to front if present
 	if i := slices.Index(remotes, defaultRemote); i >= 0 {
 		remotes = append([]string{defaultRemote}, append(remotes[:i], remotes[i+1:]...)...)
+	}
+	return remotes
+}
+
+// ParseRemoteListOutputFull parses `jj git remote list` output and returns
+// both name and URL for each remote. The output format is:
+// remote_name URL
+func ParseRemoteListOutputFull(output string) []RemoteInfo {
+	defaultRemote := config.GetGitDefaultRemote(config.Current)
+	var remotes []RemoteInfo
+	for line := range strings.SplitSeq(strings.TrimSpace(output), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) >= 2 {
+			remotes = append(remotes, RemoteInfo{
+				Name: fields[0],
+				URL:  fields[1],
+			})
+		} else if len(fields) == 1 {
+			// Handle case where only name is present (shouldn't happen but be safe)
+			remotes = append(remotes, RemoteInfo{
+				Name: fields[0],
+				URL:  "",
+			})
+		}
+	}
+	// Move defaultRemote to front if present
+	idx := slices.IndexFunc(remotes, func(r RemoteInfo) bool {
+		return r.Name == defaultRemote
+	})
+	if idx > 0 {
+		defaultInfo := remotes[idx]
+		remotes = append([]RemoteInfo{defaultInfo}, append(remotes[:idx], remotes[idx+1:]...)...)
 	}
 	return remotes
 }

--- a/internal/jj/remote_parser_test.go
+++ b/internal/jj/remote_parser_test.go
@@ -46,3 +46,54 @@ func TestParseRemoteListOutput(t *testing.T) {
 		})
 	}
 }
+
+func TestParseRemoteListOutputFull(t *testing.T) {
+	tests := []struct {
+		name     string
+		output   string
+		expected []RemoteInfo
+	}{
+		{
+			name:   "single remote",
+			output: "origin https://github.com/user/repo.git\n",
+			expected: []RemoteInfo{
+				{Name: "origin", URL: "https://github.com/user/repo.git"},
+			},
+		},
+		{
+			name:   "multiple remotes",
+			output: "origin https://github.com/user/repo.git\nupstream https://github.com/upstream/repo.git\n",
+			expected: []RemoteInfo{
+				{Name: "origin", URL: "https://github.com/user/repo.git"},
+				{Name: "upstream", URL: "https://github.com/upstream/repo.git"},
+			},
+		},
+		{
+			name:     "empty output",
+			output:   "",
+			expected: nil,
+		},
+		{
+			name:   "SSH URL",
+			output: "origin git@github.com:user/repo.git\n",
+			expected: []RemoteInfo{
+				{Name: "origin", URL: "git@github.com:user/repo.git"},
+			},
+		},
+		{
+			name:   "mixed URLs",
+			output: "origin https://github.com/user/repo.git\nupstream git@gitlab.com:upstream/repo.git\n",
+			expected: []RemoteInfo{
+				{Name: "origin", URL: "https://github.com/user/repo.git"},
+				{Name: "upstream", URL: "git@gitlab.com:upstream/repo.git"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ParseRemoteListOutputFull(tt.output)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/internal/ui/helppage/help_item_groups.go
+++ b/internal/ui/helppage/help_item_groups.go
@@ -199,6 +199,7 @@ func (h *Model) buildRightGroups() menuColumn {
 			h.newModeItem(&h.keyMap.Git.Mode, "Git"),
 			h.newBindingItem(h.keyMap.Git.Push),
 			h.newBindingItem(h.keyMap.Git.Fetch),
+			h.newBindingItem(h.keyMap.Git.CreatePR),
 			helpItem{"", ""},
 		},
 		itemGroup{

--- a/internal/ui/intents/ui_intents.go
+++ b/internal/ui/intents/ui_intents.go
@@ -73,6 +73,7 @@ type GitFilterKind string
 const (
 	GitFilterPush  GitFilterKind = "push"
 	GitFilterFetch GitFilterKind = "fetch"
+	GitFilterPR    GitFilterKind = "pr"
 )
 
 type GitFilter struct {


### PR DESCRIPTION
This PR adds the ability to create pull requests directly from jjui’s git menu proposed in #240. When a bookmark has been pushed to a remote, users can open the PR/MR creation page in their default browser. Currently, this PR supports GitHub, GitLab, and Bitbucket as providers.

The default branch can be configured via `config.toml` and is set to `main` by default.

How it works
- Open the git menu with `g`
- Press `r` to filter PR-related items
- Select a bookmark that has been pushed to a remote to open the PR creation page

https://github.com/user-attachments/assets/e7b699fb-2ef2-46aa-9afc-661985dbdd5c

edit: added the issue where this feature was proposed