### PR TITLE
fix(details): sync details selection for routed intents

### DIFF
--- a/internal/ui/operations/details/details.go
+++ b/internal/ui/operations/details/details.go
@@ -105,26 +105,13 @@ func (s *Operation) Update(msg tea.Msg) tea.Cmd {
 		}
 		s.setItems(items)
 
-		// Set selection to current cursor position
-		var selectionChangedCmd tea.Cmd
-		if current := s.current(); current != nil {
-			selectionChangedCmd = s.context.SetSelectedItem(context.SelectedFile{
-				ChangeId: s.revision.GetChangeId(),
-				CommitId: s.revision.CommitId,
-				File:     current.fileName,
-			})
-		}
-		return selectionChangedCmd
+		return s.updateSelection()
 	default:
 		oldCursor := s.cursor
 		var cmds []tea.Cmd
 		cmds = append(cmds, s.internalUpdate(msg))
 		if s.cursor != oldCursor {
-			cmds = append(cmds, s.context.SetSelectedItem(context.SelectedFile{
-				ChangeId: s.revision.GetChangeId(),
-				CommitId: s.revision.CommitId,
-				File:     s.current().fileName,
-			}))
+			cmds = append(cmds, s.updateSelection())
 		}
 		return tea.Batch(cmds...)
 	}
@@ -162,11 +149,7 @@ func (s *Operation) internalUpdate(msg tea.Msg) tea.Cmd {
 		default:
 			s.setCursor(msg.Index)
 		}
-		return s.context.SetSelectedItem(context.SelectedFile{
-			ChangeId: s.revision.GetChangeId(),
-			CommitId: s.revision.CommitId,
-			File:     s.current().fileName,
-		})
+		return s.updateSelection()
 	case FileListScrollMsg:
 		if msg.Horizontal {
 			return nil
@@ -186,6 +169,29 @@ func (s *Operation) internalUpdate(msg tea.Msg) tea.Cmd {
 }
 
 func (s *Operation) HandleIntent(intent intents.Intent) (tea.Cmd, bool) {
+	oldCursor := s.cursor
+	cmd, handled := s.handleIntentInner(intent)
+	if handled && s.cursor != oldCursor {
+		if selCmd := s.updateSelection(); selCmd != nil {
+			return tea.Batch(cmd, selCmd), true
+		}
+	}
+	return cmd, handled
+}
+
+func (s *Operation) updateSelection() tea.Cmd {
+	current := s.current()
+	if current == nil {
+		return nil
+	}
+	return s.context.SetSelectedItem(context.SelectedFile{
+		ChangeId: s.revision.GetChangeId(),
+		CommitId: s.revision.CommitId,
+		File:     current.fileName,
+	})
+}
+
+func (s *Operation) handleIntentInner(intent intents.Intent) (tea.Cmd, bool) {
 	switch intent := intent.(type) {
 	case intents.Apply:
 		if s.confirmation != nil {

--- a/internal/ui/operations/details/details_test.go
+++ b/internal/ui/operations/details/details_test.go
@@ -165,6 +165,28 @@ func TestModel_Refresh_IgnoreVirtuallySelectedFiles(t *testing.T) {
 	}
 }
 
+func TestModel_HandleIntent_UpdatesSelectedFileWhenCursorMoves(t *testing.T) {
+	commandRunner := test.NewTestCommandRunner(t)
+	commandRunner.Expect(jj.Snapshot())
+	commandRunner.Expect(jj.Status(Revision)).SetOutput([]byte(StatusOutput))
+	defer commandRunner.Verify()
+
+	model := NewOperation(test.NewTestContext(commandRunner), Commit)
+	test.SimulateModel(model, model.Init())
+
+	selected, ok := model.context.SelectedItem.(common.SelectedFile)
+	assert.True(t, ok)
+	assert.Equal(t, "file.txt", selected.File)
+
+	cmd, handled := model.HandleIntent(intents.DetailsNavigate{Delta: 1})
+	assert.True(t, handled)
+	test.SimulateModel(model, cmd)
+
+	selected, ok = model.context.SelectedItem.(common.SelectedFile)
+	assert.True(t, ok)
+	assert.Equal(t, "newfile.txt", selected.File)
+}
+
 func TestModel_Update_Quit(t *testing.T) {
 	commandRunner := test.NewTestCommandRunner(t)
 	model := NewOperation(test.NewTestContext(commandRunner), Commit)


### PR DESCRIPTION
## Bug
- Right now, when preview is open, moving selected files in details doesn't update preview.

## Cause
- `details` kept the selected file in sync when updates flowed through `Update()`, but routed intents can bypass that wrapper and call `HandleIntent()` directly. 
- That meant keyboard navigation in the details overlay could move the cursor without updating `MainContext.SelectedItem`.
- selection behavior such as preview refreshes and context-aware file commands still pointed at the previously selected file even though the highlighted row had moved.

## Fix
- added a single `updateSelection()` helper in the details
- updated the file to use it where the current file can change:
	- after loading the file list, 
	- after click handling, 
	- after cursor changes in `Update()`,
	- after handled intents in `HandleIntent()`.
