### PR TITLE
fix: close restore confirmation by batching instead of sequencing

### DIFF
--- a/internal/ui/operations/details/details.go
+++ b/internal/ui/operations/details/details.go
@@ -233,7 +233,7 @@ func (s *Operation) handleIntent(intent intents.Intent) tea.Cmd {
 			[]string{"Are you sure you want to restore the selected files?"},
 			confirmation.WithStylePrefix("revisions"),
 			confirmation.WithOption("Yes",
-				s.context.RunCommand(jj.Restore(s.revision.GetChangeId(), selectedFiles, false), common.Refresh, confirmation.Close),
+				tea.Batch(s.context.RunCommand(jj.Restore(s.revision.GetChangeId(), selectedFiles, false), common.Refresh), confirmation.Close),
 				key.NewBinding(key.WithKeys("y"), key.WithHelp("y", "yes"))),
 			confirmation.WithOption("Interactive",
 				tea.Batch(s.context.RunInteractiveCommand(jj.Restore(s.revision.GetChangeId(), selectedFiles, true), common.Refresh), common.Close),


### PR DESCRIPTION
Right now, the confirmation dialog stays open after a restore operation.
this behavior is undesirable and different from before

this change moves confirmation.Close out of RunCommand's tea.Sequence
continuation and into a tea.Batch so the CloseMsg fires immediately,
ensuring the confirmation dialog closes while keeping the details panel
open.
