### PR TITLE
fix(ui): guard against nil commit in OpenBookmarks intent

### DIFF
--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -522,8 +522,12 @@ func (m *Model) handleUiRootIntent(intent intents.Intent) (tea.Cmd, bool) {
 		if !m.revisions.InNormalMode() {
 			return nil, true
 		}
+		current := m.revisions.SelectedRevision()
+		if current == nil {
+			return nil, true
+		}
 		changeIds := m.revisions.GetCommitIds()
-		model := bookmarks.NewModel(m.context, m.revisions.SelectedRevision(), changeIds)
+		model := bookmarks.NewModel(m.context, current, changeIds)
 		m.stacked = model
 		return m.stacked.Init(), true
 	case intents.OpenGit:


### PR DESCRIPTION
SelectedRevision() can return nil when the cursor is out of bounds (e.g., during initial load of a large repo, as mentioned in #570 ). This nil was passed directly to bookmarks.NewModel, causing a nil pointer dereference at bookmarks.go:563.

Add an early return when SelectedRevision() is nil, consistent with the existing nil-filtering fix in NewSelectedRevisions for the git module 

related to #570 and #571