### PR TITLE
fix: command history clipping

### DIFF
--- a/internal/ui/commandhistory/model.go
+++ b/internal/ui/commandhistory/model.go
@@ -116,7 +116,7 @@ func (m *Model) ViewRect(dl *render.DisplayContext, box layout.Box) {
 	rest, _ := box.CutBottom(1)
 	dl.AddDim(rest.R, render.ZOverlay)
 
-	for _, item := range m.window() {
+	for _, item := range m.visibleWindow(maxWidth, area.Dy()) {
 		content := m.renderEntry(item.entry, maxWidth, item.selected)
 		w, h := lipgloss.Size(content)
 		y -= h
@@ -148,6 +148,51 @@ func (m *Model) window() []historyItem {
 		})
 	}
 	return items
+}
+
+func (m *Model) visibleWindow(maxWidth, maxHeight int) []historyItem {
+	items := m.window()
+	if len(items) == 0 || maxHeight <= 0 {
+		return items
+	}
+
+	selected := 0
+	for i, item := range items {
+		if item.selected {
+			selected = i
+			break
+		}
+	}
+
+	heights := make([]int, len(items))
+	for i, item := range items {
+		_, heights[i] = lipgloss.Size(m.renderEntry(item.entry, maxWidth, item.selected))
+	}
+
+	start := selected
+	end := selected + 1
+	used := heights[selected]
+	if used >= maxHeight {
+		return items[start:end]
+	}
+
+	for i := selected - 1; i >= 0; i-- {
+		if used+heights[i] > maxHeight {
+			break
+		}
+		start = i
+		used += heights[i]
+	}
+
+	for i := selected + 1; i < len(items); i++ {
+		if used+heights[i] > maxHeight {
+			break
+		}
+		end = i + 1
+		used += heights[i]
+	}
+
+	return items[start:end]
 }
 
 func (m *Model) clampViewport() {

--- a/internal/ui/commandhistory/model.go
+++ b/internal/ui/commandhistory/model.go
@@ -1,8 +1,6 @@
 package commandhistory
 
 import (
-	"strings"
-
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 	"github.com/idursun/jjui/internal/ui/actions"
@@ -18,7 +16,6 @@ import (
 var _ common.StackedModel = (*Model)(nil)
 
 const historyWindowSize = 10
-const commandMarkWidth = 3
 
 type selectHistoryItemMsg struct {
 	index int
@@ -30,20 +27,14 @@ type Model struct {
 	items         []flash.CommandHistoryEntry
 	selectedIndex int
 	windowStart   int
-	successStyle  lipgloss.Style
-	errorStyle    lipgloss.Style
-	textStyle     lipgloss.Style
-	matchedStyle  lipgloss.Style
+	renderer      flash.CardRenderer
 }
 
 func New(context *context.MainContext, source flash.CommandHistorySource) *Model {
 	m := &Model{
-		context:      context,
-		source:       source,
-		successStyle: common.DefaultPalette.Get("flash success"),
-		errorStyle:   common.DefaultPalette.Get("flash error"),
-		textStyle:    common.DefaultPalette.Get("flash text"),
-		matchedStyle: common.DefaultPalette.Get("flash matched"),
+		context:  context,
+		source:   source,
+		renderer: flash.NewCardRenderer(),
 	}
 	if source != nil {
 		m.items = source.CommandHistorySnapshot()
@@ -117,7 +108,7 @@ func (m *Model) ViewRect(dl *render.DisplayContext, box layout.Box) {
 	dl.AddDim(rest.R, render.ZOverlay)
 
 	for _, item := range m.visibleWindow(maxWidth, area.Dy()) {
-		content := m.renderEntry(item.entry, maxWidth, item.selected)
+		content := m.renderer.RenderHistoryEntry(item.entry, maxWidth, item.selected)
 		w, h := lipgloss.Size(content)
 		y -= h
 		rect := layout.Rect(area.Max.X-w, y, w, h)
@@ -166,7 +157,7 @@ func (m *Model) visibleWindow(maxWidth, maxHeight int) []historyItem {
 
 	heights := make([]int, len(items))
 	for i, item := range items {
-		_, heights[i] = lipgloss.Size(m.renderEntry(item.entry, maxWidth, item.selected))
+		_, heights[i] = lipgloss.Size(m.renderer.RenderHistoryEntry(item.entry, maxWidth, item.selected))
 	}
 
 	start := selected
@@ -230,43 +221,4 @@ func (m *Model) deleteSelected() {
 
 	m.selectedIndex = min(selected, len(m.items)-1)
 	m.clampViewport()
-}
-
-func (m *Model) renderEntry(entry flash.CommandHistoryEntry, maxWidth int, selected bool) string {
-	style := lipgloss.NewStyle()
-	if selected {
-		style = m.successStyle
-		if entry.Err != nil {
-			style = m.errorStyle
-		}
-	}
-
-	parts := []string{m.renderCommandLine(entry.Command, entry.Err)}
-	if selected {
-		if entry.Err != nil {
-			parts = append(parts, m.errorStyle.Render(entry.Err.Error()))
-		} else if entry.Text != "" {
-			parts = append(parts, style.Render(entry.Text))
-		}
-	}
-
-	content := strings.Join(parts, "\n")
-	if render.BlockWidth(content) > maxWidth {
-		content = lipgloss.NewStyle().Width(maxWidth).Render(content)
-	}
-
-	return lipgloss.NewStyle().
-		Border(lipgloss.NormalBorder()).
-		PaddingLeft(1).
-		PaddingRight(1).
-		BorderForeground(style.GetForeground()).
-		Render(content)
-}
-
-func (m *Model) renderCommandLine(command string, commandErr error) string {
-	mark := m.successStyle.Width(commandMarkWidth).Render("✓ ")
-	if commandErr != nil {
-		mark = m.errorStyle.Width(commandMarkWidth).Render("✗ ")
-	}
-	return mark + flash.ColorizeCommand(command, m.textStyle, m.matchedStyle)
 }

--- a/internal/ui/commandhistory/model.go
+++ b/internal/ui/commandhistory/model.go
@@ -5,7 +5,6 @@ import (
 	"charm.land/lipgloss/v2"
 	"github.com/idursun/jjui/internal/ui/actions"
 	"github.com/idursun/jjui/internal/ui/common"
-	"github.com/idursun/jjui/internal/ui/context"
 	"github.com/idursun/jjui/internal/ui/dispatch"
 	"github.com/idursun/jjui/internal/ui/flash"
 	"github.com/idursun/jjui/internal/ui/intents"
@@ -15,24 +14,19 @@ import (
 
 var _ common.StackedModel = (*Model)(nil)
 
-const historyWindowSize = 10
-
 type selectHistoryItemMsg struct {
 	index int
 }
 
 type Model struct {
-	context       *context.MainContext
 	source        flash.CommandHistorySource
 	items         []flash.CommandHistoryEntry
 	selectedIndex int
-	windowStart   int
 	renderer      flash.CardRenderer
 }
 
-func New(context *context.MainContext, source flash.CommandHistorySource) *Model {
+func New(source flash.CommandHistorySource) *Model {
 	m := &Model{
-		context:  context,
 		source:   source,
 		renderer: flash.NewCardRenderer(),
 	}
@@ -41,9 +35,8 @@ func New(context *context.MainContext, source flash.CommandHistorySource) *Model
 	}
 	if len(m.items) > 0 {
 		m.selectedIndex = len(m.items) - 1
-		m.windowStart = max(0, len(m.items)-historyWindowSize)
 	}
-	m.clampViewport()
+	m.clampSelection()
 	return m
 }
 
@@ -70,7 +63,7 @@ func (m *Model) HandleIntent(intent intents.Intent) (tea.Cmd, bool) {
 		// History renders oldest->newest from bottom to top, so move selection
 		// opposite to delta to keep j moving visually down and k up.
 		m.selectedIndex = min(len(m.items)-1, max(0, m.selectedIndex-intent.Delta))
-		m.clampViewport()
+		m.clampSelection()
 		return nil, true
 	case intents.CommandHistoryDeleteSelected:
 		m.deleteSelected()
@@ -91,7 +84,7 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 			return nil
 		}
 		m.selectedIndex = msg.index
-		m.clampViewport()
+		m.clampSelection()
 		return nil
 	case common.CloseViewMsg:
 		return common.Close
@@ -123,13 +116,44 @@ type historyItem struct {
 	selected bool
 }
 
-func (m *Model) window() []historyItem {
-	if len(m.items) == 0 {
+func (m *Model) visibleWindow(maxWidth, maxHeight int) []historyItem {
+	if len(m.items) == 0 || maxHeight <= 0 {
 		return nil
 	}
-	m.clampViewport()
-	start := m.windowStart
-	end := min(len(m.items), start+historyWindowSize)
+	m.clampSelection()
+
+	heights := make([]int, len(m.items))
+	for i, entry := range m.items {
+		_, heights[i] = lipgloss.Size(m.renderer.RenderHistoryEntry(entry, maxWidth, i == m.selectedIndex))
+	}
+
+	start := m.selectedIndex
+	end := m.selectedIndex + 1
+	used := heights[m.selectedIndex]
+	if used >= maxHeight {
+		return []historyItem{{
+			entry:    m.items[m.selectedIndex],
+			index:    m.selectedIndex,
+			selected: true,
+		}}
+	}
+
+	for i := m.selectedIndex - 1; i >= 0; i-- {
+		if used+heights[i] > maxHeight {
+			break
+		}
+		start = i
+		used += heights[i]
+	}
+
+	for i := m.selectedIndex + 1; i < len(m.items); i++ {
+		if used+heights[i] > maxHeight {
+			break
+		}
+		end = i + 1
+		used += heights[i]
+	}
+
 	items := make([]historyItem, 0, end-start)
 	for i := start; i < end; i++ {
 		items = append(items, historyItem{
@@ -141,67 +165,16 @@ func (m *Model) window() []historyItem {
 	return items
 }
 
-func (m *Model) visibleWindow(maxWidth, maxHeight int) []historyItem {
-	items := m.window()
-	if len(items) == 0 || maxHeight <= 0 {
-		return items
-	}
-
-	selected := 0
-	for i, item := range items {
-		if item.selected {
-			selected = i
-			break
-		}
-	}
-
-	heights := make([]int, len(items))
-	for i, item := range items {
-		_, heights[i] = lipgloss.Size(m.renderer.RenderHistoryEntry(item.entry, maxWidth, item.selected))
-	}
-
-	start := selected
-	end := selected + 1
-	used := heights[selected]
-	if used >= maxHeight {
-		return items[start:end]
-	}
-
-	for i := selected - 1; i >= 0; i-- {
-		if used+heights[i] > maxHeight {
-			break
-		}
-		start = i
-		used += heights[i]
-	}
-
-	for i := selected + 1; i < len(items); i++ {
-		if used+heights[i] > maxHeight {
-			break
-		}
-		end = i + 1
-		used += heights[i]
-	}
-
-	return items[start:end]
-}
-
-func (m *Model) clampViewport() {
+func (m *Model) clampSelection() {
 	if len(m.items) == 0 {
 		m.selectedIndex = 0
-		m.windowStart = 0
 		return
 	}
 	m.selectedIndex = min(len(m.items)-1, max(0, m.selectedIndex))
-	maxStart := max(0, len(m.items)-historyWindowSize)
-	m.windowStart = min(m.selectedIndex, min(maxStart, max(0, m.windowStart)))
-	if m.selectedIndex >= m.windowStart+historyWindowSize {
-		m.windowStart = m.selectedIndex - historyWindowSize + 1
-	}
 }
 
 func (m *Model) deleteSelected() {
-	m.clampViewport()
+	m.clampSelection()
 	if len(m.items) == 0 {
 		return
 	}
@@ -215,10 +188,9 @@ func (m *Model) deleteSelected() {
 
 	if len(m.items) == 0 {
 		m.selectedIndex = 0
-		m.windowStart = 0
 		return
 	}
 
 	m.selectedIndex = min(selected, len(m.items)-1)
-	m.clampViewport()
+	m.clampSelection()
 }

--- a/internal/ui/commandhistory/model_test.go
+++ b/internal/ui/commandhistory/model_test.go
@@ -2,6 +2,7 @@ package commandhistory
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/idursun/jjui/internal/ui/common"
@@ -91,6 +92,24 @@ func TestCommandHistory_ViewOnlyShowsSelectedOutput(t *testing.T) {
 	assert.Contains(t, rendered, "older-output")
 	assert.Contains(t, rendered, "jj newer")
 	assert.NotContains(t, rendered, "newer-output")
+}
+
+func TestCommandHistory_ViewKeepsSelectedEntryVisibleWhenItExpands(t *testing.T) {
+	source := flash.New(test.NewTestContext(test.NewTestCommandRunner(t)))
+	for i := range 6 {
+		source.AddWithCommand(fmt.Sprintf("output-%d", i), fmt.Sprintf("jj cmd %d", i), nil)
+	}
+	source.AddWithCommand(strings.Repeat("expanded line\n", 4)+"expanded line", "jj expanded", nil)
+
+	history := New(test.NewTestContext(test.NewTestCommandRunner(t)), source)
+
+	dl := render.NewDisplayContext()
+	box := layout.NewBox(layout.Rect(0, 0, 60, 12))
+	history.ViewRect(dl, box)
+	rendered := dl.RenderToString(box.R.Dx(), box.R.Dy())
+
+	assert.Contains(t, rendered, "jj expanded")
+	assert.Contains(t, rendered, "expanded line")
 }
 
 func TestCommandHistory_DeleteSelectedRemovesFromSourceAndLiveMessages(t *testing.T) {

--- a/internal/ui/commandhistory/model_test.go
+++ b/internal/ui/commandhistory/model_test.go
@@ -10,13 +10,12 @@ import (
 	"github.com/idursun/jjui/internal/ui/intents"
 	"github.com/idursun/jjui/internal/ui/layout"
 	"github.com/idursun/jjui/internal/ui/render"
-	"github.com/idursun/jjui/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestFlash_CompletionBeforeRunning_ReconcilesByCommandID(t *testing.T) {
-	source := flash.New(test.NewTestContext(test.NewTestCommandRunner(t)))
+	source := flash.New()
 
 	cmd := source.Update(common.CommandCompletedMsg{ID: 9, Output: "ok", Err: nil})
 	assert.Nil(t, cmd)
@@ -33,7 +32,7 @@ func TestFlash_CompletionBeforeRunning_ReconcilesByCommandID(t *testing.T) {
 }
 
 func TestFlash_HistoryIsBoundedToConfiguredLimit(t *testing.T) {
-	source := flash.New(test.NewTestContext(test.NewTestCommandRunner(t)))
+	source := flash.New()
 
 	for i := 1; i <= flash.HistoryLimit+5; i++ {
 		source.AddWithCommand(fmt.Sprintf("m-%d", i), fmt.Sprintf("jj cmd %d", i), nil)
@@ -47,7 +46,7 @@ func TestFlash_HistoryIsBoundedToConfiguredLimit(t *testing.T) {
 }
 
 func TestFlash_HistoryOnlyContainsCommandMessages(t *testing.T) {
-	source := flash.New(test.NewTestContext(test.NewTestCommandRunner(t)))
+	source := flash.New()
 
 	source.Update(intents.AddMessage{Text: "user message"})
 	source.AddWithCommand("command output", "jj status", nil)
@@ -60,12 +59,12 @@ func TestFlash_HistoryOnlyContainsCommandMessages(t *testing.T) {
 }
 
 func TestCommandHistory_NavigationAdjustsSelection(t *testing.T) {
-	source := flash.New(test.NewTestContext(test.NewTestCommandRunner(t)))
+	source := flash.New()
 	for i := range 6 {
 		source.AddWithCommand(fmt.Sprintf("m-%d", i), fmt.Sprintf("jj cmd %d", i), nil)
 	}
 
-	history := New(test.NewTestContext(test.NewTestCommandRunner(t)), source)
+	history := New(source)
 	assert.Equal(t, 5, history.selectedIndex)
 
 	history.Update(intents.CommandHistoryNavigate{Delta: 1})
@@ -77,11 +76,11 @@ func TestCommandHistory_NavigationAdjustsSelection(t *testing.T) {
 }
 
 func TestCommandHistory_ViewOnlyShowsSelectedOutput(t *testing.T) {
-	source := flash.New(test.NewTestContext(test.NewTestCommandRunner(t)))
+	source := flash.New()
 	source.AddWithCommand("older-output", "jj older", nil)
 	source.AddWithCommand("newer-output", "jj newer", nil)
 
-	history := New(test.NewTestContext(test.NewTestCommandRunner(t)), source)
+	history := New(source)
 	history.Update(intents.CommandHistoryNavigate{Delta: 1}) // select older
 
 	dl := render.NewDisplayContext()
@@ -95,13 +94,13 @@ func TestCommandHistory_ViewOnlyShowsSelectedOutput(t *testing.T) {
 }
 
 func TestCommandHistory_ViewKeepsSelectedEntryVisibleWhenItExpands(t *testing.T) {
-	source := flash.New(test.NewTestContext(test.NewTestCommandRunner(t)))
+	source := flash.New()
 	for i := range 6 {
 		source.AddWithCommand(fmt.Sprintf("output-%d", i), fmt.Sprintf("jj cmd %d", i), nil)
 	}
 	source.AddWithCommand(strings.Repeat("expanded line\n", 4)+"expanded line", "jj expanded", nil)
 
-	history := New(test.NewTestContext(test.NewTestCommandRunner(t)), source)
+	history := New(source)
 
 	dl := render.NewDisplayContext()
 	box := layout.NewBox(layout.Rect(0, 0, 60, 12))
@@ -112,12 +111,29 @@ func TestCommandHistory_ViewKeepsSelectedEntryVisibleWhenItExpands(t *testing.T)
 	assert.Contains(t, rendered, "expanded line")
 }
 
+func TestCommandHistory_ViewUsesAvailableHeightInsteadOfFixedWindow(t *testing.T) {
+	source := flash.New()
+	for i := range 12 {
+		source.AddWithCommand(fmt.Sprintf("output-%d", i), fmt.Sprintf("jj cmd %d", i), nil)
+	}
+
+	history := New(source)
+
+	dl := render.NewDisplayContext()
+	box := layout.NewBox(layout.Rect(0, 0, 60, 60))
+	history.ViewRect(dl, box)
+	rendered := dl.RenderToString(box.R.Dx(), box.R.Dy())
+
+	assert.Contains(t, rendered, "jj cmd 0")
+	assert.Contains(t, rendered, "jj cmd 11")
+}
+
 func TestCommandHistory_DeleteSelectedRemovesFromSourceAndLiveMessages(t *testing.T) {
-	source := flash.New(test.NewTestContext(test.NewTestCommandRunner(t)))
+	source := flash.New()
 	source.AddWithCommand("older-output", "jj older", nil)
 	source.AddWithCommand("newer-output", "jj newer", nil)
 
-	history := New(test.NewTestContext(test.NewTestCommandRunner(t)), source)
+	history := New(source)
 	history.Update(intents.CommandHistoryNavigate{Delta: 1}) // select older
 	history.Update(intents.CommandHistoryDeleteSelected{})
 
@@ -133,9 +149,9 @@ func TestCommandHistory_DeleteSelectedRemovesFromSourceAndLiveMessages(t *testin
 }
 
 func TestCommandHistory_CloseReturnsCloseViewMsg(t *testing.T) {
-	source := flash.New(test.NewTestContext(test.NewTestCommandRunner(t)))
+	source := flash.New()
 	source.AddWithCommand("output", "jj cmd", nil)
-	history := New(test.NewTestContext(test.NewTestCommandRunner(t)), source)
+	history := New(source)
 
 	cmd := history.Update(intents.CommandHistoryClose{})
 	require.NotNil(t, cmd)

--- a/internal/ui/flash/command_history.go
+++ b/internal/ui/flash/command_history.go
@@ -1,4 +1,4 @@
-package commandhistory
+package flash
 
 import (
 	tea "charm.land/bubbletea/v2"
@@ -6,32 +6,31 @@ import (
 	"github.com/idursun/jjui/internal/ui/actions"
 	"github.com/idursun/jjui/internal/ui/common"
 	"github.com/idursun/jjui/internal/ui/dispatch"
-	"github.com/idursun/jjui/internal/ui/flash"
 	"github.com/idursun/jjui/internal/ui/intents"
 	"github.com/idursun/jjui/internal/ui/layout"
 	"github.com/idursun/jjui/internal/ui/render"
 )
 
-var _ common.StackedModel = (*Model)(nil)
+var _ common.StackedModel = (*CommandHistoryModel)(nil)
 
 type selectHistoryItemMsg struct {
 	index int
 }
 
-type Model struct {
-	source        flash.CommandHistorySource
-	items         []flash.CommandHistoryEntry
+type CommandHistoryModel struct {
+	source        *Model
+	items         []commandHistoryEntry
 	selectedIndex int
-	renderer      flash.CardRenderer
+	renderer      CardRenderer
 }
 
-func New(source flash.CommandHistorySource) *Model {
-	m := &Model{
+func newCommandHistory(source *Model) *CommandHistoryModel {
+	m := &CommandHistoryModel{
 		source:   source,
-		renderer: flash.NewCardRenderer(),
+		renderer: NewCardRenderer(),
 	}
 	if source != nil {
-		m.items = source.CommandHistorySnapshot()
+		m.items = source.commandHistorySnapshot()
 	}
 	if len(m.items) > 0 {
 		m.selectedIndex = len(m.items) - 1
@@ -40,11 +39,11 @@ func New(source flash.CommandHistorySource) *Model {
 	return m
 }
 
-func (m *Model) Init() tea.Cmd {
+func (m *CommandHistoryModel) Init() tea.Cmd {
 	return nil
 }
 
-func (m *Model) Scopes() []dispatch.Scope {
+func (m *CommandHistoryModel) Scopes() []dispatch.Scope {
 	return []dispatch.Scope{
 		{
 			Name:    actions.ScopeCommandHistory,
@@ -54,7 +53,7 @@ func (m *Model) Scopes() []dispatch.Scope {
 	}
 }
 
-func (m *Model) HandleIntent(intent intents.Intent) (tea.Cmd, bool) {
+func (m *CommandHistoryModel) HandleIntent(intent intents.Intent) (tea.Cmd, bool) {
 	switch intent := intent.(type) {
 	case intents.CommandHistoryNavigate:
 		if len(m.items) == 0 {
@@ -74,7 +73,7 @@ func (m *Model) HandleIntent(intent intents.Intent) (tea.Cmd, bool) {
 	return nil, false
 }
 
-func (m *Model) Update(msg tea.Msg) tea.Cmd {
+func (m *CommandHistoryModel) Update(msg tea.Msg) tea.Cmd {
 	switch msg := msg.(type) {
 	case intents.Intent:
 		cmd, _ := m.HandleIntent(msg)
@@ -92,7 +91,7 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 	return nil
 }
 
-func (m *Model) ViewRect(dl *render.DisplayContext, box layout.Box) {
+func (m *CommandHistoryModel) ViewRect(dl *render.DisplayContext, box layout.Box) {
 	area := box.R
 	y := area.Max.Y - 1
 	maxWidth := area.Dx() - 4
@@ -111,12 +110,12 @@ func (m *Model) ViewRect(dl *render.DisplayContext, box layout.Box) {
 }
 
 type historyItem struct {
-	entry    flash.CommandHistoryEntry
+	entry    commandHistoryEntry
 	index    int
 	selected bool
 }
 
-func (m *Model) visibleWindow(maxWidth, maxHeight int) []historyItem {
+func (m *CommandHistoryModel) visibleWindow(maxWidth, maxHeight int) []historyItem {
 	if len(m.items) == 0 || maxHeight <= 0 {
 		return nil
 	}
@@ -165,7 +164,7 @@ func (m *Model) visibleWindow(maxWidth, maxHeight int) []historyItem {
 	return items
 }
 
-func (m *Model) clampSelection() {
+func (m *CommandHistoryModel) clampSelection() {
 	if len(m.items) == 0 {
 		m.selectedIndex = 0
 		return
@@ -173,7 +172,7 @@ func (m *Model) clampSelection() {
 	m.selectedIndex = min(len(m.items)-1, max(0, m.selectedIndex))
 }
 
-func (m *Model) deleteSelected() {
+func (m *CommandHistoryModel) deleteSelected() {
 	m.clampSelection()
 	if len(m.items) == 0 {
 		return
@@ -183,7 +182,7 @@ func (m *Model) deleteSelected() {
 	removed := m.items[selected]
 	m.items = append(m.items[:selected], m.items[selected+1:]...)
 	if m.source != nil {
-		m.source.DeleteCommandHistoryByID(removed.ID)
+		m.source.deleteCommandHistoryByID(removed.ID)
 	}
 
 	if len(m.items) == 0 {

--- a/internal/ui/flash/command_history.go
+++ b/internal/ui/flash/command_history.go
@@ -17,6 +17,13 @@ type selectHistoryItemMsg struct {
 	index int
 }
 
+type commandHistoryEntry struct {
+	ID      uint64
+	Command string
+	Text    string
+	Err     error
+}
+
 type CommandHistoryModel struct {
 	source        *Model
 	items         []commandHistoryEntry
@@ -24,19 +31,19 @@ type CommandHistoryModel struct {
 	renderer      CardRenderer
 }
 
-func newCommandHistory(source *Model) *CommandHistoryModel {
-	m := &CommandHistoryModel{
-		source:   source,
+func (m *Model) NewHistory() *CommandHistoryModel {
+	history := &CommandHistoryModel{
+		source:   m,
 		renderer: NewCardRenderer(),
 	}
-	if source != nil {
-		m.items = source.commandHistorySnapshot()
+	if history.source != nil {
+		history.items = history.source.commandHistorySnapshot()
 	}
-	if len(m.items) > 0 {
-		m.selectedIndex = len(m.items) - 1
+	if len(history.items) > 0 {
+		history.selectedIndex = len(history.items) - 1
 	}
-	m.clampSelection()
-	return m
+	history.clampSelection()
+	return history
 }
 
 func (m *CommandHistoryModel) Init() tea.Cmd {
@@ -193,4 +200,28 @@ func (m *CommandHistoryModel) deleteSelected() {
 
 	m.selectedIndex = min(selected, len(m.items)-1)
 	m.clampSelection()
+}
+
+func (m *Model) commandHistorySnapshot() []commandHistoryEntry {
+	out := make([]commandHistoryEntry, 0, len(m.messageHistory))
+	for _, item := range m.messageHistory {
+		out = append(out, commandHistoryEntry{
+			ID:      item.id,
+			Command: item.command,
+			Text:    item.text,
+			Err:     item.error,
+		})
+	}
+	return out
+}
+
+func (m *Model) deleteCommandHistoryByID(id uint64) {
+	for i, item := range m.messageHistory {
+		if item.id != id {
+			continue
+		}
+		m.messageHistory = append(m.messageHistory[:i], m.messageHistory[i+1:]...)
+		break
+	}
+	m.removeLiveMessageByID(id)
 }

--- a/internal/ui/flash/command_history.go
+++ b/internal/ui/flash/command_history.go
@@ -93,75 +93,76 @@ func (m *CommandHistoryModel) Update(msg tea.Msg) tea.Cmd {
 
 func (m *CommandHistoryModel) ViewRect(dl *render.DisplayContext, box layout.Box) {
 	area := box.R
-	y := area.Max.Y - 1
+	y := area.Max.Y
 	maxWidth := area.Dx() - 4
 
 	rest, _ := box.CutBottom(1)
 	dl.AddDim(rest.R, render.ZOverlay)
 
-	for _, item := range m.visibleWindow(maxWidth, area.Dy()) {
-		content := m.renderer.RenderHistoryEntry(item.entry, maxWidth, item.selected)
-		w, h := lipgloss.Size(content)
-		y -= h
-		rect := layout.Rect(area.Max.X-w, y, w, h)
-		dl.AddDraw(rect, content, render.ZOverlay)
+	for _, item := range m.renderedItems(maxWidth, area.Dy()) {
+		y -= item.h
+		rect := layout.Rect(area.Max.X-item.w, y, item.w, item.h)
+		dl.AddDraw(rect, item.content, render.ZOverlay)
 		dl.AddInteraction(rect, selectHistoryItemMsg{index: item.index}, render.InteractionClick, render.ZOverlay)
 	}
 }
 
-type historyItem struct {
-	entry    commandHistoryEntry
-	index    int
-	selected bool
+type renderedHistoryItem struct {
+	index   int
+	content string
+	w       int
+	h       int
 }
 
-func (m *CommandHistoryModel) visibleWindow(maxWidth, maxHeight int) []historyItem {
+func (m *CommandHistoryModel) renderedItems(maxWidth, maxHeight int) []renderedHistoryItem {
 	if len(m.items) == 0 || maxHeight <= 0 {
 		return nil
 	}
 	m.clampSelection()
 
-	heights := make([]int, len(m.items))
-	for i, entry := range m.items {
-		_, heights[i] = lipgloss.Size(m.renderer.RenderHistoryEntry(entry, maxWidth, i == m.selectedIndex))
+	selected := m.renderedItem(m.selectedIndex, maxWidth)
+	if selected.h >= maxHeight {
+		return []renderedHistoryItem{selected}
 	}
 
-	start := m.selectedIndex
-	end := m.selectedIndex + 1
-	used := heights[m.selectedIndex]
-	if used >= maxHeight {
-		return []historyItem{{
-			entry:    m.items[m.selectedIndex],
-			index:    m.selectedIndex,
-			selected: true,
-		}}
-	}
-
+	used := selected.h
+	before := make([]renderedHistoryItem, 0, m.selectedIndex)
 	for i := m.selectedIndex - 1; i >= 0; i-- {
-		if used+heights[i] > maxHeight {
+		item := m.renderedItem(i, maxWidth)
+		if used+item.h > maxHeight {
 			break
 		}
-		start = i
-		used += heights[i]
+		before = append(before, item)
+		used += item.h
 	}
+
+	items := make([]renderedHistoryItem, 0, len(before)+1)
+	for i := len(before) - 1; i >= 0; i-- {
+		items = append(items, before[i])
+	}
+	items = append(items, selected)
 
 	for i := m.selectedIndex + 1; i < len(m.items); i++ {
-		if used+heights[i] > maxHeight {
+		item := m.renderedItem(i, maxWidth)
+		if used+item.h > maxHeight {
 			break
 		}
-		end = i + 1
-		used += heights[i]
+		items = append(items, item)
+		used += item.h
 	}
 
-	items := make([]historyItem, 0, end-start)
-	for i := start; i < end; i++ {
-		items = append(items, historyItem{
-			entry:    m.items[i],
-			index:    i,
-			selected: i == m.selectedIndex,
-		})
-	}
 	return items
+}
+
+func (m *CommandHistoryModel) renderedItem(index, maxWidth int) renderedHistoryItem {
+	content := m.renderer.RenderHistoryEntry(m.items[index], maxWidth, index == m.selectedIndex)
+	w, h := lipgloss.Size(content)
+	return renderedHistoryItem{
+		index:   index,
+		content: content,
+		w:       w,
+		h:       h,
+	}
 }
 
 func (m *CommandHistoryModel) clampSelection() {

--- a/internal/ui/flash/command_history_test.go
+++ b/internal/ui/flash/command_history_test.go
@@ -1,4 +1,4 @@
-package commandhistory
+package flash
 
 import (
 	"fmt"
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/idursun/jjui/internal/ui/common"
-	"github.com/idursun/jjui/internal/ui/flash"
 	"github.com/idursun/jjui/internal/ui/intents"
 	"github.com/idursun/jjui/internal/ui/layout"
 	"github.com/idursun/jjui/internal/ui/render"
@@ -15,16 +14,16 @@ import (
 )
 
 func TestFlash_CompletionBeforeRunning_ReconcilesByCommandID(t *testing.T) {
-	source := flash.New()
+	source := New()
 
 	cmd := source.Update(common.CommandCompletedMsg{ID: 9, Output: "ok", Err: nil})
 	assert.Nil(t, cmd)
-	assert.Empty(t, source.CommandHistorySnapshot())
+	assert.Empty(t, source.commandHistorySnapshot())
 	assert.Equal(t, 0, source.LiveMessagesCount())
 
 	cmd = source.Update(common.CommandRunningMsg{ID: 9, Command: "jj git fetch"})
 	assert.NotNil(t, cmd)
-	snapshot := source.CommandHistorySnapshot()
+	snapshot := source.commandHistorySnapshot()
 	if assert.Len(t, snapshot, 1) {
 		assert.Equal(t, "jj git fetch", snapshot[0].Command)
 		assert.Equal(t, "ok", snapshot[0].Text)
@@ -32,26 +31,26 @@ func TestFlash_CompletionBeforeRunning_ReconcilesByCommandID(t *testing.T) {
 }
 
 func TestFlash_HistoryIsBoundedToConfiguredLimit(t *testing.T) {
-	source := flash.New()
+	source := New()
 
-	for i := 1; i <= flash.HistoryLimit+5; i++ {
+	for i := 1; i <= HistoryLimit+5; i++ {
 		source.AddWithCommand(fmt.Sprintf("m-%d", i), fmt.Sprintf("jj cmd %d", i), nil)
 	}
 
-	snapshot := source.CommandHistorySnapshot()
-	if assert.Len(t, snapshot, flash.HistoryLimit) {
+	snapshot := source.commandHistorySnapshot()
+	if assert.Len(t, snapshot, HistoryLimit) {
 		assert.Equal(t, "m-6", snapshot[0].Text)
 		assert.Equal(t, "m-55", snapshot[len(snapshot)-1].Text)
 	}
 }
 
 func TestFlash_HistoryOnlyContainsCommandMessages(t *testing.T) {
-	source := flash.New()
+	source := New()
 
 	source.Update(intents.AddMessage{Text: "user message"})
 	source.AddWithCommand("command output", "jj status", nil)
 
-	snapshot := source.CommandHistorySnapshot()
+	snapshot := source.commandHistorySnapshot()
 	if assert.Len(t, snapshot, 1) {
 		assert.Equal(t, "jj status", snapshot[0].Command)
 		assert.Equal(t, "command output", snapshot[0].Text)
@@ -59,12 +58,12 @@ func TestFlash_HistoryOnlyContainsCommandMessages(t *testing.T) {
 }
 
 func TestCommandHistory_NavigationAdjustsSelection(t *testing.T) {
-	source := flash.New()
+	source := New()
 	for i := range 6 {
 		source.AddWithCommand(fmt.Sprintf("m-%d", i), fmt.Sprintf("jj cmd %d", i), nil)
 	}
 
-	history := New(source)
+	history := newCommandHistory(source)
 	assert.Equal(t, 5, history.selectedIndex)
 
 	history.Update(intents.CommandHistoryNavigate{Delta: 1})
@@ -76,11 +75,11 @@ func TestCommandHistory_NavigationAdjustsSelection(t *testing.T) {
 }
 
 func TestCommandHistory_ViewOnlyShowsSelectedOutput(t *testing.T) {
-	source := flash.New()
+	source := New()
 	source.AddWithCommand("older-output", "jj older", nil)
 	source.AddWithCommand("newer-output", "jj newer", nil)
 
-	history := New(source)
+	history := newCommandHistory(source)
 	history.Update(intents.CommandHistoryNavigate{Delta: 1}) // select older
 
 	dl := render.NewDisplayContext()
@@ -94,13 +93,13 @@ func TestCommandHistory_ViewOnlyShowsSelectedOutput(t *testing.T) {
 }
 
 func TestCommandHistory_ViewKeepsSelectedEntryVisibleWhenItExpands(t *testing.T) {
-	source := flash.New()
+	source := New()
 	for i := range 6 {
 		source.AddWithCommand(fmt.Sprintf("output-%d", i), fmt.Sprintf("jj cmd %d", i), nil)
 	}
 	source.AddWithCommand(strings.Repeat("expanded line\n", 4)+"expanded line", "jj expanded", nil)
 
-	history := New(source)
+	history := newCommandHistory(source)
 
 	dl := render.NewDisplayContext()
 	box := layout.NewBox(layout.Rect(0, 0, 60, 12))
@@ -112,12 +111,12 @@ func TestCommandHistory_ViewKeepsSelectedEntryVisibleWhenItExpands(t *testing.T)
 }
 
 func TestCommandHistory_ViewUsesAvailableHeightInsteadOfFixedWindow(t *testing.T) {
-	source := flash.New()
+	source := New()
 	for i := range 12 {
 		source.AddWithCommand(fmt.Sprintf("output-%d", i), fmt.Sprintf("jj cmd %d", i), nil)
 	}
 
-	history := New(source)
+	history := newCommandHistory(source)
 
 	dl := render.NewDisplayContext()
 	box := layout.NewBox(layout.Rect(0, 0, 60, 60))
@@ -129,11 +128,11 @@ func TestCommandHistory_ViewUsesAvailableHeightInsteadOfFixedWindow(t *testing.T
 }
 
 func TestCommandHistory_DeleteSelectedRemovesFromSourceAndLiveMessages(t *testing.T) {
-	source := flash.New()
+	source := New()
 	source.AddWithCommand("older-output", "jj older", nil)
 	source.AddWithCommand("newer-output", "jj newer", nil)
 
-	history := New(source)
+	history := newCommandHistory(source)
 	history.Update(intents.CommandHistoryNavigate{Delta: 1}) // select older
 	history.Update(intents.CommandHistoryDeleteSelected{})
 
@@ -141,7 +140,7 @@ func TestCommandHistory_DeleteSelectedRemovesFromSourceAndLiveMessages(t *testin
 		assert.Equal(t, "jj newer", history.items[0].Command)
 	}
 
-	snapshot := source.CommandHistorySnapshot()
+	snapshot := source.commandHistorySnapshot()
 	if assert.Len(t, snapshot, 1) {
 		assert.Equal(t, "jj newer", snapshot[0].Command)
 	}
@@ -149,9 +148,9 @@ func TestCommandHistory_DeleteSelectedRemovesFromSourceAndLiveMessages(t *testin
 }
 
 func TestCommandHistory_CloseReturnsCloseViewMsg(t *testing.T) {
-	source := flash.New()
+	source := New()
 	source.AddWithCommand("output", "jj cmd", nil)
-	history := New(source)
+	history := newCommandHistory(source)
 
 	cmd := history.Update(intents.CommandHistoryClose{})
 	require.NotNil(t, cmd)

--- a/internal/ui/flash/command_history_test.go
+++ b/internal/ui/flash/command_history_test.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/idursun/jjui/internal/ui/common"
 	"github.com/idursun/jjui/internal/ui/intents"
 	"github.com/idursun/jjui/internal/ui/layout"
 	"github.com/idursun/jjui/internal/ui/render"
@@ -13,57 +12,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestFlash_CompletionBeforeRunning_ReconcilesByCommandID(t *testing.T) {
-	source := New()
-
-	cmd := source.Update(common.CommandCompletedMsg{ID: 9, Output: "ok", Err: nil})
-	assert.Nil(t, cmd)
-	assert.Empty(t, source.commandHistorySnapshot())
-	assert.Equal(t, 0, source.LiveMessagesCount())
-
-	cmd = source.Update(common.CommandRunningMsg{ID: 9, Command: "jj git fetch"})
-	assert.NotNil(t, cmd)
-	snapshot := source.commandHistorySnapshot()
-	if assert.Len(t, snapshot, 1) {
-		assert.Equal(t, "jj git fetch", snapshot[0].Command)
-		assert.Equal(t, "ok", snapshot[0].Text)
-	}
-}
-
-func TestFlash_HistoryIsBoundedToConfiguredLimit(t *testing.T) {
-	source := New()
-
-	for i := 1; i <= HistoryLimit+5; i++ {
-		source.AddWithCommand(fmt.Sprintf("m-%d", i), fmt.Sprintf("jj cmd %d", i), nil)
-	}
-
-	snapshot := source.commandHistorySnapshot()
-	if assert.Len(t, snapshot, HistoryLimit) {
-		assert.Equal(t, "m-6", snapshot[0].Text)
-		assert.Equal(t, "m-55", snapshot[len(snapshot)-1].Text)
-	}
-}
-
-func TestFlash_HistoryOnlyContainsCommandMessages(t *testing.T) {
-	source := New()
-
-	source.Update(intents.AddMessage{Text: "user message"})
-	source.AddWithCommand("command output", "jj status", nil)
-
-	snapshot := source.commandHistorySnapshot()
-	if assert.Len(t, snapshot, 1) {
-		assert.Equal(t, "jj status", snapshot[0].Command)
-		assert.Equal(t, "command output", snapshot[0].Text)
-	}
-}
-
 func TestCommandHistory_NavigationAdjustsSelection(t *testing.T) {
 	source := New()
-	for i := range 6 {
-		source.AddWithCommand(fmt.Sprintf("m-%d", i), fmt.Sprintf("jj cmd %d", i), nil)
+	for range 6 {
+		source.AddWithCommand("output", "jj cmd", nil)
 	}
 
-	history := newCommandHistory(source)
+	history := source.NewHistory()
 	assert.Equal(t, 5, history.selectedIndex)
 
 	history.Update(intents.CommandHistoryNavigate{Delta: 1})
@@ -79,7 +34,7 @@ func TestCommandHistory_ViewOnlyShowsSelectedOutput(t *testing.T) {
 	source.AddWithCommand("older-output", "jj older", nil)
 	source.AddWithCommand("newer-output", "jj newer", nil)
 
-	history := newCommandHistory(source)
+	history := source.NewHistory()
 	history.Update(intents.CommandHistoryNavigate{Delta: 1}) // select older
 
 	dl := render.NewDisplayContext()
@@ -99,7 +54,7 @@ func TestCommandHistory_ViewKeepsSelectedEntryVisibleWhenItExpands(t *testing.T)
 	}
 	source.AddWithCommand(strings.Repeat("expanded line\n", 4)+"expanded line", "jj expanded", nil)
 
-	history := newCommandHistory(source)
+	history := source.NewHistory()
 
 	dl := render.NewDisplayContext()
 	box := layout.NewBox(layout.Rect(0, 0, 60, 12))
@@ -116,7 +71,7 @@ func TestCommandHistory_ViewUsesAvailableHeightInsteadOfFixedWindow(t *testing.T
 		source.AddWithCommand(fmt.Sprintf("output-%d", i), fmt.Sprintf("jj cmd %d", i), nil)
 	}
 
-	history := newCommandHistory(source)
+	history := source.NewHistory()
 
 	dl := render.NewDisplayContext()
 	box := layout.NewBox(layout.Rect(0, 0, 60, 60))
@@ -132,7 +87,7 @@ func TestCommandHistory_ViewDoesNotClipTopBorderOnExactFit(t *testing.T) {
 	source.AddWithCommand("older-output", "jj older", nil)
 	source.AddWithCommand("newer-output", "jj newer", nil)
 
-	history := newCommandHistory(source)
+	history := source.NewHistory()
 	items := history.renderedItems(60-4, 100)
 	require.Len(t, items, 2)
 
@@ -155,7 +110,7 @@ func TestCommandHistory_DeleteSelectedRemovesFromSourceAndLiveMessages(t *testin
 	source.AddWithCommand("older-output", "jj older", nil)
 	source.AddWithCommand("newer-output", "jj newer", nil)
 
-	history := newCommandHistory(source)
+	history := source.NewHistory()
 	history.Update(intents.CommandHistoryNavigate{Delta: 1}) // select older
 	history.Update(intents.CommandHistoryDeleteSelected{})
 
@@ -168,15 +123,4 @@ func TestCommandHistory_DeleteSelectedRemovesFromSourceAndLiveMessages(t *testin
 		assert.Equal(t, "jj newer", snapshot[0].Command)
 	}
 	assert.Equal(t, 1, source.LiveMessagesCount())
-}
-
-func TestCommandHistory_CloseReturnsCloseViewMsg(t *testing.T) {
-	source := New()
-	source.AddWithCommand("output", "jj cmd", nil)
-	history := newCommandHistory(source)
-
-	cmd := history.Update(intents.CommandHistoryClose{})
-	require.NotNil(t, cmd)
-	_, ok := cmd().(common.CloseViewMsg)
-	assert.True(t, ok)
 }

--- a/internal/ui/flash/command_history_test.go
+++ b/internal/ui/flash/command_history_test.go
@@ -127,6 +127,29 @@ func TestCommandHistory_ViewUsesAvailableHeightInsteadOfFixedWindow(t *testing.T
 	assert.Contains(t, rendered, "jj cmd 11")
 }
 
+func TestCommandHistory_ViewDoesNotClipTopBorderOnExactFit(t *testing.T) {
+	source := New()
+	source.AddWithCommand("older-output", "jj older", nil)
+	source.AddWithCommand("newer-output", "jj newer", nil)
+
+	history := newCommandHistory(source)
+	items := history.renderedItems(60-4, 100)
+	require.Len(t, items, 2)
+
+	totalHeight := 0
+	for _, item := range items {
+		totalHeight += item.h
+	}
+
+	dl := render.NewDisplayContext()
+	box := layout.NewBox(layout.Rect(0, 0, 60, totalHeight))
+	history.ViewRect(dl, box)
+	rendered := dl.RenderToString(box.R.Dx(), box.R.Dy())
+
+	firstLine := strings.Split(rendered, "\n")[0]
+	assert.Contains(t, firstLine, "┌")
+}
+
 func TestCommandHistory_DeleteSelectedRemovesFromSourceAndLiveMessages(t *testing.T) {
 	source := New()
 	source.AddWithCommand("older-output", "jj older", nil)

--- a/internal/ui/flash/flash.go
+++ b/internal/ui/flash/flash.go
@@ -41,15 +41,11 @@ type Model struct {
 	pendingCommands map[int]string
 	pendingResults  map[int]pendingResult
 	spinner         spinner.Model
-	successStyle    lipgloss.Style
-	errorStyle      lipgloss.Style
-	textStyle       lipgloss.Style
-	matchedStyle    lipgloss.Style
+	renderer        CardRenderer
 	currentId       uint64
 }
 
 const HistoryLimit = 50
-const commandMarkWidth = 3
 
 type pendingResult struct {
 	Output string
@@ -137,7 +133,7 @@ func (m *Model) ViewRect(dl *render.DisplayContext, box layout.Box) {
 func (m *Model) renderMessages(dl *render.DisplayContext, area layout.Rectangle, messages []flashMessage, y int) int {
 	maxWidth := area.Dx() - 4
 	for _, message := range messages {
-		content := m.renderMessageContent(message, maxWidth)
+		content := m.renderer.RenderMessage(message.command, message.text, message.error, maxWidth)
 		w, h := lipgloss.Size(content)
 		y -= h
 
@@ -150,19 +146,8 @@ func (m *Model) renderMessages(dl *render.DisplayContext, area layout.Rectangle,
 func (m *Model) renderPendingCommands(dl *render.DisplayContext, area layout.Rectangle, y int) int {
 	maxWidth := area.Dx() - 4
 	for _, cmd := range m.pendingCommands {
-		content := m.renderCommandLine(cmd, nil, true)
+		content := m.renderer.RenderRunningCommand(cmd, m.spinner.View(), maxWidth)
 		w, h := lipgloss.Size(content)
-		if w > maxWidth {
-			content = lipgloss.NewStyle().Width(maxWidth).Render(content)
-			w, h = lipgloss.Size(content)
-		}
-		content = lipgloss.NewStyle().
-			Border(lipgloss.NormalBorder()).
-			PaddingLeft(1).
-			PaddingRight(1).
-			BorderForeground(m.textStyle.GetForeground()).
-			Render(content)
-		w, h = lipgloss.Size(content)
 		y -= h
 		rect := layout.Rect(area.Max.X-w, y, w, h)
 		dl.AddDraw(rect, content, render.ZOverlay)
@@ -179,38 +164,6 @@ func (m *Model) removeLiveMessageByID(id uint64) bool {
 		return true
 	}
 	return false
-}
-
-func (m *Model) renderMessageContent(message flashMessage, maxWidth int) string {
-	var style lipgloss.Style
-	if message.error != nil {
-		style = m.errorStyle
-	} else {
-		style = m.successStyle
-	}
-
-	var parts []string
-	if message.command != "" {
-		parts = append(parts, m.renderCommandLine(message.command, message.error, false))
-	}
-
-	var bodyText string
-	if message.error != nil {
-		bodyText = message.error.Error()
-	} else {
-		bodyText = message.text
-	}
-	if bodyText != "" {
-		parts = append(parts, style.Render(bodyText))
-	}
-
-	text := strings.Join(parts, "\n")
-	naturalContent := text
-	w, _ := lipgloss.Size(naturalContent)
-	if w > maxWidth {
-		naturalContent = lipgloss.NewStyle().Width(maxWidth).Render(text)
-	}
-	return lipgloss.NewStyle().Border(lipgloss.NormalBorder()).PaddingLeft(1).PaddingRight(1).BorderForeground(style.GetForeground()).Render(naturalContent)
 }
 
 func (m *Model) completeCommand(command string, output string, commandErr error) tea.Cmd {
@@ -242,19 +195,6 @@ func ColorizeCommand(cmd string, textStyle, matchedStyle lipgloss.Style) string 
 		}
 	}
 	return b.String()
-}
-
-func (m *Model) renderCommandLine(command string, commandErr error, running bool) string {
-	if command == "" {
-		return ""
-	}
-	mark := m.successStyle.Width(commandMarkWidth).Render("✓ ")
-	if running {
-		mark = m.textStyle.Width(commandMarkWidth).Render(m.spinner.View() + " ")
-	} else if commandErr != nil {
-		mark = m.errorStyle.Width(commandMarkWidth).Render("✗ ")
-	}
-	return mark + ColorizeCommand(command, m.textStyle, m.matchedStyle)
 }
 
 func (m *Model) add(text string, error error) uint64 {
@@ -341,10 +281,6 @@ func (m *Model) nextId() uint64 {
 }
 
 func New(context *context.MainContext) *Model {
-	successStyle := common.DefaultPalette.Get("flash success")
-	errorStyle := common.DefaultPalette.Get("flash error")
-	textStyle := common.DefaultPalette.Get("flash text")
-	matchedStyle := common.DefaultPalette.Get("flash matched")
 	s := spinner.New()
 	s.Spinner = spinner.Dot
 	return &Model{
@@ -353,10 +289,7 @@ func New(context *context.MainContext) *Model {
 		messageHistory:  make([]flashMessage, 0),
 		pendingCommands: make(map[int]string),
 		pendingResults:  make(map[int]pendingResult),
-		successStyle:    successStyle,
-		errorStyle:      errorStyle,
-		textStyle:       textStyle,
-		matchedStyle:    matchedStyle,
+		renderer:        NewCardRenderer(),
 		spinner:         s,
 	}
 }

--- a/internal/ui/flash/flash.go
+++ b/internal/ui/flash/flash.go
@@ -171,24 +171,6 @@ func (m *Model) completeCommand(command string, output string, commandErr error)
 	return nil
 }
 
-// ColorizeCommand tokenizes cmd and applies textStyle to plain tokens and
-// matchedStyle to flag tokens (those starting with "-").
-func ColorizeCommand(cmd string, textStyle, matchedStyle lipgloss.Style) string {
-	tokens := strings.Split(strings.ReplaceAll(cmd, "\n", "⏎"), " ")
-	var b strings.Builder
-	for i, token := range tokens {
-		if i > 0 {
-			b.WriteByte(' ')
-		}
-		if strings.HasPrefix(token, "-") {
-			b.WriteString(matchedStyle.Render(token))
-		} else {
-			b.WriteString(textStyle.Render(token))
-		}
-	}
-	return b.String()
-}
-
 func (m *Model) add(text string, error error) uint64 {
 	return m.AddWithCommand(text, "", error)
 }
@@ -231,44 +213,9 @@ func (m *Model) DeleteOldest() {
 	m.messages = m.messages[1:]
 }
 
-type commandHistoryEntry struct {
-	ID      uint64
-	Command string
-	Text    string
-	Err     error
-}
-
-func (m *Model) commandHistorySnapshot() []commandHistoryEntry {
-	out := make([]commandHistoryEntry, 0, len(m.messageHistory))
-	for _, item := range m.messageHistory {
-		out = append(out, commandHistoryEntry{
-			ID:      item.id,
-			Command: item.command,
-			Text:    item.text,
-			Err:     item.error,
-		})
-	}
-	return out
-}
-
-func (m *Model) deleteCommandHistoryByID(id uint64) {
-	for i, item := range m.messageHistory {
-		if item.id != id {
-			continue
-		}
-		m.messageHistory = append(m.messageHistory[:i], m.messageHistory[i+1:]...)
-		break
-	}
-	m.removeLiveMessageByID(id)
-}
-
 func (m *Model) nextId() uint64 {
 	m.currentId = m.currentId + 1
 	return m.currentId
-}
-
-func (m *Model) NewHistory() common.StackedModel {
-	return newCommandHistory(m)
 }
 
 func New() *Model {

--- a/internal/ui/flash/flash.go
+++ b/internal/ui/flash/flash.go
@@ -117,7 +117,7 @@ func (m *Model) handleIntent(intent intents.Intent) tea.Cmd {
 
 func (m *Model) ViewRect(dl *render.DisplayContext, box layout.Box) {
 	area := box.R
-	y := area.Max.Y - 1
+	y := area.Max.Y
 	y = m.renderMessages(dl, area, m.messages, y)
 	m.renderPendingCommands(dl, area, y)
 }

--- a/internal/ui/flash/flash.go
+++ b/internal/ui/flash/flash.go
@@ -9,7 +9,6 @@ import (
 	"charm.land/lipgloss/v2"
 	"github.com/idursun/jjui/internal/config"
 	"github.com/idursun/jjui/internal/ui/common"
-	"github.com/idursun/jjui/internal/ui/context"
 	"github.com/idursun/jjui/internal/ui/intents"
 	"github.com/idursun/jjui/internal/ui/layout"
 	"github.com/idursun/jjui/internal/ui/render"
@@ -28,14 +27,7 @@ type flashMessage struct {
 	id      uint64
 }
 
-type FlashMessageView struct {
-	// Content might contain ANSI colour codes
-	Content string
-	Rect    layout.Rectangle
-}
-
 type Model struct {
-	context         *context.MainContext
 	messages        []flashMessage
 	messageHistory  []flashMessage // completed commands only
 	pendingCommands map[int]string
@@ -280,11 +272,10 @@ func (m *Model) nextId() uint64 {
 	return m.currentId
 }
 
-func New(context *context.MainContext) *Model {
+func New() *Model {
 	s := spinner.New()
 	s.Spinner = spinner.Dot
 	return &Model{
-		context:         context,
 		messages:        make([]flashMessage, 0),
 		messageHistory:  make([]flashMessage, 0),
 		pendingCommands: make(map[int]string),

--- a/internal/ui/flash/flash.go
+++ b/internal/ui/flash/flash.go
@@ -231,22 +231,17 @@ func (m *Model) DeleteOldest() {
 	m.messages = m.messages[1:]
 }
 
-type CommandHistoryEntry struct {
+type commandHistoryEntry struct {
 	ID      uint64
 	Command string
 	Text    string
 	Err     error
 }
 
-type CommandHistorySource interface {
-	CommandHistorySnapshot() []CommandHistoryEntry
-	DeleteCommandHistoryByID(id uint64)
-}
-
-func (m *Model) CommandHistorySnapshot() []CommandHistoryEntry {
-	out := make([]CommandHistoryEntry, 0, len(m.messageHistory))
+func (m *Model) commandHistorySnapshot() []commandHistoryEntry {
+	out := make([]commandHistoryEntry, 0, len(m.messageHistory))
 	for _, item := range m.messageHistory {
-		out = append(out, CommandHistoryEntry{
+		out = append(out, commandHistoryEntry{
 			ID:      item.id,
 			Command: item.command,
 			Text:    item.text,
@@ -256,7 +251,7 @@ func (m *Model) CommandHistorySnapshot() []CommandHistoryEntry {
 	return out
 }
 
-func (m *Model) DeleteCommandHistoryByID(id uint64) {
+func (m *Model) deleteCommandHistoryByID(id uint64) {
 	for i, item := range m.messageHistory {
 		if item.id != id {
 			continue
@@ -270,6 +265,10 @@ func (m *Model) DeleteCommandHistoryByID(id uint64) {
 func (m *Model) nextId() uint64 {
 	m.currentId = m.currentId + 1
 	return m.currentId
+}
+
+func (m *Model) NewHistory() common.StackedModel {
+	return newCommandHistory(m)
 }
 
 func New() *Model {

--- a/internal/ui/flash/flash_test.go
+++ b/internal/ui/flash/flash_test.go
@@ -2,10 +2,12 @@ package flash
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 
 	"github.com/idursun/jjui/internal/ui/common"
+	"github.com/idursun/jjui/internal/ui/intents"
 	"github.com/idursun/jjui/internal/ui/layout"
 	"github.com/idursun/jjui/internal/ui/render"
 	"github.com/stretchr/testify/assert"
@@ -98,5 +100,49 @@ func TestDeleteOldest_RemovesFirstMessage(t *testing.T) {
 
 	if assert.Len(t, m.messages, 1) {
 		assert.Equal(t, "second", m.messages[0].text)
+	}
+}
+
+func TestHistory_CompletionBeforeRunning_ReconcilesByCommandID(t *testing.T) {
+	m := New()
+
+	cmd := m.Update(common.CommandCompletedMsg{ID: 9, Output: "ok", Err: nil})
+	assert.Nil(t, cmd)
+	assert.Empty(t, m.commandHistorySnapshot())
+	assert.Equal(t, 0, m.LiveMessagesCount())
+
+	cmd = m.Update(common.CommandRunningMsg{ID: 9, Command: "jj git fetch"})
+	assert.NotNil(t, cmd)
+	snapshot := m.commandHistorySnapshot()
+	if assert.Len(t, snapshot, 1) {
+		assert.Equal(t, "jj git fetch", snapshot[0].Command)
+		assert.Equal(t, "ok", snapshot[0].Text)
+	}
+}
+
+func TestHistory_IsBoundedToConfiguredLimit(t *testing.T) {
+	m := New()
+
+	for i := 1; i <= HistoryLimit+5; i++ {
+		m.AddWithCommand(fmt.Sprintf("m-%d", i), fmt.Sprintf("jj cmd %d", i), nil)
+	}
+
+	snapshot := m.commandHistorySnapshot()
+	if assert.Len(t, snapshot, HistoryLimit) {
+		assert.Equal(t, "m-6", snapshot[0].Text)
+		assert.Equal(t, "m-55", snapshot[len(snapshot)-1].Text)
+	}
+}
+
+func TestHistory_OnlyContainsCommandMessages(t *testing.T) {
+	m := New()
+
+	m.Update(intents.AddMessage{Text: "user message"})
+	m.AddWithCommand("command output", "jj status", nil)
+
+	snapshot := m.commandHistorySnapshot()
+	if assert.Len(t, snapshot, 1) {
+		assert.Equal(t, "jj status", snapshot[0].Command)
+		assert.Equal(t, "command output", snapshot[0].Text)
 	}
 }

--- a/internal/ui/flash/flash_test.go
+++ b/internal/ui/flash/flash_test.go
@@ -8,12 +8,11 @@ import (
 	"github.com/idursun/jjui/internal/ui/common"
 	"github.com/idursun/jjui/internal/ui/layout"
 	"github.com/idursun/jjui/internal/ui/render"
-	"github.com/idursun/jjui/test"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestAdd_IgnoresEmptyMessages(t *testing.T) {
-	m := New(test.NewTestContext(test.NewTestCommandRunner(t)))
+	m := New()
 
 	id := m.add("   ", nil)
 
@@ -22,7 +21,7 @@ func TestAdd_IgnoresEmptyMessages(t *testing.T) {
 }
 
 func TestUpdate_AddsSuccessMessageAndSchedulesExpiry(t *testing.T) {
-	m := New(test.NewTestContext(test.NewTestCommandRunner(t)))
+	m := New()
 
 	cmd := m.Update(common.CommandCompletedMsg{Output: "  success  ", Err: nil})
 
@@ -35,7 +34,7 @@ func TestUpdate_AddsSuccessMessageAndSchedulesExpiry(t *testing.T) {
 }
 
 func TestUpdate_AddsErrorMessageWithoutExpiry(t *testing.T) {
-	m := New(test.NewTestContext(test.NewTestCommandRunner(t)))
+	m := New()
 
 	cmd := m.Update(common.CommandCompletedMsg{Output: "", Err: errors.New("boom")})
 
@@ -48,7 +47,7 @@ func TestUpdate_AddsErrorMessageWithoutExpiry(t *testing.T) {
 }
 
 func TestUpdate_ExpiresMessages(t *testing.T) {
-	m := New(test.NewTestContext(test.NewTestCommandRunner(t)))
+	m := New()
 
 	first := m.add("first", nil)
 	m.add("second", nil)
@@ -62,7 +61,7 @@ func TestUpdate_ExpiresMessages(t *testing.T) {
 }
 
 func TestView_StacksFromBottomRight(t *testing.T) {
-	m := New(test.NewTestContext(test.NewTestCommandRunner(t)))
+	m := New()
 
 	m.add("abc", nil)
 	m.add("de", nil)
@@ -89,7 +88,7 @@ func TestView_StacksFromBottomRight(t *testing.T) {
 }
 
 func TestDeleteOldest_RemovesFirstMessage(t *testing.T) {
-	m := New(test.NewTestContext(test.NewTestCommandRunner(t)))
+	m := New()
 
 	m.add("first", nil)
 	m.add("second", nil)

--- a/internal/ui/flash/render.go
+++ b/internal/ui/flash/render.go
@@ -99,5 +99,21 @@ func (r CardRenderer) renderCommandLine(command string, commandErr error, runnin
 	} else if commandErr != nil {
 		mark = r.errorStyle.Width(commandMarkWidth).Render("✗ ")
 	}
-	return mark + ColorizeCommand(command, r.textStyle, r.matchedStyle)
+	return mark + colorizeCommand(command, r.textStyle, r.matchedStyle)
+}
+
+func colorizeCommand(cmd string, textStyle, matchedStyle lipgloss.Style) string {
+	tokens := strings.Split(strings.ReplaceAll(cmd, "\n", "⏎"), " ")
+	var b strings.Builder
+	for i, token := range tokens {
+		if i > 0 {
+			b.WriteByte(' ')
+		}
+		if strings.HasPrefix(token, "-") {
+			b.WriteString(matchedStyle.Render(token))
+		} else {
+			b.WriteString(textStyle.Render(token))
+		}
+	}
+	return b.String()
 }

--- a/internal/ui/flash/render.go
+++ b/internal/ui/flash/render.go
@@ -30,7 +30,7 @@ func (r CardRenderer) RenderMessage(command, text string, commandErr error, maxW
 	return r.renderCard(command, text, commandErr, maxWidth, true, true)
 }
 
-func (r CardRenderer) RenderHistoryEntry(entry CommandHistoryEntry, maxWidth int, selected bool) string {
+func (r CardRenderer) RenderHistoryEntry(entry commandHistoryEntry, maxWidth int, selected bool) string {
 	return r.renderCard(entry.Command, entry.Text, entry.Err, maxWidth, selected, selected)
 }
 

--- a/internal/ui/flash/render.go
+++ b/internal/ui/flash/render.go
@@ -1,0 +1,103 @@
+package flash
+
+import (
+	"strings"
+
+	"charm.land/lipgloss/v2"
+	"github.com/idursun/jjui/internal/ui/common"
+	"github.com/idursun/jjui/internal/ui/render"
+)
+
+const commandMarkWidth = 3
+
+type CardRenderer struct {
+	successStyle lipgloss.Style
+	errorStyle   lipgloss.Style
+	textStyle    lipgloss.Style
+	matchedStyle lipgloss.Style
+}
+
+func NewCardRenderer() CardRenderer {
+	return CardRenderer{
+		successStyle: common.DefaultPalette.Get("flash success"),
+		errorStyle:   common.DefaultPalette.Get("flash error"),
+		textStyle:    common.DefaultPalette.Get("flash text"),
+		matchedStyle: common.DefaultPalette.Get("flash matched"),
+	}
+}
+
+func (r CardRenderer) RenderMessage(command, text string, commandErr error, maxWidth int) string {
+	return r.renderCard(command, text, commandErr, maxWidth, true, true)
+}
+
+func (r CardRenderer) RenderHistoryEntry(entry CommandHistoryEntry, maxWidth int, selected bool) string {
+	return r.renderCard(entry.Command, entry.Text, entry.Err, maxWidth, selected, selected)
+}
+
+func (r CardRenderer) RenderRunningCommand(command, indicator string, maxWidth int) string {
+	if command == "" {
+		return ""
+	}
+	return r.wrapCard(
+		r.renderCommandLine(command, nil, true, indicator),
+		maxWidth,
+		r.textStyle,
+	)
+}
+
+func (r CardRenderer) renderCard(command, text string, commandErr error, maxWidth int, showBody bool, highlight bool) string {
+	statusStyle := r.successStyle
+	if commandErr != nil {
+		statusStyle = r.errorStyle
+	}
+
+	var parts []string
+	if command != "" {
+		parts = append(parts, r.renderCommandLine(command, commandErr, false, ""))
+	}
+	if showBody {
+		bodyText := text
+		if commandErr != nil {
+			bodyText = commandErr.Error()
+		}
+		if bodyText != "" {
+			bodyStyle := lipgloss.NewStyle()
+			if highlight {
+				bodyStyle = statusStyle
+			}
+			parts = append(parts, bodyStyle.Render(bodyText))
+		}
+	}
+
+	borderStyle := lipgloss.NewStyle()
+	if highlight {
+		borderStyle = statusStyle
+	}
+
+	return r.wrapCard(strings.Join(parts, "\n"), maxWidth, borderStyle)
+}
+
+func (r CardRenderer) wrapCard(content string, maxWidth int, borderStyle lipgloss.Style) string {
+	if render.BlockWidth(content) > maxWidth {
+		content = lipgloss.NewStyle().Width(maxWidth).Render(content)
+	}
+	return lipgloss.NewStyle().
+		Border(lipgloss.NormalBorder()).
+		PaddingLeft(1).
+		PaddingRight(1).
+		BorderForeground(borderStyle.GetForeground()).
+		Render(content)
+}
+
+func (r CardRenderer) renderCommandLine(command string, commandErr error, running bool, indicator string) string {
+	if command == "" {
+		return ""
+	}
+	mark := r.successStyle.Width(commandMarkWidth).Render("✓ ")
+	if running {
+		mark = r.textStyle.Width(commandMarkWidth).Render(indicator + " ")
+	} else if commandErr != nil {
+		mark = r.errorStyle.Width(commandMarkWidth).Render("✗ ")
+	}
+	return mark + ColorizeCommand(command, r.textStyle, r.matchedStyle)
+}

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -11,7 +11,6 @@ import (
 	"github.com/idursun/jjui/internal/ui/actionmeta"
 	"github.com/idursun/jjui/internal/ui/actions"
 	keybindings "github.com/idursun/jjui/internal/ui/bindings"
-	"github.com/idursun/jjui/internal/ui/commandhistory"
 	"github.com/idursun/jjui/internal/ui/dispatch"
 	"github.com/idursun/jjui/internal/ui/flash"
 	"github.com/idursun/jjui/internal/ui/intents"
@@ -559,7 +558,7 @@ func (m *Model) HandleIntent(intent intents.Intent) (tea.Cmd, bool) {
 			m.stacked = nil
 			return nil, true
 		}
-		m.stacked = commandhistory.New(m.flash)
+		m.stacked = m.flash.NewHistory()
 		return m.stacked.Init(), true
 
 	// --- Activate input modes ---

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -559,7 +559,7 @@ func (m *Model) HandleIntent(intent intents.Intent) (tea.Cmd, bool) {
 			m.stacked = nil
 			return nil, true
 		}
-		m.stacked = commandhistory.New(m.context, m.flash)
+		m.stacked = commandhistory.New(m.flash)
 		return m.stacked.Init(), true
 
 	// --- Activate input modes ---
@@ -724,7 +724,7 @@ func (w *wrapper) View() tea.View {
 func NewUI(c *context.MainContext) *Model {
 	revisionsModel := revisions.New(c)
 	statusModel := status.New(c)
-	flashView := flash.New(c)
+	flashView := flash.New()
 	previewModel := preview.New(c)
 	revsetModel := revset.New(c)
 


### PR DESCRIPTION
I fixed the command history overlay so the selected entry stays fully visible, including exact-fit cases where the top border was getting clipped. While addressing that, I folded command history into `flash`, removed redundant viewport/rendering logic.

fixes #622 