### PR TITLE
feat: add interactive split for files in details view

### DIFF
--- a/internal/jj/commands.go
+++ b/internal/jj/commands.go
@@ -82,10 +82,13 @@ func DiffEdit(changeId string) CommandArgs {
 	return []string{"diffedit", "-r", changeId}
 }
 
-func Split(revision string, files []string, parallel bool) CommandArgs {
+func Split(revision string, files []string, parallel bool, interactive bool) CommandArgs {
 	args := []string{"split", "-r", revision}
 	if parallel {
 		args = append(args, "--parallel")
+	}
+	if interactive {
+		args = append(args, "--interactive")
 	}
 	var escapedFiles []string
 	for _, file := range files {
@@ -132,21 +135,16 @@ func Diff(revision string, fileName string, extraArgs ...string) CommandArgs {
 	return args
 }
 
-func Restore(revision string, files []string) CommandArgs {
+func Restore(revision string, files []string, interactive bool) CommandArgs {
 	args := []string{"restore", "-c", revision}
+	if interactive {
+		args = append(args, "--interactive")
+	}
 	var escapedFiles []string
 	for _, file := range files {
 		escapedFiles = append(escapedFiles, EscapeFileName(file))
 	}
 	args = append(args, escapedFiles...)
-	return args
-}
-
-func RestoreInteractive(revision string, file string) CommandArgs {
-	args := []string{"restore", "-c", revision, "--interactive"}
-	if file != "" {
-		args = append(args, EscapeFileName(file))
-	}
 	return args
 }
 

--- a/internal/ui/intents/details_intents.go
+++ b/internal/ui/intents/details_intents.go
@@ -15,7 +15,8 @@ type DetailsDiff struct{}
 func (DetailsDiff) isIntent() {}
 
 type DetailsSplit struct {
-	IsParallel bool
+	IsParallel    bool
+	IsInteractive bool
 }
 
 func (DetailsSplit) isIntent() {}

--- a/internal/ui/intents/revisions_intents.go
+++ b/internal/ui/intents/revisions_intents.go
@@ -53,9 +53,10 @@ type ShowDiff struct {
 func (ShowDiff) isIntent() {}
 
 type StartSplit struct {
-	Selected   *jj.Commit
-	IsParallel bool
-	Files      []string
+	Selected      *jj.Commit
+	IsParallel    bool
+	IsInteractive bool
+	Files         []string
 }
 
 func (StartSplit) isIntent() {}

--- a/internal/ui/operations/details/details.go
+++ b/internal/ui/operations/details/details.go
@@ -202,8 +202,11 @@ func (s *Operation) handleIntent(intent intents.Intent) tea.Cmd {
 			[]string{"Are you sure you want to split the selected files?"},
 			confirmation.WithStylePrefix("revisions"),
 			confirmation.WithOption("Yes",
-				tea.Batch(s.context.RunInteractiveCommand(jj.Split(s.revision.GetChangeId(), selectedFiles, intent.IsParallel), common.Refresh), common.Close),
+				tea.Batch(s.context.RunInteractiveCommand(jj.Split(s.revision.GetChangeId(), selectedFiles, intent.IsParallel, false), common.Refresh), common.Close),
 				key.NewBinding(key.WithKeys("y"), key.WithHelp("y", "yes"))),
+			confirmation.WithOption("Interactive",
+				tea.Batch(s.context.RunInteractiveCommand(jj.Split(s.revision.GetChangeId(), selectedFiles, intent.IsParallel, true), common.Refresh), common.Close),
+				key.NewBinding(key.WithKeys("i"), key.WithHelp("i", "interactive"))),
 			confirmation.WithOption("No",
 				confirmation.Close,
 				key.NewBinding(key.WithKeys("n", "esc"), key.WithHelp("n/esc", "no"))),
@@ -219,17 +222,16 @@ func (s *Operation) handleIntent(intent intents.Intent) tea.Cmd {
 		}
 	case intents.DetailsRestore:
 		selectedFiles := s.getSelectedFiles(true)
-		selected := s.current()
 		s.selectedHint = "gets restored"
 		s.unselectedHint = "stays as is"
 		model := confirmation.New(
 			[]string{"Are you sure you want to restore the selected files?"},
 			confirmation.WithStylePrefix("revisions"),
 			confirmation.WithOption("Yes",
-				s.context.RunCommand(jj.Restore(s.revision.GetChangeId(), selectedFiles), common.Refresh, confirmation.Close),
+				s.context.RunCommand(jj.Restore(s.revision.GetChangeId(), selectedFiles, false), common.Refresh, confirmation.Close),
 				key.NewBinding(key.WithKeys("y"), key.WithHelp("y", "yes"))),
 			confirmation.WithOption("Interactive",
-				tea.Batch(s.context.RunInteractiveCommand(jj.RestoreInteractive(s.revision.GetChangeId(), selected.fileName), common.Refresh), common.Close),
+				tea.Batch(s.context.RunInteractiveCommand(jj.Restore(s.revision.GetChangeId(), selectedFiles, true), common.Refresh), common.Close),
 				key.NewBinding(key.WithKeys("i"), key.WithHelp("i", "interactive"))),
 			confirmation.WithOption("No",
 				confirmation.Close,

--- a/internal/ui/operations/details/details_test.go
+++ b/internal/ui/operations/details/details_test.go
@@ -38,7 +38,7 @@ func TestModel_Update_RestoresSelectedFiles(t *testing.T) {
 	commandRunner := test.NewTestCommandRunner(t)
 	commandRunner.Expect(jj.Snapshot())
 	commandRunner.Expect(jj.Status(Revision)).SetOutput([]byte(StatusOutput))
-	commandRunner.Expect(jj.Restore(Revision, []string{"file.txt"}))
+	commandRunner.Expect(jj.Restore(Revision, []string{"file.txt"}, false))
 	defer commandRunner.Verify()
 
 	model := NewOperation(test.NewTestContext(commandRunner), Commit)
@@ -54,7 +54,7 @@ func TestModel_Update_RestoresInteractively(t *testing.T) {
 	commandRunner := test.NewTestCommandRunner(t)
 	commandRunner.Expect(jj.Snapshot())
 	commandRunner.Expect(jj.Status(Revision)).SetOutput([]byte(StatusOutput))
-	commandRunner.Expect(jj.RestoreInteractive(Revision, "file.txt"))
+	commandRunner.Expect(jj.Restore(Revision, []string{"file.txt"}, true))
 	defer commandRunner.Verify()
 
 	model := NewOperation(test.NewTestContext(commandRunner), Commit)
@@ -67,7 +67,7 @@ func TestModel_Update_SplitsSelectedFiles(t *testing.T) {
 	commandRunner := test.NewTestCommandRunner(t)
 	commandRunner.Expect(jj.Snapshot())
 	commandRunner.Expect(jj.Status(Revision)).SetOutput([]byte(StatusOutput))
-	commandRunner.Expect(jj.Split(Revision, []string{"file.txt"}, false))
+	commandRunner.Expect(jj.Split(Revision, []string{"file.txt"}, false, false))
 	defer commandRunner.Verify()
 
 	model := NewOperation(test.NewTestContext(commandRunner), Commit)
@@ -83,7 +83,7 @@ func TestModel_Update_ParallelSplitsSelectedFiles(t *testing.T) {
 	commandRunner := test.NewTestCommandRunner(t)
 	commandRunner.Expect(jj.Snapshot())
 	commandRunner.Expect(jj.Status(Revision)).SetOutput([]byte(StatusOutput))
-	commandRunner.Expect(jj.Split(Revision, []string{"file.txt"}, true))
+	commandRunner.Expect(jj.Split(Revision, []string{"file.txt"}, true, false))
 	defer commandRunner.Verify()
 
 	model := NewOperation(test.NewTestContext(commandRunner), Commit)
@@ -101,7 +101,7 @@ func TestModel_Update_HandlesMovedFiles(t *testing.T) {
 	commandRunner := test.NewTestCommandRunner(t)
 	commandRunner.Expect(jj.Snapshot())
 	commandRunner.Expect(jj.Status(Revision)).SetOutput([]byte("false false $\nR internal/ui/{revisions => }/file.go\nR {file => sub/newfile}\n"))
-	commandRunner.Expect(jj.Restore(Revision, []string{"internal/ui/file.go", "sub/newfile"}))
+	commandRunner.Expect(jj.Restore(Revision, []string{"internal/ui/file.go", "sub/newfile"}, false))
 	defer commandRunner.Verify()
 
 	model := NewOperation(test.NewTestContext(commandRunner), Commit)
@@ -118,7 +118,7 @@ func TestModel_Update_HandlesMovedFilesInDeepDirectories(t *testing.T) {
 	commandRunner := test.NewTestCommandRunner(t)
 	commandRunner.Expect(jj.Snapshot())
 	commandRunner.Expect(jj.Status(Revision)).SetOutput([]byte("false false false $\nR {src/new_file_3.md => new_file.md}\nR src/{new_file.py => renamed_py.py}\nR {src1/to_be_renamed.md => src2/renamed.md}\n"))
-	commandRunner.Expect(jj.Restore(Revision, []string{"new_file.md", "src/renamed_py.py", "src2/renamed.md"}))
+	commandRunner.Expect(jj.Restore(Revision, []string{"new_file.md", "src/renamed_py.py", "src2/renamed.md"}, false))
 	defer commandRunner.Verify()
 
 	model := NewOperation(test.NewTestContext(commandRunner), Commit)
@@ -136,7 +136,7 @@ func TestModel_Update_HandlesFilenamesWithBraces(t *testing.T) {
 	commandRunner := test.NewTestCommandRunner(t)
 	commandRunner.Expect(jj.Snapshot())
 	commandRunner.Expect(jj.Status(Revision)).SetOutput([]byte("false false $\nM file{with}braces.txt\nA another{test}.go\n"))
-	commandRunner.Expect(jj.Restore(Revision, []string{"file{with}braces.txt", "another{test}.go"}))
+	commandRunner.Expect(jj.Restore(Revision, []string{"file{with}braces.txt", "another{test}.go"}, false))
 	defer commandRunner.Verify()
 
 	model := NewOperation(test.NewTestContext(commandRunner), Commit)

--- a/internal/ui/revisions/revisions.go
+++ b/internal/ui/revisions/revisions.go
@@ -871,7 +871,7 @@ func (m *Model) startSplit(intent intents.StartSplit) tea.Cmd {
 	if commit == nil {
 		return nil
 	}
-	return m.context.RunInteractiveCommand(jj.Split(commit.GetChangeId(), intent.Files, intent.IsParallel), common.Refresh)
+	return m.context.RunInteractiveCommand(jj.Split(commit.GetChangeId(), intent.Files, intent.IsParallel, intent.IsInteractive), common.Refresh)
 }
 
 func (m *Model) updateSelection() tea.Cmd {


### PR DESCRIPTION

- Add `interactive` to `Split` and `Restore` command builders
- Remove `SplitInteractive` and `RestoreInteractive` functions as they
  are now redundant
- Add `IsInteractive` field to `StartSplit` and `DetailsSplit` intents
  for future keybinding support
