### PR TITLE
render: avoid no-op highlight rewrites that erase wide glyphs

### DIFF
--- a/internal/ui/render/display_context_test.go
+++ b/internal/ui/render/display_context_test.go
@@ -7,6 +7,7 @@ import (
 	"charm.land/lipgloss/v2"
 	uv "github.com/charmbracelet/ultraviolet"
 	"github.com/idursun/jjui/internal/ui/layout"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestDisplayContext_AddDraw(t *testing.T) {
@@ -177,9 +178,30 @@ func TestDisplayContext_HighlightPreservesWideCharacters(t *testing.T) {
 	dl.Render(buf)
 
 	out := buf.Render()
-	if !strings.Contains(out, "🙂") {
-		t.Fatalf("expected highlighted output to preserve emoji, got: %q", out)
-	}
+	assert.Contains(t, out, "🙂", "highlighted output should preserve emoji")
+}
+
+func TestDisplayContext_HighlightPreservesWideCharactersWithExistingBackground(t *testing.T) {
+	dl := NewDisplayContext()
+
+	text := lipgloss.NewStyle().Background(lipgloss.Color("0")).Render("hello🙂中文어👨‍👩‍👧‍👦Ａあ가")
+	rect := layout.Rect(0, 0, 28, 1)
+
+	dl.AddDraw(rect, text, 0)
+	dl.AddHighlight(rect, lipgloss.NewStyle().Background(lipgloss.Color("4")), 1)
+
+	buf := uv.NewScreenBuffer(28, 1)
+	dl.Render(buf)
+
+	out := buf.Render()
+	assert.Contains(t, out, "🙂", "highlighted output should preserve emoji with existing background")
+	assert.Contains(t, out, "中", "highlighted output should preserve CJK glyphs with existing background")
+	assert.Contains(t, out, "文", "highlighted output should preserve CJK glyphs with existing background")
+	assert.Contains(t, out, "어", "highlighted output should preserve Korean glyphs with existing background")
+	assert.Contains(t, out, "👨‍👩‍👧‍👦", "highlighted output should preserve ZWJ emoji sequences with existing background")
+	assert.Contains(t, out, "Ａ", "highlighted output should preserve full-width Latin characters with existing background")
+	assert.Contains(t, out, "あ", "highlighted output should preserve Hiragana glyphs with existing background")
+	assert.Contains(t, out, "가", "highlighted output should preserve Hangul glyphs with existing background")
 }
 
 func TestEmptyDisplayContext(t *testing.T) {

--- a/internal/ui/render/effect.go
+++ b/internal/ui/render/effect.go
@@ -61,7 +61,7 @@ func (e HighlightEffect) Apply(buf uv.Screen) {
 			newCell.Style.Bg = bgColor
 			return newCell
 		}
-		return cell
+		return nil
 	})
 }
 


### PR DESCRIPTION
When inline describe is active, the textarea already renders its content
with a background color. Highlighting pass still walked those cells and
wrote them back unchanged. 

the harmless code rewrites a wide cell, which in ultraviolet is not a
no-op. The buffer treats it like an overwrite and clears the wide-glyph
span first. 
As a result, emoji and chinese characters (all CJK characters) in the inline
description disappeared only while the row highlight was active.

The fix is surprisingly simple, because the highlight pass never needed
to touch those cells in the first place.

If a cell already has a background and we are not forcing an override,
we now skip it entirely instead of re-setting the same cell. That
preserves wide glyphs and matches the intended behavior. 

Also, added a regression test (failed without the test) covering 
highlighted wide characters with an existing background.

Fixes #526

<img width="612" height="83" alt="image" src="https://github.com/user-attachments/assets/107e3a85-3c03-4b45-89b3-df990ec668ff" />
