### PR TITLE
fix: add back `esc` to clear checked revisions

### DIFF
--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -652,7 +652,7 @@ func (m *Model) routeCancel(owner string, cancel intents.Cancel) tea.Cmd {
 	}
 
 	if m.shouldRouteCancelToRevisions() {
-		if cmd, handled := m.revisions.HandleDispatchedAction("revisions.cancel", nil); handled {
+		if cmd, handled := m.revisions.HandleDispatchedAction(actions.UiCancel, nil); handled {
 			return cmd
 		}
 	}


### PR DESCRIPTION
Previously, the `esc` key would clear the checked revisions. Adding back
this functionality here
