### PR TITLE
fix(preview): update preview window after squash operation

### DIFF
--- a/internal/ui/revisions/revisions.go
+++ b/internal/ui/revisions/revisions.go
@@ -577,7 +577,7 @@ func (m *Model) startSquash(intent intents.StartSquash) tea.Cmd {
 		m.SetCursor(m.cursor + 1)
 	}
 	m.op = squash.NewOperation(m.context, selected, squash.WithFiles(intent.Files))
-	return m.op.Init()
+	return tea.Batch(m.op.Init(), m.updateSelection())
 }
 
 func (m *Model) startRebase(intent intents.StartRebase) tea.Cmd {


### PR DESCRIPTION
Root cause: startSquash() called SetCursor() to move to the parent revision
but never emitted a SelectionChangedMsg. The preview panel only refreshes
when it receives that message, so it stayed stale until the user pressed
j/k which does emit the message via updateSelection().

Fix: batch updateSelection() alongside the operation init command in
startSquash(), matching the pattern used by all other cursor-moving
operations.

Closes #516
