### PR TITLE
DO NOT MERGE: Add line wrapping by adding a PTY

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,11 @@ require (
 )
 
 require (
+	github.com/creack/pty/v2 v2.0.1
+	golang.org/x/term v0.38.0
+)
+
+require (
 	github.com/charmbracelet/colorprofile v0.4.2 // indirect
 	github.com/charmbracelet/ultraviolet v0.0.0-20260205113103-524a6607adb8
 	github.com/charmbracelet/x/termios v0.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -30,6 +30,8 @@ github.com/clipperhouse/displaywidth v0.11.0 h1:lBc6kY44VFw+TDx4I8opi/EtL9m20WSE
 github.com/clipperhouse/displaywidth v0.11.0/go.mod h1:bkrFNkf81G8HyVqmKGxsPufD3JhNl3dSqnGhOoSD/o0=
 github.com/clipperhouse/uax29/v2 v2.7.0 h1:+gs4oBZ2gPfVrKPthwbMzWZDaAFPGYK72F0NJv2v7Vk=
 github.com/clipperhouse/uax29/v2 v2.7.0/go.mod h1:EFJ2TJMRUaplDxHKj1qAEhCtQPW2tJSwu5BF98AuoVM=
+github.com/creack/pty/v2 v2.0.1 h1:RDY1VY5b+7m2mfPsugucOYPIxMp+xal5ZheSyVzUA+k=
+github.com/creack/pty/v2 v2.0.1/go.mod h1:2dSssKp3b86qYEMwA/FPwc3ff+kYpDdQI8osU8J7gxQ=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=

--- a/internal/ui/preview/preview.go
+++ b/internal/ui/preview/preview.go
@@ -225,7 +225,7 @@ func (m *Model) refreshPreviewForItem(item common.SelectedItem) tea.Cmd {
 			})
 		}
 
-		output, _ := m.context.RunCommandImmediate(args)
+		output, _ := m.context.RunCommandWithPTY(args, m.view.Width(), m.view.Height())
 		return updatePreviewContentMsg{
 			Content: string(output),
 		}
@@ -247,6 +247,7 @@ func New(context *context.MainContext) *Model {
 	}
 
 	return &Model{
+		view:                viewport.Model{SoftWrap: true},
 		context:             context,
 		previewAutoPosition: previewAutoPosition,
 		previewAtBottom:     previewAtBottom,

--- a/internal/ui/preview/preview_test.go
+++ b/internal/ui/preview/preview_test.go
@@ -29,6 +29,8 @@ func TestModel_View(t *testing.T) {
 		expected string
 	}{
 		{
+			// With soft-wrap, lines longer than the viewport width wrap onto
+			// the next visual line rather than being clipped.
 			name:     "clips",
 			scrollBy: layout.Position{},
 			width:    5,
@@ -40,7 +42,7 @@ func TestModel_View(t *testing.T) {
 			`),
 			expected: test.Stripped(`
 			+++++
-			+abcd
+			..
 			`),
 		},
 		{
@@ -56,11 +58,13 @@ func TestModel_View(t *testing.T) {
 			`),
 			expected: test.Stripped(`
 			+++++
+			..
 			+abcd
-			+++++
 			`),
 		},
 		{
+			// With soft-wrap enabled, horizontal scroll has no effect; lines
+			// wrap at the viewport width instead.
 			name:     "Scroll by down and right",
 			scrollBy: layout.Position{X: 1, Y: 1},
 			width:    5,
@@ -71,8 +75,8 @@ func TestModel_View(t *testing.T) {
 			.......
 			`),
 			expected: test.Stripped(`
-			abcde
-			.....
+			..
+			.abcd
 			`),
 		},
 		{
@@ -87,11 +91,14 @@ func TestModel_View(t *testing.T) {
 			.......
 			`),
 			expected: test.Stripped(`
+			..
 			.abcd
-			.....
+			e.
 			`),
 		},
 		{
+			// Horizontal scroll is a no-op with soft-wrap; the view starts
+			// from the top unchanged.
 			name:     "Scroll 2 right when at bottom",
 			scrollBy: layout.Position{X: 2, Y: 0},
 			atBottom: true,
@@ -104,8 +111,8 @@ func TestModel_View(t *testing.T) {
 			`),
 			expected: test.Stripped(`
 			.....
-			bcde.
-			.....
+			..
+			.abcd
 			`),
 		},
 	}

--- a/test/test_command_runner.go
+++ b/test/test_command_runner.go
@@ -59,6 +59,10 @@ func (t *CommandRunner) RunCommandImmediate(args []string) ([]byte, error) {
 	return nil, nil
 }
 
+func (t *CommandRunner) RunCommandWithPTY(args []string, cols int, rows int) ([]byte, error) {
+	return t.RunCommandImmediate(args)
+}
+
 func (t *CommandRunner) RunCommandStreaming(_ context.Context, args []string) (*appContext.StreamingCommand, error) {
 	reader, err := t.RunCommandImmediate(args)
 	return &appContext.StreamingCommand{


### PR DESCRIPTION
This is just an idea for how line wrapping could work. The PR creates a PTY for the preview pane and disables the jj pager, sets TERM=dumb to suppress queries, and sets SoftWrap to true so it wraps.

I'm just submitting it for inspiration, though it does work. I don't have an intention of it being merged.