### PR TITLE
feat(status): change display to column major order

### DIFF
--- a/internal/ui/status/status.go
+++ b/internal/ui/status/status.go
@@ -405,7 +405,7 @@ func (m *Model) buildHelpGrid(entries []string, maxEntryWidth, maxWidth int) []s
 	for row := range numRows {
 		var line strings.Builder
 		for col := range numCols {
-			idx := row*numCols + col
+			idx := col*numRows + row
 			if idx < len(entries) {
 				entry := entries[idx]
 				line.WriteString(entry)

--- a/internal/ui/status/status_test.go
+++ b/internal/ui/status/status_test.go
@@ -69,3 +69,15 @@ func TestStatus_Update_ExecProcessCompletedMsg(t *testing.T) {
 		})
 	}
 }
+
+func TestModel_BuildHelpGrid_ColumnMajorOrder(t *testing.T) {
+	m := &Model{}
+	entries := []string{"A", "B", "C", "D", "E", "F"}
+
+	lines := m.buildHelpGrid(entries, 1, 9)
+
+	assert.Equal(t, []string{
+		"A  C  E",
+		"B  D  F",
+	}, lines)
+}


### PR DESCRIPTION
Addressed the ordering of items in status menu brought up in #562. 

The change is the easier approach mentioned in the issue. As the build grid function is already in place, it's only a one-line change

<table>
  <tr>
    <th>before</th>
    <td><img width="1000" alt="image" src="https://github.com/user-attachments/assets/cb6943ff-0e3c-490a-a323-b93697ebe4b4" /></td>
  </tr>
  <tr>
    <th>after </th>
    <td><img width="1000" alt="image" src="https://github.com/user-attachments/assets/766022ff-e1a5-479f-b4b4-46d25aa7e974" /></td>
  </tr>
</table>