### PR TITLE
fix: pretty-print left/right keys

### DIFF
--- a/internal/config/keys.go
+++ b/internal/config/keys.go
@@ -153,6 +153,10 @@ func JoinKeys(keys []string) string {
 			k = "↑"
 		case "down":
 			k = "↓"
+		case "left":
+			k = "←"
+		case "right":
+			k = "→"
 		case " ":
 			k = "space"
 		}


### PR DESCRIPTION
This PR makes the legend render all arrow keys (instead of just up and down).

i.e. I now see:

    normal    ↑/k up • ↓/j down • q quit • ? help • ctrl+r refresh • p preview • L revset • →/l details

instead of:

    normal    ↑/k up • ↓/j down • q quit • ? help • ctrl+r refresh • p preview • L revset • right/l details