### PR TITLE
fix(render): detect terminal width method

### DIFF
--- a/internal/ui/choose/choose.go
+++ b/internal/ui/choose/choose.go
@@ -242,10 +242,10 @@ func (m *Model) ViewRect(dl *render.DisplayContext, box layout.Box) {
 		orderPrefix = 3 // "N. " prefix
 	}
 	for _, opt := range m.options {
-		itemWidth = max(itemWidth, lipgloss.Width(opt)+2+orderPrefix)
+		itemWidth = max(itemWidth, render.StringWidth(opt)+2+orderPrefix)
 	}
 	if m.title != "" {
-		itemWidth = max(itemWidth, lipgloss.Width(m.title))
+		itemWidth = max(itemWidth, render.StringWidth(m.title))
 	}
 	if m.filtering {
 		itemWidth = max(itemWidth, 25)

--- a/internal/ui/commandhistory/model.go
+++ b/internal/ui/commandhistory/model.go
@@ -193,7 +193,7 @@ func (m *Model) renderEntry(entry flash.CommandHistoryEntry, maxWidth int, selec
 	}
 
 	content := strings.Join(parts, "\n")
-	if lipgloss.Width(content) > maxWidth {
+	if render.BlockWidth(content) > maxWidth {
 		content = lipgloss.NewStyle().Width(maxWidth).Render(content)
 	}
 

--- a/internal/ui/diff/diff.go
+++ b/internal/ui/diff/diff.go
@@ -4,7 +4,6 @@ import (
 	"strings"
 
 	tea "charm.land/bubbletea/v2"
-	"charm.land/lipgloss/v2"
 	uv "github.com/charmbracelet/ultraviolet"
 	"github.com/idursun/jjui/internal/ui/intents"
 	"github.com/idursun/jjui/internal/ui/layout"
@@ -42,7 +41,7 @@ func (v *defaultView) scrollHorizontal(delta int, viewportWidth int) {
 func (v *defaultView) ViewRect(dl *render.DisplayContext, box layout.Box, scrollY int) {
 	width := box.R.Dx()
 	height := box.R.Dy()
-	buf := uv.NewScreenBuffer(width, height)
+	buf := render.NewScreenBuffer(width, height)
 	firstLine := max(0, scrollY)
 	lineW := max(width, v.maxLineWidth)
 	for i := range height {
@@ -77,7 +76,7 @@ func (v *wrappedView) recomputeIndex(width int) {
 	v.visualRowStart = make([]int, len(v.lines))
 	total := 0
 	for i, line := range v.lines {
-		visWidth := lipgloss.Width(line)
+		visWidth := render.StringWidth(line)
 		h := max(1, (visWidth+width-1)/width)
 		v.rowHeights[i] = h
 		v.visualRowStart[i] = total
@@ -120,7 +119,7 @@ func (v *wrappedView) ViewRect(dl *render.DisplayContext, box layout.Box, scroll
 	width := box.R.Dx()
 	height := box.R.Dy()
 	v.ensureIndex(width)
-	buf := uv.NewScreenBuffer(width, height)
+	buf := render.NewScreenBuffer(width, height)
 	firstLine, skip := v.firstLine(scrollY, width)
 	destY := 0
 	for i := firstLine; i < len(v.lines) && destY < height; i++ {
@@ -244,7 +243,7 @@ func New(output string) *Model {
 	lines := strings.Split(content, "\n")
 	maxWidth := 0
 	for _, line := range lines {
-		if w := lipgloss.Width(line); w > maxWidth {
+		if w := render.StringWidth(line); w > maxWidth {
 			maxWidth = w
 		}
 	}

--- a/internal/ui/help/help.go
+++ b/internal/ui/help/help.go
@@ -285,7 +285,7 @@ func (m *Model) renderGroups(groups []scopeGroup, width int) []string {
 func (m *Model) renderEntries(entries []helpkeys.Entry, width int) []string {
 	maxLabelWidth := 0
 	for _, e := range entries {
-		if w := lipgloss.Width(e.Label); w > maxLabelWidth {
+		if w := render.StringWidth(e.Label); w > maxLabelWidth {
 			maxLabelWidth = w
 		}
 	}
@@ -307,7 +307,7 @@ func (m *Model) renderEntries(entries []helpkeys.Entry, width int) []string {
 			label := m.styles.shortcut.Width(maxLabelWidth + 1).Render(e.Label)
 			desc := m.styles.desc.Render(e.Desc)
 			entry := "  " + label + " " + desc
-			entryWidth := lipgloss.Width(entry)
+			entryWidth := render.StringWidth(entry)
 			if col < numCols-1 {
 				entry += strings.Repeat(" ", max(0, actualColWidth-entryWidth))
 			}
@@ -327,7 +327,7 @@ func (m *Model) totalLines() int {
 		total++ // header
 		maxLabelWidth := 0
 		for _, e := range group.entries {
-			if w := lipgloss.Width(e.Label); w > maxLabelWidth {
+			if w := render.StringWidth(e.Label); w > maxLabelWidth {
 				maxLabelWidth = w
 			}
 		}

--- a/internal/ui/render/display_context.go
+++ b/internal/ui/render/display_context.go
@@ -159,7 +159,7 @@ func (dl *DisplayContext) Render(buf uv.Screen) {
 // RenderToString is a convenience method that renders to a new buffer
 // and returns the final string output.
 func (dl *DisplayContext) RenderToString(width, height int) string {
-	buf := uv.NewScreenBuffer(width, height)
+	buf := NewScreenBuffer(width, height)
 	dl.Render(buf)
 	return buf.Render()
 }

--- a/internal/ui/render/text_builder.go
+++ b/internal/ui/render/text_builder.go
@@ -110,7 +110,7 @@ func (tb *TextBuilder) layout() ([]layoutSegment, int, int) {
 			}
 
 			rendered := seg.style.Render(part)
-			width := lipgloss.Width(rendered)
+			width := StringWidth(rendered)
 			if width == 0 {
 				continue
 			}

--- a/internal/ui/render/width.go
+++ b/internal/ui/render/width.go
@@ -1,0 +1,41 @@
+package render
+
+import (
+	"strings"
+
+	uv "github.com/charmbracelet/ultraviolet"
+	"github.com/charmbracelet/x/ansi"
+)
+
+var widthMethod = ansi.WcWidth
+
+// SetWidthMethod updates the render width method.
+func SetWidthMethod(m ansi.Method) {
+	widthMethod = m
+}
+
+// WidthMethod returns the current render width method.
+func WidthMethod() ansi.Method {
+	return widthMethod
+}
+
+// StringWidth returns the display width of a string.
+func StringWidth(s string) int {
+	return widthMethod.StringWidth(s)
+}
+
+// BlockWidth returns the display width of the widest line in a multiline string.
+func BlockWidth(s string) int {
+	width := 0
+	for line := range strings.SplitSeq(s, "\n") {
+		width = max(width, StringWidth(line))
+	}
+	return width
+}
+
+// NewScreenBuffer creates a screen buffer using the current width method.
+func NewScreenBuffer(w, h int) uv.ScreenBuffer {
+	buf := uv.NewScreenBuffer(w, h)
+	buf.Method = widthMethod
+	return buf
+}

--- a/internal/ui/render/width_test.go
+++ b/internal/ui/render/width_test.go
@@ -1,0 +1,20 @@
+package render
+
+import (
+	"testing"
+
+	"github.com/charmbracelet/x/ansi"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBlockWidthUsesWidestLine(t *testing.T) {
+	t.Cleanup(func() {
+		SetWidthMethod(ansi.WcWidth)
+	})
+
+	for _, method := range []ansi.Method{ansi.WcWidth, ansi.GraphemeWidth} {
+		SetWidthMethod(method)
+		assert.Equal(t, 3, BlockWidth("ab\n中d"))
+		assert.Equal(t, 5, StringWidth("ab\n中d"))
+	}
+}

--- a/internal/ui/revisions/displaycontext_renderer.go
+++ b/internal/ui/revisions/displaycontext_renderer.go
@@ -337,7 +337,7 @@ func (r *DisplayContextRenderer) renderItemToDisplayContext(
 		extended := item.Extend()
 		gutterWidth := 0
 		for _, segment := range extended.Segments {
-			gutterWidth += lipgloss.Width(segment.Text)
+			gutterWidth += render.StringWidth(segment.Text)
 		}
 
 		// Create content rect offset by gutter width
@@ -404,7 +404,7 @@ func (r *DisplayContextRenderer) renderItemToDisplayContext(
 			extended := item.Extend()
 			gutterWidth := 0
 			for _, segment := range extended.Segments {
-				gutterWidth += lipgloss.Width(segment.Text)
+				gutterWidth += render.StringWidth(segment.Text)
 			}
 
 			// Create content rect with proper width (minus gutter)
@@ -455,7 +455,7 @@ func (r *DisplayContextRenderer) renderItemToDisplayContext(
 		extended := item.Extend()
 		gutterWidth := 0
 		for _, segment := range extended.Segments {
-			gutterWidth += lipgloss.Width(segment.Text)
+			gutterWidth += render.StringWidth(segment.Text)
 		}
 
 		// Try RenderToDisplayContext first

--- a/internal/ui/status/status.go
+++ b/internal/ui/status/status.go
@@ -227,8 +227,8 @@ func (m *Model) renderContent(width, modeWidth int) string {
 		editHelp, _ = m.helpView(m.entries, 0)
 	}
 
-	promptWidth := len(m.input.Prompt) + 2
-	m.input.SetWidth(width - modeWidth - promptWidth - lipgloss.Width(editHelp))
+	promptWidth := render.StringWidth(m.input.Prompt) + 2
+	m.input.SetWidth(width - modeWidth - promptWidth - render.StringWidth(editHelp))
 	return lipgloss.JoinHorizontal(0, m.input.View(), editHelp)
 }
 
@@ -252,7 +252,7 @@ func (m *Model) renderExpandedStatusBorder(dl *render.DisplayContext, box layout
 		return
 	}
 	modeLabel := m.styles.title.Render("  " + m.mode + "  ")
-	borderLine := strings.Repeat("─", max(0, width-lipgloss.Width(modeLabel)))
+	borderLine := strings.Repeat("─", max(0, width-render.StringWidth(modeLabel)))
 	topBorder := modeLabel + m.styles.dimmed.Render(borderLine)
 	borderRect := layout.Rect(box.R.Min.X, startY, width, 1)
 	dl.AddDraw(borderRect, topBorder, render.ZExpandedStatus)
@@ -276,7 +276,7 @@ func (m *Model) renderExpandedStatusContent(dl *render.DisplayContext, box layou
 
 		// calculate right padding
 		// subtract 4 for: 2 chars left padding + 2 chars border space
-		padding := max(0, width-lipgloss.Width(line)-4)
+		padding := max(0, width-render.StringWidth(line)-4)
 
 		// padded line: 2-space indent + content + right padding
 		paddedLine := "  " + line + strings.Repeat(" ", padding)
@@ -380,12 +380,12 @@ func (m *Model) collectHelpEntries(helpEntries []helpkeys.Entry) ([]string, int)
 		}
 		e := m.styles.shortcut.Render(entry.Label) + m.styles.dimmed.PaddingLeft(1).Render(entry.Desc)
 		rendered = append(rendered, e)
-		if w := lipgloss.Width(e); w > maxEntryWidth {
+		if w := render.StringWidth(e); w > maxEntryWidth {
 			maxEntryWidth = w
 		}
 	}
 
-	if w := lipgloss.Width(closeHint); w > maxEntryWidth {
+	if w := render.StringWidth(closeHint); w > maxEntryWidth {
 		maxEntryWidth = w
 	}
 	rendered = append(rendered, closeHint)
@@ -410,7 +410,7 @@ func (m *Model) buildHelpGrid(entries []string, maxEntryWidth, maxWidth int) []s
 				entry := entries[idx]
 				line.WriteString(entry)
 				if col < numCols-1 {
-					padding := max(0, colWidth-lipgloss.Width(entry))
+					padding := max(0, colWidth-render.StringWidth(entry))
 					line.WriteString(strings.Repeat(" ", padding))
 				}
 			}
@@ -426,7 +426,7 @@ func (m *Model) helpView(helpEntries []helpkeys.Entry, maxWidth int) (string, bo
 	expandKey := m.expandStatusKey(helpEntries)
 	moreHint := separator + m.styles.shortcut.Render(expandKey) + m.styles.dimmed.PaddingLeft(1).Render("more")
 
-	rendered, truncated := m.collectHelpEntriesWithLimit(helpEntries, maxWidth, lipgloss.Width(separator), lipgloss.Width(moreHint))
+	rendered, truncated := m.collectHelpEntriesWithLimit(helpEntries, maxWidth, render.StringWidth(separator), render.StringWidth(moreHint))
 
 	result := strings.Join(rendered, separator)
 	if truncated {
@@ -447,7 +447,7 @@ func (m *Model) collectHelpEntriesWithLimit(helpEntries []helpkeys.Entry, maxWid
 		}
 
 		e := m.styles.shortcut.Render(entry.Label) + m.styles.dimmed.PaddingLeft(1).Render(entry.Desc)
-		entryWidth := lipgloss.Width(e)
+		entryWidth := render.StringWidth(e)
 
 		addedWidth := entryWidth
 		if len(rendered) > 0 {

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 	"time"
 
-	uv "github.com/charmbracelet/ultraviolet"
 	"github.com/charmbracelet/x/ansi"
 
 	"github.com/idursun/jjui/internal/scripting"
@@ -115,6 +114,13 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 	var cmds []tea.Cmd
 
 	switch msg := msg.(type) {
+	case tea.ModeReportMsg:
+		if msg.Mode == ansi.ModeUnicodeCore {
+			if msg.Value == ansi.ModeReset || msg.Value == ansi.ModeSet || msg.Value == ansi.ModePermanentlySet {
+				render.SetWidthMethod(ansi.GraphemeWidth)
+			}
+		}
+		return nil
 	case tea.FocusMsg:
 		return common.RefreshAndKeepSelections
 	case tea.MouseReleaseMsg:
@@ -365,8 +371,7 @@ func (m *Model) View() string {
 	m.updateStatus()
 
 	box := layout.NewBox(layout.Rect(0, 0, m.width, m.height))
-	screenBuf := uv.NewScreenBuffer(m.width, m.height)
-	screenBuf.Method = ansi.GraphemeWidth
+	screenBuf := render.NewScreenBuffer(m.width, m.height)
 
 	if m.diff != nil {
 		m.renderDiffLayout(box)

--- a/test/render.go
+++ b/test/render.go
@@ -1,7 +1,6 @@
 package test
 
 import (
-	uv "github.com/charmbracelet/ultraviolet"
 	"github.com/idursun/jjui/internal/ui/layout"
 	"github.com/idursun/jjui/internal/ui/render"
 )
@@ -13,7 +12,7 @@ func RenderImmediate(model interface {
 	dl := render.NewDisplayContext()
 	box := layout.NewBox(layout.Rect(0, 0, width, height))
 	model.ViewRect(dl, box)
-	buf := uv.NewScreenBuffer(width, height)
+	buf := render.NewScreenBuffer(width, height)
 	dl.Render(buf)
 	return buf.Render()
 }


### PR DESCRIPTION

This fixes misaligned lines in terminals that use grapheme clustering by default, such as Ghostty, while preserving correct rendering in terminals like Kitty that do not.

We detect terminal support for Unicode core width mode by listening for `tea.ModeReportMsg`, then we store the detected width method into the `render` package. I moved `Width` methods to the render package so that it is consistent across the codebase (by using the detected width method).

I tested it on both terminals and seems to be rendering correctly.