### PR TITLE
fix(status): remove extra gap above status line during file fzf

### DIFF
--- a/internal/ui/status/status.go
+++ b/internal/ui/status/status.go
@@ -352,7 +352,7 @@ func (m *Model) renderFuzzyOverlay(dl *render.DisplayContext, box layout.Box) {
 	if m.fuzzy == nil {
 		return
 	}
-	overlayRect := cellbuf.Rect(box.R.Min.X, 0, box.R.Dx(), box.R.Min.Y-1)
+	overlayRect := cellbuf.Rect(box.R.Min.X, 0, box.R.Dx(), box.R.Min.Y)
 	m.fuzzy.ViewRect(dl, layout.Box{R: overlayRect})
 }
 


### PR DESCRIPTION
an extra `-1` is introduced in https://github.com/idursun/jjui/blob/8b29b21273ce6a23e679e806ce47e843965786ce/internal/ui/status/status.go#L256

which causes a gap to be rendered between fzf file list and status line

<img width="736" height="261" alt="image" src="https://github.com/user-attachments/assets/d50ae019-043f-44ad-8a13-b5c89a5c2684" />

removed `-1` and ran this build for a weekend, didn't notice anything breaking