### PR TITLE
feat(evolog): change default evolog command to show interdiff

### DIFF
--- a/internal/config/default/config.toml
+++ b/internal/config/default/config.toml
@@ -22,7 +22,7 @@ binding_profile = ":builtin"
 
 [preview]
   revision_command = ["show", "--color", "always", "-r", "$change_id"]
-  evolog_command = ["show", "--color", "always", "-r", "$commit_id"]
+  evolog_command = ["evolog", "--color", "always", "-r", "$commit_id", "-p", "-n", "1"]
   oplog_command = ["op", "show", "$operation_id", "--color", "always"]
   file_command = ["diff", "--color", "always", "-r", "$change_id", "$file"]
   position = "auto"


### PR DESCRIPTION
The default `jj evolog -p` output shows interdiff output instead of showing the whole diff after applying all versions of the commit. This change to the configuration for `evolog_command` suggested by @nickchomey replicates that behavior for the preview window.

This is a change to peoples' workflow, but you can still view the full diff for an evolog entry by pressing `d` (or restoring the old `evolog_command` value in your configuration, which was the same as `revision_command`).

Closes #227
Closes #464