### PR TITLE
fix(revisions): avoid toggle-select panic on empty revisions

### DIFF
--- a/internal/ui/revisions/dispatch_actions_test.go
+++ b/internal/ui/revisions/dispatch_actions_test.go
@@ -180,3 +180,14 @@ func TestHandleIntent_CancelLeaksWithoutSelectionsInNormalMode(t *testing.T) {
 	_, handled := model.HandleIntent(intents.Cancel{})
 	assert.False(t, handled, "revisions cancel should leak when there are no selections and in normal mode")
 }
+
+func TestHandleIntent_ToggleSelectWithNoRowsDoesNotPanic(t *testing.T) {
+	ctx := test.NewTestContext(test.NewTestCommandRunner(t))
+	model := New(ctx)
+
+	assert.NotPanics(t, func() {
+		_, handled := model.HandleIntent(intents.RevisionsToggleSelect{})
+		assert.True(t, handled, "toggle_select should remain a handled revisions action even with no rows")
+	})
+	assert.Empty(t, ctx.CheckedItems, "toggle_select should be a no-op when there is no selected revision")
+}

--- a/internal/ui/revisions/revisions.go
+++ b/internal/ui/revisions/revisions.go
@@ -635,7 +635,10 @@ func (m *Model) HandleIntent(intent intents.Intent) (tea.Cmd, bool) {
 	case intents.OpenSetBookmark:
 		return m.startBookmarkSet(), true
 	case intents.RevisionsToggleSelect:
-		commit := m.rows[m.cursor].Commit
+		commit := m.SelectedRevision()
+		if commit == nil {
+			return nil, true
+		}
 		changeId := commit.GetChangeId()
 		item := appContext.SelectedRevision{ChangeId: changeId, CommitId: commit.CommitId}
 		m.context.ToggleCheckedItem(item)


### PR DESCRIPTION
Bug:
Pressing the revisions toggle-select action could panic with
"index out of range [0] with length 0" when the revisions list was empty.
The handler indexed m.rows[m.cursor] directly even when there was no selected row.

How to reproduce:
1. Open jjui with a revset or search that yields no matching revisions.
2. Press the revisions toggle-select binding (space).
3. jjui panics from revisions.HandleIntent while handling RevisionsToggleSelect.

Fix:
Use SelectedRevision() instead of indexing m.rows directly. That centralizes the
bounds check and returns nil when no revision is selected, so toggle-select
becomes a safe no-op for the empty-list case. Add a regression test to lock in
that behavior.