### PR TITLE
fix(evolog): keep restore mode navigation on revisions and esc close

### DIFF
--- a/internal/ui/operations/evolog/evolog_operation.go
+++ b/internal/ui/operations/evolog/evolog_operation.go
@@ -126,14 +126,10 @@ func (o *Operation) handleIntent(intent intents.Intent) tea.Cmd {
 	case intents.Quit:
 		return tea.Quit
 	case intents.Cancel:
-		if o.mode == restoreMode {
-			o.mode = selectMode
-			return nil
-		}
 		return common.Close
 	case intents.EvologNavigate:
-		if o.mode != selectMode {
-			return nil
+		if o.mode == restoreMode {
+			return intents.Invoke(intents.Navigate{Delta: msg.Delta})
 		}
 		if msg.Delta < 0 && o.cursor > 0 {
 			o.cursor--

--- a/internal/ui/operations/evolog/evolog_operation_test.go
+++ b/internal/ui/operations/evolog/evolog_operation_test.go
@@ -3,9 +3,14 @@ package evolog
 import (
 	"testing"
 
+	tea "github.com/charmbracelet/bubbletea"
 	"github.com/idursun/jjui/internal/jj"
+	"github.com/idursun/jjui/internal/parser"
+	"github.com/idursun/jjui/internal/ui/common"
+	"github.com/idursun/jjui/internal/ui/intents"
 	"github.com/idursun/jjui/test"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var revision = &jj.Commit{
@@ -59,4 +64,58 @@ func TestOperation_Init(t *testing.T) {
 	test.SimulateModel(operation, operation.Init())
 
 	assert.True(t, commandRunner.IsVerified())
+}
+
+func TestOperation_RestoreMode_NavigationDelegatesToRevisions(t *testing.T) {
+	commandRunner := test.NewTestCommandRunner(t)
+	context := test.NewTestContext(commandRunner)
+	operation := NewOperation(context, revision)
+
+	operation.Update(updateEvologMsg{
+		rows: []parser.Row{
+			{Commit: &jj.Commit{ChangeId: "a", CommitId: "111"}},
+			{Commit: &jj.Commit{ChangeId: "b", CommitId: "222"}},
+		},
+	})
+
+	operation.Update(intents.EvologRestore{})
+	assert.Equal(t, restoreMode, operation.mode)
+
+	cmd := operation.Update(intents.EvologNavigate{Delta: 1})
+	assert.Equal(t, 0, operation.cursor)
+	if assert.NotNil(t, cmd) {
+		msg := cmd()
+		navigate, ok := msg.(intents.Navigate)
+		if assert.True(t, ok) {
+			assert.Equal(t, 1, navigate.Delta)
+		}
+	}
+
+	cmd = operation.Update(intents.EvologNavigate{Delta: -1})
+	assert.Equal(t, 0, operation.cursor)
+	if assert.NotNil(t, cmd) {
+		msg := cmd()
+		navigate, ok := msg.(intents.Navigate)
+		if assert.True(t, ok) {
+			assert.Equal(t, -1, navigate.Delta)
+		}
+	}
+}
+
+func TestOperation_RestoreMode_CancelClosesEvolog(t *testing.T) {
+	commandRunner := test.NewTestCommandRunner(t)
+	context := test.NewTestContext(commandRunner)
+	operation := NewOperation(context, revision)
+	operation.mode = restoreMode
+
+	cmd := operation.Update(intents.Cancel{})
+	require.NotNil(t, cmd)
+
+	msg := cmd()
+	if batch, ok := msg.(tea.BatchMsg); ok {
+		require.NotEmpty(t, batch)
+		msg = batch[0]()
+	}
+	_, ok := msg.(common.CloseViewMsg)
+	assert.True(t, ok, "cancel in restore mode should close evolog")
 }


### PR DESCRIPTION
Right now, when user press `r` in evolog, navigation doesn't work. Also,
instead of restoring to evolog on the correct revision after navigation,
which requires slightly more complexity, pressing `esc` simply cancel
evolog operation