### PR TITLE
fix(set_parents): leak set_parents operation key scope

### DIFF
--- a/internal/ui/operations/set_parents/set_parents_operation.go
+++ b/internal/ui/operations/set_parents/set_parents_operation.go
@@ -8,8 +8,10 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 	"github.com/idursun/jjui/internal/jj"
+	"github.com/idursun/jjui/internal/ui/actions"
 	"github.com/idursun/jjui/internal/ui/common"
 	"github.com/idursun/jjui/internal/ui/context"
+	"github.com/idursun/jjui/internal/ui/dispatch"
 	"github.com/idursun/jjui/internal/ui/intents"
 	"github.com/idursun/jjui/internal/ui/layout"
 	"github.com/idursun/jjui/internal/ui/operations"
@@ -18,6 +20,7 @@ import (
 
 var _ operations.Operation = (*Model)(nil)
 var _ common.Focusable = (*Model)(nil)
+var _ dispatch.ScopeProvider = (*Model)(nil)
 
 type Model struct {
 	context  *context.MainContext
@@ -35,6 +38,16 @@ func (m *Model) IsFocused() bool {
 
 func (m *Model) Init() tea.Cmd {
 	return nil
+}
+
+func (m *Model) Scopes() []dispatch.Scope {
+	return []dispatch.Scope{
+		{
+			Name:    actions.ScopeSetParents,
+			Leak:    dispatch.LeakAll,
+			Handler: m,
+		},
+	}
 }
 
 func (m *Model) Update(msg tea.Msg) tea.Cmd {

--- a/internal/ui/ui_test.go
+++ b/internal/ui/ui_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/idursun/jjui/internal/ui/operations/describe"
 	"github.com/idursun/jjui/internal/ui/operations/details"
 	"github.com/idursun/jjui/internal/ui/operations/rebase"
+	"github.com/idursun/jjui/internal/ui/operations/set_parents"
 	"github.com/idursun/jjui/internal/ui/render"
 	"github.com/idursun/jjui/internal/ui/revset"
 	"github.com/idursun/jjui/test"
@@ -633,6 +634,22 @@ func Test_HandleDispatchedAction_RevisionsScopedActionInRebaseMode(t *testing.T)
 
 	_, handled := dispatchAction(model, "revisions.move_down", nil)
 	assert.True(t, handled, "revisions navigation actions should remain handled in rebase scope")
+}
+
+func Test_HandleDispatchedAction_RevisionsScopedActionInSetParentsMode(t *testing.T) {
+	commandRunner := test.NewTestCommandRunner(t)
+	commandRunner.Expect(jj.GetParents("abc123")).SetOutput([]byte("parent1"))
+	defer commandRunner.Verify()
+
+	ctx := test.NewTestContext(commandRunner)
+	model := NewUI(ctx)
+
+	op := set_parents.NewModel(ctx, &jj.Commit{ChangeId: "abc123", CommitId: "def456"})
+	model.Update(common.RestoreOperationMsg{Operation: op})
+	assert.False(t, model.revisions.InNormalMode(), "model should be in set parents mode")
+
+	_, handled := dispatchAction(model, "revisions.move_down", nil)
+	assert.True(t, handled, "revisions navigation actions should remain handled in set parents scope")
 }
 
 func Test_HandleIntent_EditEntersRevsetInNormalMode(t *testing.T) {


### PR DESCRIPTION
Right now, when set_parents is triggered, no keys are leaked are key strokes like `j` `k` doesn't work

Following the pattern in for rebase operation, add leakAll to set_parent's scope