### PR TITLE
fix(textinput): handle shift+backspace in terminals with Kitty keyboard protocol

### DIFF
--- a/internal/ui/bookmarks/bookmarks.go
+++ b/internal/ui/bookmarks/bookmarks.go
@@ -575,7 +575,7 @@ func NewModel(c *context.MainContext, current *jj.Commit, commitIds []string) *M
 	}
 	m.listRenderer.Z = render.ZMenuContent
 
-	m.filterInput = textinput.New()
+	m.filterInput = common.TextInputNew()
 	m.filterInput.Prompt = "Filter: "
 	fis := m.filterInput.Styles()
 	fis.Focused.Prompt = m.menuStyles.matched.PaddingLeft(1)

--- a/internal/ui/choose/choose.go
+++ b/internal/ui/choose/choose.go
@@ -70,7 +70,7 @@ func NewWithTitle(options []string, title string, filterable bool) *Model {
 }
 
 func NewWithOptions(options []string, title string, filterable bool, ordered bool) *Model {
-	ti := textinput.New()
+	ti := common.TextInputNew()
 	ti.Prompt = "/"
 	ti.Placeholder = "filter..."
 	ti.CharLimit = 100

--- a/internal/ui/common/autocompletion/autocompletion.go
+++ b/internal/ui/common/autocompletion/autocompletion.go
@@ -62,7 +62,7 @@ func WithCompletionsDisabled() Option {
 }
 
 func New(provider CompletionProvider, options ...Option) *AutoCompletionInput {
-	ti := textinput.New()
+	ti := common.TextInputNew()
 	ti.Focus()
 	ti.Prompt = ""
 	ti.ShowSuggestions = true

--- a/internal/ui/common/textinput.go
+++ b/internal/ui/common/textinput.go
@@ -1,0 +1,25 @@
+package common
+
+import "charm.land/bubbles/v2/textinput"
+
+// Create a textinput.Model extending the KeyMap so that shift+backspace and
+// shift+delete behave the same as their unshifted counterparts. Some terminals
+// (e.g. wezterm, ghostty on Linux) report these as distinct key events via the
+// Kitty keyboard protocol, but the bubbles default KeyMap does not include
+// them.
+func TextInputNew() textinput.Model {
+	ti := textinput.New()
+
+	km := &ti.KeyMap
+	km.DeleteCharacterBackward.SetKeys(
+		append(km.DeleteCharacterBackward.Keys(), "shift+backspace")...,
+	)
+	km.DeleteCharacterForward.SetKeys(
+		append(km.DeleteCharacterForward.Keys(), "shift+delete")...,
+	)
+	km.DeleteWordBackward.SetKeys(
+		append(km.DeleteWordBackward.Keys(), "alt+shift+backspace")...,
+	)
+
+	return ti;
+}

--- a/internal/ui/git/git.go
+++ b/internal/ui/git/git.go
@@ -412,7 +412,7 @@ func NewModel(c *context.MainContext, revisions jj.SelectedRevisions) *Model {
 	items := m.createMenuItems()
 	m.items = items
 	m.filteredItems = items
-	m.filterInput = textinput.New()
+	m.filterInput = common.TextInputNew()
 	m.filterInput.Prompt = "Filter: "
 	gfis := m.filterInput.Styles()
 	gfis.Focused.Prompt = m.menuStyles.matched.PaddingLeft(1)

--- a/internal/ui/help/help.go
+++ b/internal/ui/help/help.go
@@ -350,7 +350,7 @@ func New() *Model {
 		dimmed:   palette.Get("help dimmed"),
 	}
 
-	ti := textinput.New()
+	ti := common.TextInputNew()
 	ti.Placeholder = "search"
 	ti.Prompt = "/ "
 	ti.SetWidth(40)

--- a/internal/ui/input/input.go
+++ b/internal/ui/input/input.go
@@ -53,7 +53,7 @@ func NewWithTitle(title string, prompt string) *Model {
 		text:   common.DefaultPalette.Get("input text"),
 		title:  common.DefaultPalette.Get("input title"),
 	}
-	ti := textinput.New()
+	ti := common.TextInputNew()
 	ti.SetWidth(40)
 	ti.Focus()
 	ti.Prompt = prompt

--- a/internal/ui/operations/bookmark/set_bookmark.go
+++ b/internal/ui/operations/bookmark/set_bookmark.go
@@ -108,7 +108,7 @@ func (s *SetBookmarkOperation) Scope() keybindings.Scope {
 func NewSetBookmarkOperation(context *context.MainContext, changeId string) *SetBookmarkOperation {
 	dimmedStyle := common.DefaultPalette.Get("revisions dimmed").Inline(true)
 	textStyle := common.DefaultPalette.Get("revisions text").Inline(true)
-	t := textinput.New()
+	t := common.TextInputNew()
 	t.ShowSuggestions = true
 	t.CharLimit = 120
 	t.Prompt = ""

--- a/internal/ui/operations/target_picker/target_picker.go
+++ b/internal/ui/operations/target_picker/target_picker.go
@@ -86,7 +86,7 @@ func NewModel(ctx *context.MainContext) *Model {
 	palette := common.DefaultPalette
 	text := palette.Get("picker text")
 	dimmed := palette.Get("picker dimmed")
-	ti := textinput.New()
+	ti := common.TextInputNew()
 	ti.Prompt = "> "
 	tis := ti.Styles()
 	tis.Focused.Prompt = dimmed

--- a/internal/ui/password/password.go
+++ b/internal/ui/password/password.go
@@ -26,7 +26,7 @@ func New(msg common.TogglePasswordMsg) *Model {
 	styles := styles{
 		border: common.DefaultPalette.GetBorder("password border", lipgloss.NormalBorder()).Padding(1),
 	}
-	ti := textinput.New()
+	ti := common.TextInputNew()
 	ti.Prompt = msg.Prompt
 	ti.EchoMode = textinput.EchoPassword
 	ps := ti.Styles()

--- a/internal/ui/status/status.go
+++ b/internal/ui/status/status.go
@@ -487,7 +487,7 @@ func New(context *context.MainContext) *Model {
 		title:    common.DefaultPalette.Get("status title").PaddingLeft(1).PaddingRight(1),
 	}
 
-	t := textinput.New()
+	t := common.TextInputNew()
 	t.SetWidth(50)
 	ts := t.Styles()
 	ts.Focused.Text = styles.text


### PR DESCRIPTION
Disclaimer: I am not a Go developer and this was mostly figured out by Claude Code.

Terminals like wezterm and ghostty on Linux report shift+backspace as a distinct key event via the Kitty keyboard protocol. The bubbles textinput default KeyMap only binds plain backspace, so shift+backspace was silently ignored. Add a PatchTextInputKeys helper that extends the KeyMap to also accept shift+backspace, shift+delete, and shift+alt+backspace, and apply it to all textinput instances.

Fixes #619