### PR TITLE
fix: Use wcwidth for final UI screen rendering

### DIFF
--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -84,6 +84,14 @@ const (
 	scopeCommandHistory   keybindings.Scope = "command_history"
 )
 
+// Use wcwidth-style measurement for the final screen buffer.
+//
+// This matches how terminals typically place variation-selector emoji such as
+// "⬇️": GraphemeWidth counts it as 2 cells, but terminals commonly render it
+// in 1 cell. Using WcWidth keeps pane separators aligned with terminal layout.
+// Regular emoji like "😭" still measure as width 2.
+var screenWidthMethod = ansi.WcWidth
+
 func (m *Model) Init() tea.Cmd {
 	return tea.Batch(m.revisions.Init(), m.scheduleAutoRefresh())
 }
@@ -366,7 +374,7 @@ func (m *Model) View() string {
 
 	box := layout.NewBox(layout.Rect(0, 0, m.width, m.height))
 	screenBuf := uv.NewScreenBuffer(m.width, m.height)
-	screenBuf.Method = ansi.GraphemeWidth
+	screenBuf.Method = screenWidthMethod
 
 	if m.diff != nil {
 		m.renderDiffLayout(box)

--- a/internal/ui/ui_test.go
+++ b/internal/ui/ui_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/x/ansi"
 	"github.com/idursun/jjui/internal/config"
 	"github.com/idursun/jjui/internal/jj"
 	"github.com/idursun/jjui/internal/scripting"
@@ -36,6 +37,12 @@ func dispatchAction(model *Model, action keybindings.Action, args map[string]any
 		return model.routeIntent(result.Owner, result.Intent), true
 	}
 	return nil, result.Consumed
+}
+
+func Test_ScreenWidthMethod_MatchesTerminalWidthForVariationSelectorEmoji(t *testing.T) {
+	assert.Equal(t, ansi.WcWidth, screenWidthMethod)
+	assert.Equal(t, 1, screenWidthMethod.StringWidth("⬇️"))
+	assert.Equal(t, 2, screenWidthMethod.StringWidth("😭"))
 }
 
 func Test_Update_PreviewScrollKeysWorkWhenVisible(t *testing.T) {


### PR DESCRIPTION
Bug: 
Certain emojis break the rendering of Preview border, causing the border
to be left shifted. 

<img width="450" alt="image" src="https://github.com/user-attachments/assets/0f4e36aa-7f84-42cd-9d3f-a1f5e619fac9" />




Root cause:
the final Ultraviolet screen buffer used GraphemeWidth, which counts
variation-selector emoji like "⬇️" as 2 cells. Many terminals render
that glyph in 1 cell, so pane separators in the preview layout appeared
shifted when such a glyph was present in revision text. Regular emoji
like "😭" still measure as width 2, which is why they did not reproduce
the bug.

Fix:
render the final screen buffer with ansi.WcWidth instead, and add a
regression test documenting the differing widths for "⬇️" and "😭".