### PR TITLE
fix(ui/git): update key for `jj git fetch --tracked`

### DIFF
--- a/internal/ui/git/git.go
+++ b/internal/ui/git/git.go
@@ -751,7 +751,7 @@ func (m *Model) createMenuItems() []item {
 			name:     fmt.Sprintf("git fetch --tracked --remote %s", selectedRemote),
 			desc:     "Fetch from remote",
 			command:  jj.GitFetch("--tracked", "--remote", selectedRemote),
-			category: itemCategoryFetch, key: "f",
+			category: itemCategoryFetch, key: "t",
 		},
 		item{
 			name:     "git fetch --all-remotes",


### PR DESCRIPTION
Noticed that both the default fetch and the tracked options are set to use the key `f`.

I'm assuming that's not intended. This PR updates it to use the key `t` similar to how `jj git push --tracked` is configured.