### PR TITLE
fix(details): reload when selection changes

### DIFF
--- a/internal/ui/operations/details/details.go
+++ b/internal/ui/operations/details/details.go
@@ -303,6 +303,13 @@ func (s *Operation) ViewRect(dl *render.DisplayContext, box layout.Box) {
 
 func (s *Operation) SetSelectedRevision(commit *jj.Commit) tea.Cmd {
 	s.Current = commit
+	if commit == nil {
+		return nil
+	}
+	if s.revision == nil || s.revision.GetChangeId() != commit.GetChangeId() {
+		s.revision = commit
+		return s.load(commit.GetChangeId())
+	}
 	return nil
 }
 


### PR DESCRIPTION
when current revision is `abc` and details is open, and the user run 
`jj abandon abc`, after `abc` is abandoned, the command run for `Log`
is still fetching `abc`. and error 'Error: Change ID prefix `abc` is
ambiguous' is shown

this change refreshes revision with latest ChangeID
