### PR TITLE
feat: add change_offset in jj log prefix template for divergent revisions

### DIFF
--- a/internal/jj/commands.go
+++ b/internal/jj/commands.go
@@ -53,7 +53,7 @@ func Log(revset string, limit int, jjTemplate string) CommandArgs {
 		template = jjTemplate
 	}
 	prefix := fmt.Sprintf(
-		"stringify('%s' ++ separate('%s', change_id.shortest(), commit_id.shortest(), divergent))",
+		"stringify('%s' ++ separate('%s', change_id.shortest() ++ if(divergent, \"/\" ++ change_offset), commit_id.shortest(), divergent))",
 		JJUIPrefix, JJUIPrefix)
 	template = fmt.Sprintf("%s ++ ' ' ++ %s", prefix, template)
 	args = append(args, "-T", template)

--- a/internal/jj/commit.go
+++ b/internal/jj/commit.go
@@ -1,7 +1,5 @@
 package jj
 
-import "strings"
-
 const (
 	RootChangeId = "zzzzzzzz"
 )
@@ -17,12 +15,8 @@ func (c Commit) IsRoot() bool {
 	return c.ChangeId == RootChangeId
 }
 
-func (c Commit) IsConflicting() bool {
-	return strings.HasSuffix(c.ChangeId, "??")
-}
-
 func (c Commit) GetChangeId() string {
-	if c.Hidden || c.IsConflicting() {
+	if c.Hidden {
 		return c.CommitId
 	}
 	return c.ChangeId

--- a/internal/parser/streaming_log_parser.go
+++ b/internal/parser/streaming_log_parser.go
@@ -2,7 +2,6 @@ package parser
 
 import (
 	"io"
-	"strings"
 	"unicode/utf8"
 
 	"github.com/idursun/jjui/internal/screen"
@@ -29,7 +28,7 @@ func ParseRowsStreaming(reader io.Reader, controlChannel <-chan ControlMsg, batc
 		rawSegments := screen.ParseFromReader(reader)
 		for segmentedLine := range screen.BreakNewLinesIter(rawSegments) {
 			rowLine := NewGraphRowLine(segmentedLine)
-			changeIDIdx, changeID, commitID, isDivergent := rowLine.ParseRowPrefixes()
+			changeIDIdx, changeID, commitID, _ := rowLine.ParseRowPrefixes()
 			if changeIDIdx != -1 && changeIDIdx != len(rowLine.Segments)-1 {
 				rowLine.Flags = Revision | Highlightable
 				previousRow := row
@@ -52,18 +51,6 @@ func ParseRowsStreaming(reader io.Reader, controlChannel <-chan ControlMsg, batc
 				}
 				row.Commit.ChangeId = changeID
 				row.Commit.CommitId = commitID
-
-				if isDivergent {
-					fullChangeID := ""
-					for nextIdx := changeIDIdx; nextIdx < len(rowLine.Segments); nextIdx++ {
-						nextSegment := strings.TrimSpace(rowLine.Segments[nextIdx].Text)
-						fullChangeID += nextSegment
-						if nextSegment == "" || strings.HasPrefix(nextSegment, "/") || strings.HasSuffix(nextSegment, "??") {
-							break
-						}
-					}
-					row.Commit.ChangeId = fullChangeID
-				}
 			}
 			row.AddLine(&rowLine)
 		}

--- a/internal/ui/operations/ace_jump/operation.go
+++ b/internal/ui/operations/ace_jump/operation.go
@@ -160,7 +160,7 @@ func (o *Operation) findAceKeys() *AceJump {
 			continue
 		}
 		aj.Append(i, c.CommitId, 0)
-		if c.Hidden || c.IsConflicting() || c.IsRoot() {
+		if c.Hidden || c.IsRoot() {
 			continue
 		}
 		aj.Append(i, c.ChangeId, 0)

--- a/test/log_parser_test.go
+++ b/test/log_parser_test.go
@@ -73,12 +73,9 @@ func TestParser_Parse_ConflictedLongIds(t *testing.T) {
 	file, _ := os.Open("testdata/conflicted-change-id.log")
 	rows := parser.ParseRows(file)
 	assert.Len(t, rows, 3)
-	assert.Equal(t, "p??", rows[0].Commit.ChangeId)
-	assert.Equal(t, true, rows[0].Commit.IsConflicting())
-	assert.Equal(t, "qusvoztl??", rows[1].Commit.ChangeId)
-	assert.Equal(t, true, rows[1].Commit.IsConflicting())
-	assert.Equal(t, "tyoqvzlm??", rows[2].Commit.ChangeId)
-	assert.Equal(t, true, rows[2].Commit.IsConflicting())
+	assert.Equal(t, "p/0", rows[0].Commit.ChangeId)
+	assert.Equal(t, "q/0", rows[1].Commit.ChangeId)
+	assert.Equal(t, "t/0", rows[2].Commit.ChangeId)
 }
 
 func TestParser_Parse_Disconnected(t *testing.T) {
@@ -157,24 +154,20 @@ func TestParser_DivergentChangeID(t *testing.T) {
 	file, _ := os.Open("testdata/divergent-change-id.log")
 	rows := parser.ParseRows(file)
 	assert.Len(t, rows, 2)
-	assert.Equal(t, "omvxtumm??", rows[0].Commit.ChangeId)
+	assert.Equal(t, "omv/0", rows[0].Commit.ChangeId)
 	assert.Equal(t, "f99", rows[0].Commit.CommitId)
-	assert.Equal(t, true, rows[0].Commit.IsConflicting())
-	assert.Equal(t, "omvxtumm??", rows[1].Commit.ChangeId)
+	assert.Equal(t, "omv/1", rows[1].Commit.ChangeId)
 	assert.Equal(t, "43bd", rows[1].Commit.CommitId)
-	assert.Equal(t, true, rows[1].Commit.IsConflicting())
 }
 
 func TestParser_DivergentChangeIDShort(t *testing.T) {
 	file, _ := os.Open("testdata/divergent-short-change-id.log")
 	rows := parser.ParseRows(file)
 	assert.Len(t, rows, 2)
-	assert.Equal(t, "omv??", rows[0].Commit.ChangeId)
+	assert.Equal(t, "omv/0", rows[0].Commit.ChangeId)
 	assert.Equal(t, "f99", rows[0].Commit.CommitId)
-	assert.Equal(t, true, rows[0].Commit.IsConflicting())
-	assert.Equal(t, "omv??", rows[1].Commit.ChangeId)
+	assert.Equal(t, "omv/1", rows[1].Commit.ChangeId)
 	assert.Equal(t, "43bd", rows[1].Commit.CommitId)
-	assert.Equal(t, true, rows[1].Commit.IsConflicting())
 }
 
 func TestParser_ChangeIDCommitIDSameColor(t *testing.T) {
@@ -183,13 +176,10 @@ func TestParser_ChangeIDCommitIDSameColor(t *testing.T) {
 	assert.Len(t, rows, 3)
 	assert.Equal(t, "vvr", rows[0].Commit.ChangeId)
 	assert.Equal(t, "ae", rows[0].Commit.CommitId)
-	assert.Equal(t, false, rows[0].Commit.IsConflicting())
 	assert.Equal(t, "l", rows[1].Commit.ChangeId)
 	assert.Equal(t, "6e", rows[1].Commit.CommitId)
-	assert.Equal(t, false, rows[1].Commit.IsConflicting())
 	assert.Equal(t, "xv", rows[2].Commit.ChangeId)
 	assert.Equal(t, "fa", rows[2].Commit.CommitId)
-	assert.Equal(t, false, rows[2].Commit.IsConflicting())
 }
 
 func TestParser_Evolog(t *testing.T) {
@@ -198,5 +188,4 @@ func TestParser_Evolog(t *testing.T) {
 	assert.Len(t, rows, 2)
 	assert.Equal(t, "l", rows[0].Commit.ChangeId)
 	assert.Equal(t, "98", rows[0].Commit.CommitId)
-	assert.Equal(t, false, rows[0].Commit.IsConflicting())
 }

--- a/test/testdata/conflicted-change-id.log
+++ b/test/testdata/conflicted-change-id.log
@@ -1,9 +1,9 @@
-○  _PREFIX:p_PREFIX:70_PREFIX:true [1m[4m[38;5;1mp[0m[38;5;1m??[39m [38;5;3mibrahim@dursun.cc[39m [38;5;6m2025-02-26 13:49:30[39m [1m[38;5;4m70[0m
+○  _PREFIX:p/0_PREFIX:70_PREFIX:true [1m[4m[38;5;1mp[0m[38;5;1m??[39m [38;5;3mibrahim@dursun.cc[39m [38;5;6m2025-02-26 13:49:30[39m [1m[38;5;4m70[0m
 │  [38;5;2m(empty)[39m update ARCHITECTURE documentation
 ~
-○  _PREFIX:q_PREFIX:70_PREFIX:true [1m[4m[38;5;1mq[0m[38;5;1musvoztl??[39m [38;5;3mibrahim@dursun.cc[39m [38;5;6m2025-02-26 13:49:30[39m [1m[38;5;4m70[0m[38;5;8m5c4ddf[39m
+○  _PREFIX:q/0_PREFIX:70_PREFIX:true [1m[4m[38;5;1mq[0m[38;5;1musvoztl??[39m [38;5;3mibrahim@dursun.cc[39m [38;5;6m2025-02-26 13:49:30[39m [1m[38;5;4m70[0m[38;5;8m5c4ddf[39m
 │  [38;5;2m(empty)[39m update ARCHITECTURE documentation
 ~
-○  _PREFIX:t_PREFIX:70_PREFIX:true [1m[4m[38;5;1mt[0m[38;5;8myoqvzlm[0m[38;5;1m??[39m [38;5;3mibrahim@dursun.cc[39m [38;5;6m2025-02-27 23:19:21[39m [1m[38;5;4m70[0m[38;5;8m5c4ddf[39m
+○  _PREFIX:t/0_PREFIX:70_PREFIX:true [1m[4m[38;5;1mt[0m[38;5;8myoqvzlm[0m[38;5;1m??[39m [38;5;3mibrahim@dursun.cc[39m [38;5;6m2025-02-27 23:19:21[39m [1m[38;5;4m70[0m[38;5;8m5c4ddf[39m
 │  [38;5;2m(empty)[39m something gone wrong
 ~

--- a/test/testdata/divergent-change-id.log
+++ b/test/testdata/divergent-change-id.log
@@ -1,7 +1,7 @@
-[1m[38;5;14m◆[0m  _PREFIX:omv_PREFIX:f99_PREFIX:true [1m[38;5;5momv[0m[38;5;8mxtumm[39m?? [38;5;3mibrahim@dursun.cc[39m [38;5;6m1 month ago[39m [38;5;5mexp/scripting[39m [1m[38;5;4mf99[0m[38;5;8mb66ec[39m
+[1m[38;5;14m◆[0m  _PREFIX:omv/0_PREFIX:f99_PREFIX:true [1m[38;5;5momv[0m[38;5;8mxtumm[39m?? [38;5;3mibrahim@dursun.cc[39m [38;5;6m1 month ago[39m [38;5;5mexp/scripting[39m [1m[38;5;4mf99[0m[38;5;8mb66ec[39m
 │  fix(revset): bind up and down keys
 ~
 
-[1m[38;5;14m◆[0m  _PREFIX:omv_PREFIX:43bd_PREFIX:true [1m[38;5;5momv[0m[38;5;8mxtumm[39m?? [38;5;3mibrahim@dursun.cc[39m [38;5;6m1 month ago[39m [1m[38;5;4m43bd[0m[38;5;8ma069[39m
+[1m[38;5;14m◆[0m  _PREFIX:omv/1_PREFIX:43bd_PREFIX:true [1m[38;5;5momv[0m[38;5;8mxtumm[39m?? [38;5;3mibrahim@dursun.cc[39m [38;5;6m1 month ago[39m [1m[38;5;4m43bd[0m[38;5;8ma069[39m
 │  fix(revset): bind up and down keys
 ~

--- a/test/testdata/divergent-short-change-id.log
+++ b/test/testdata/divergent-short-change-id.log
@@ -1,7 +1,7 @@
-[1m[38;5;14m◆[0m  _PREFIX:omv_PREFIX:f99_PREFIX:true [1m[38;5;5momv[0m?? [38;5;3mibrahim@dursun.cc[39m [38;5;6m2025-10-21 06:41:19[39m [38;5;5mexp/scripting[39m [1m[38;5;4mf99[0m
+[1m[38;5;14m◆[0m  _PREFIX:omv/0_PREFIX:f99_PREFIX:true [1m[38;5;5momv[0m?? [38;5;3mibrahim@dursun.cc[39m [38;5;6m2025-10-21 06:41:19[39m [38;5;5mexp/scripting[39m [1m[38;5;4mf99[0m
 │  fix(revset): bind up and down keys
 ~
 
-[1m[38;5;14m◆[0m  _PREFIX:omv_PREFIX:43bd_PREFIX:true [1m[38;5;5momv[0m?? [38;5;3mibrahim@dursun.cc[39m [38;5;6m2025-10-21 01:21:26[39m [1m[38;5;4m43bd[0m
+[1m[38;5;14m◆[0m  _PREFIX:omv/1_PREFIX:43bd_PREFIX:true [1m[38;5;5momv[0m?? [38;5;3mibrahim@dursun.cc[39m [38;5;6m2025-10-21 01:21:26[39m [1m[38;5;4m43bd[0m
 │  fix(revset): bind up and down keys
 ~

--- a/test/testdata/divergent.log
+++ b/test/testdata/divergent.log
@@ -1,10 +1,10 @@
-[1m[38;5;14m◆[0m  _PREFIX:ukn_PREFIX:dab8_PREFIX:true [1m[38;5;5mukn[0m[38;5;8muxuvn[1m[38;5;5m/0[0m [38;5;3mmoritz@tarn-vedra.de[39m [38;5;6m2025-10-03 18:57:57[39m [1m[38;5;4mdab8[0m[38;5;8m63be[39m [38;5;5m(divergent)[39m
+[1m[38;5;14m◆[0m  _PREFIX:ukn/0_PREFIX:dab8_PREFIX:true [1m[38;5;5mukn[0m[38;5;8muxuvn[1m[38;5;5m/0[0m [38;5;3mmoritz@tarn-vedra.de[39m [38;5;6m2025-10-03 18:57:57[39m [1m[38;5;4mdab8[0m[38;5;8m63be[39m [38;5;5m(divergent)[39m
 │  feat(git): Support multiple revisions
 ~
 
-○  _PREFIX:ukn_PREFIX:cf_PREFIX:true [1m[38;5;1mukn[0m[38;5;8muxuvn[1m[38;5;1m/1[0m [38;5;3mmoritz@tarn-vedra.de[39m [38;5;6m2025-10-03 10:28:49[39m [38;5;5mmvg/push-uknuxuvnprtq[39m [1m[38;5;4mcf[0m[38;5;8m1519e0[39m [38;5;1m(divergent)[39m
+○  _PREFIX:ukn/1_PREFIX:cf_PREFIX:true [1m[38;5;1mukn[0m[38;5;8muxuvn[1m[38;5;1m/1[0m [38;5;3mmoritz@tarn-vedra.de[39m [38;5;6m2025-10-03 10:28:49[39m [38;5;5mmvg/push-uknuxuvnprtq[39m [1m[38;5;4mcf[0m[38;5;8m1519e0[39m [38;5;1m(divergent)[39m
 │  feat(git): Support multiple revisions
 ~
-[1m[38;5;14m◆[0m  _PREFIX:zo_PREFIX:8_PREFIX:true [1m[38;5;5mzo/2[0m [38;5;3mibrahim@dursun.cc[39m [38;5;6m2025-10-19 15:32:02[39m [1m[38;5;4m8[0m [38;5;5m(divergent)[39m
+[1m[38;5;14m◆[0m  _PREFIX:zo/2_PREFIX:8_PREFIX:true [1m[38;5;5mzo/2[0m [38;5;3mibrahim@dursun.cc[39m [38;5;6m2025-10-19 15:32:02[39m [1m[38;5;4m8[0m [38;5;5m(divergent)[39m
 │  bind confirmation keys to `undo`
 ~


### PR DESCRIPTION
Previously, when abandoning a divergent revision, a full ChangeID is used by detecting double question marks at the end of a change ID. This has been deprecated since the jj 0.36.0 release, and since then we have introduced `_PREFIX` template in `jj log` to fetch divergent info.

Replace fragile segment-scanning logic that reconstructed full change IDs (ending in ??) with a simpler approach: the jj template now outputs change_id/offset direclty in the prefix for divergent revisions. And when abandoning a divergent revision, we simply `jj abandon $ChangeID/offset`

This eliminates `IsConflicting()`, removes the need to fall back to CommitId, and simplifies both the parser and `GetChangeId()`.

Fixes #545