### PR TITLE
feat: add `(` to functions when autocompleted

### DIFF
--- a/internal/jj/source/source.go
+++ b/internal/jj/source/source.go
@@ -26,10 +26,13 @@ type Item struct {
 	HasParameters bool
 }
 
-// DisplayName returns the item name, appending "()" for parameterless functions.
+// DisplayName returns the item name, appending "()" for parameterless functions and "(" for functions with parameters.
 func (i Item) DisplayName() string {
-	if i.Kind == KindFunction && !i.HasParameters {
-		return i.Name + "()"
+	if i.Kind == KindFunction {
+		if !i.HasParameters {
+			return i.Name + "()"
+		}
+		return i.Name + "("
 	}
 	return i.Name
 }

--- a/internal/ui/revset/completion_provider_test.go
+++ b/internal/ui/revset/completion_provider_test.go
@@ -57,9 +57,9 @@ func TestGetCompletions(t *testing.T) {
 		input    string
 		expected string
 	}{
-		{"ancestors", "ancestors"},
+		{"ancestors", "ancestors("},
 		{"ancestors(visible_", "visible_heads()"},
-		{"author", "author"},
+		{"author", "author("},
 		{"author(m", "mine()"},
 		{"author( m", "mine()"},
 		{"present(@) | m", "mine()"},


### PR DESCRIPTION
I finally decided to use AI to help me make changes to jjui (along with using jjui itself to navigate the different branches etc to test out new functionality)!

A small first PR: when you autocomplete `ta` it'll fill `tags(` with the opening `(`. functions like `all` still autocomplete as `all()` 

 It was, of course, an easy and seamless experience. Looking forward to contributing more in the future!