### PR TITLE
feat(revisions): stream quick search until match or revset exhausted

### DIFF
--- a/internal/ui/common/search.go
+++ b/internal/ui/common/search.go
@@ -7,10 +7,10 @@ import (
 )
 
 // CircularSearch performs a circular search through searchable items.
-// Returns the index of the first matching item, or cursor if no match is found.
-func CircularSearch(items []screen.Searchable, query string, startIndex, cursor int, backward bool) int {
+// Returns (matchedIndex, true) when an item matches, or (cursor, false) otherwise.
+func CircularSearch(items []screen.Searchable, query string, startIndex, cursor int, backward bool) (int, bool) {
 	if query == "" {
-		return cursor
+		return cursor, false
 	}
 
 	n := len(items)
@@ -22,10 +22,10 @@ func CircularSearch(items []screen.Searchable, query string, startIndex, cursor 
 			c = (startIndex - i + n) % n
 		}
 		if matchesQuery(items[c], query) {
-			return c
+			return c, true
 		}
 	}
-	return cursor
+	return cursor, false
 }
 
 func matchesQuery(item screen.Searchable, query string) bool {

--- a/internal/ui/common/search_test.go
+++ b/internal/ui/common/search_test.go
@@ -49,6 +49,7 @@ func TestCircularSearch(t *testing.T) {
 		cursor     int
 		backward   bool
 		want       int
+		wantFound  bool
 	}{
 		{
 			name:       "empty query returns cursor",
@@ -56,6 +57,7 @@ func TestCircularSearch(t *testing.T) {
 			startIndex: 0,
 			cursor:     2,
 			want:       2,
+			wantFound:  false,
 		},
 		{
 			name:       "forward match from start",
@@ -63,6 +65,7 @@ func TestCircularSearch(t *testing.T) {
 			startIndex: 0,
 			cursor:     0,
 			want:       1,
+			wantFound:  true,
 		},
 		{
 			name:       "forward wraps around",
@@ -70,6 +73,7 @@ func TestCircularSearch(t *testing.T) {
 			startIndex: 3,
 			cursor:     0,
 			want:       4,
+			wantFound:  true,
 		},
 		{
 			name:       "backward match",
@@ -78,6 +82,7 @@ func TestCircularSearch(t *testing.T) {
 			cursor:     0,
 			backward:   true,
 			want:       1,
+			wantFound:  true,
 		},
 		{
 			name:       "backward wraps around",
@@ -86,6 +91,7 @@ func TestCircularSearch(t *testing.T) {
 			cursor:     0,
 			backward:   true,
 			want:       3,
+			wantFound:  true,
 		},
 		{
 			name:       "no match returns cursor",
@@ -93,6 +99,7 @@ func TestCircularSearch(t *testing.T) {
 			startIndex: 0,
 			cursor:     2,
 			want:       2,
+			wantFound:  false,
 		},
 		{
 			name:       "case insensitive match",
@@ -100,13 +107,15 @@ func TestCircularSearch(t *testing.T) {
 			startIndex: 0,
 			cursor:     0,
 			want:       2,
+			wantFound:  true,
 		},
 		{
-			name:       "match spanning multiple segments",
+			name:       "query spanning multiple segments does not match",
 			query:      "hello world",
 			startIndex: 0,
 			cursor:     0,
 			want:       0,
+			wantFound:  false,
 		},
 	}
 
@@ -119,11 +128,12 @@ func TestCircularSearch(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			searchItems := items
-			if tt.name == "match spanning multiple segments" {
+			if tt.name == "query spanning multiple segments does not match" {
 				searchItems = spanItems
 			}
-			got := CircularSearch(searchItems, tt.query, tt.startIndex, tt.cursor, tt.backward)
+			got, found := CircularSearch(searchItems, tt.query, tt.startIndex, tt.cursor, tt.backward)
 			assert.Equal(t, tt.want, got)
+			assert.Equal(t, tt.wantFound, found)
 		})
 	}
 }

--- a/internal/ui/oplog/operation_log.go
+++ b/internal/ui/oplog/operation_log.go
@@ -196,7 +196,8 @@ func (m *Model) search(startIndex int, backward bool) int {
 	for i := range m.rows {
 		items[i] = &m.rows[i]
 	}
-	return common.CircularSearch(items, m.quickSearch, startIndex, m.cursor, backward)
+	idx, _ := common.CircularSearch(items, m.quickSearch, startIndex, m.cursor, backward)
+	return idx
 }
 
 func (m *Model) close() tea.Cmd {

--- a/internal/ui/revisions/revisions.go
+++ b/internal/ui/revisions/revisions.go
@@ -65,6 +65,7 @@ type Model struct {
 	output                 string
 	err                    error
 	quickSearch            string
+	pendingSearch          *pendingQuickSearch
 	previousOpLogId        string
 	isLoading              bool
 	displayContextRenderer *DisplayContextRenderer
@@ -74,6 +75,15 @@ type Model struct {
 	matchedStyle           lipgloss.Style
 	ensureCursorView       bool
 	requestInFlight        bool
+}
+
+// pendingQuickSearch records a quick search that has not yet found a match in
+// the loaded rows. Once set, appendRowsBatchMsg keeps streaming and re-runs the
+// search as more rows arrive, until a match is found or the revset is
+// exhausted.
+type pendingQuickSearch struct {
+	startIndex int
+	backward   bool
 }
 
 type revisionsMsg struct {
@@ -412,9 +422,9 @@ func (m *Model) internalUpdate(msg tea.Msg) tea.Cmd {
 		return m.popLayer()
 	case common.QuickSearchMsg:
 		m.quickSearch = strings.ToLower(string(msg))
-		m.SetCursor(m.search(0, false))
+		streamCmd := m.applyQuickSearch(0, false)
 		m.resetOperations()
-		return m.updateSelection()
+		return tea.Batch(streamCmd, m.updateSelection())
 	case common.CommandCompletedMsg:
 		m.output = msg.Output
 		m.err = msg.Err
@@ -471,6 +481,7 @@ func (m *Model) internalUpdate(msg tea.Msg) tea.Cmd {
 		m.revisionToSelect = msg.selectedRevision
 		m.hasMore = true
 		m.requestInFlight = false
+		m.pendingSearch = nil
 
 		// If the revision to select is not set, use the currently selected item
 		if m.revisionToSelect == "" {
@@ -523,11 +534,25 @@ func (m *Model) internalUpdate(msg tea.Msg) tea.Cmd {
 			m.SetCursor(0)
 		}
 
+		if m.pendingSearch != nil {
+			if idx, found := m.search(m.pendingSearch.startIndex, m.pendingSearch.backward); found {
+				m.SetCursor(idx)
+				m.pendingSearch = nil
+			} else if !m.hasMore {
+				m.pendingSearch = nil
+			}
+		}
+
 		cmds := []tea.Cmd{m.highlightChanges, m.updateSelection()}
 		if len(m.offScreenRows) > 0 {
 			cmds = append(cmds, func() tea.Msg {
 				return common.UpdateRevisionsSuccessMsg{}
 			})
+		}
+		if m.pendingSearch != nil {
+			if c := m.requestMoreRows(msg.tag); c != nil {
+				cmds = append(cmds, c)
+			}
 		}
 		return tea.Batch(cmds...)
 	}
@@ -659,10 +684,11 @@ func (m *Model) HandleIntent(intent intents.Intent) (tea.Cmd, bool) {
 		if intent.Reverse {
 			offset = -1
 		}
-		m.SetCursor(m.search(m.cursor+offset, intent.Reverse))
-		return m.updateSelection(), true
+		streamCmd := m.applyQuickSearch(m.cursor+offset, intent.Reverse)
+		return tea.Batch(streamCmd, m.updateSelection()), true
 	case intents.RevisionsQuickSearchClear:
 		m.quickSearch = ""
+		m.pendingSearch = nil
 		return nil, true
 	}
 	return nil, false
@@ -1178,12 +1204,32 @@ func (m *Model) selectRevision(revision string) int {
 	return idx
 }
 
-func (m *Model) search(startIndex int, backward bool) int {
+func (m *Model) search(startIndex int, backward bool) (int, bool) {
 	items := make([]screen.Searchable, len(m.rows))
 	for i := range m.rows {
 		items[i] = &m.rows[i]
 	}
 	return common.CircularSearch(items, m.quickSearch, startIndex, m.cursor, backward)
+}
+
+// applyQuickSearch runs the current quick search and, if no match is found in
+// the loaded rows, records a pending search so subsequent streamed batches
+// extend the search. Returns a command to request more rows when streaming is
+// needed.
+func (m *Model) applyQuickSearch(startIndex int, backward bool) tea.Cmd {
+	m.pendingSearch = nil
+	if m.quickSearch == "" {
+		return nil
+	}
+	if idx, found := m.search(startIndex, backward); found {
+		m.SetCursor(idx)
+		return nil
+	}
+	if !m.hasMore {
+		return nil
+	}
+	m.pendingSearch = &pendingQuickSearch{startIndex: startIndex, backward: backward}
+	return m.requestMoreRows(m.tag.Load())
 }
 
 func (m *Model) CurrentOperation() operations.Operation {

--- a/internal/ui/revisions/revisions_quicksearch_test.go
+++ b/internal/ui/revisions/revisions_quicksearch_test.go
@@ -87,6 +87,76 @@ func TestQuickSearch_UpdatesSelection(t *testing.T) {
 	})
 }
 
+func TestQuickSearch_StreamsUntilMatchFound(t *testing.T) {
+	ctx := test.NewTestContext(test.NewTestCommandRunner(t))
+	model := New(ctx)
+	model.updateGraphRows(append([]parser.Row(nil), searchableRows[:2]...), "first")
+	model.offScreenRows = append([]parser.Row(nil), model.rows...)
+	model.hasMore = true
+
+	model.quickSearch = "third"
+	model.applyQuickSearch(0, false)
+	assert.NotNil(t, model.pendingSearch, "pending search should be recorded when match is missing and more rows remain")
+	assert.Equal(t, 0, model.cursor, "cursor should not move until the match is found")
+
+	test.SimulateModel(model, model.Update(appendRowsBatchMsg{
+		rows:    []parser.Row{searchableRows[2]},
+		hasMore: false,
+		tag:     0,
+	}))
+
+	assert.Nil(t, model.pendingSearch, "pending search should clear once the match is found")
+	assert.Equal(t, 2, model.cursor, "cursor should move to the streamed match")
+}
+
+func TestQuickSearch_StopsWhenStreamExhausted(t *testing.T) {
+	ctx := test.NewTestContext(test.NewTestCommandRunner(t))
+	model := New(ctx)
+	model.updateGraphRows(append([]parser.Row(nil), searchableRows[:2]...), "first")
+	model.offScreenRows = append([]parser.Row(nil), model.rows...)
+	model.hasMore = true
+
+	model.quickSearch = "no-such-query"
+	model.applyQuickSearch(0, false)
+	assert.NotNil(t, model.pendingSearch)
+	initialCursor := model.cursor
+
+	test.SimulateModel(model, model.Update(appendRowsBatchMsg{
+		rows:    []parser.Row{searchableRows[2]},
+		hasMore: false,
+		tag:     0,
+	}))
+
+	assert.Nil(t, model.pendingSearch, "pending search should clear when the stream is exhausted")
+	assert.Equal(t, initialCursor, model.cursor, "cursor should not move when no match exists")
+}
+
+func TestQuickSearch_DoesNotStreamWhenNoMoreRows(t *testing.T) {
+	ctx := test.NewTestContext(test.NewTestCommandRunner(t))
+	model := New(ctx)
+	model.updateGraphRows(append([]parser.Row(nil), searchableRows[:2]...), "first")
+	model.hasMore = false
+
+	model.quickSearch = "no-such-query"
+	model.applyQuickSearch(0, false)
+
+	assert.Nil(t, model.pendingSearch, "no pending search should be recorded when the stream has already ended")
+}
+
+func TestQuickSearch_ClearCancelsPendingSearch(t *testing.T) {
+	model := &Model{
+		quickSearch:   "test",
+		pendingSearch: &pendingQuickSearch{startIndex: 0},
+		baseOp:        operations.NewDefault(),
+		rows:          []parser.Row{{Commit: &jj.Commit{ChangeId: "test123"}}},
+	}
+
+	_ = model.internalUpdate(intents.RevisionsQuickSearchClear{})
+
+	assert.Equal(t, "", model.quickSearch)
+	assert.Nil(t, model.pendingSearch, "clearing the quick search should also drop any pending streamed search")
+}
+
 func TestScopes_ExposeQuickSearchScopeWhenSearchActive(t *testing.T) {
 	model := &Model{
 		quickSearch: "match",


### PR DESCRIPTION
## Summary

- `/` and `n`/`N` now keep pulling rows from the `GraphStreamer` until a match is found or the revset is exhausted, instead of only searching what's already in the in-memory buffer.
- `common.CircularSearch` now returns `(int, bool)` so callers can distinguish "no match" from "match-at-cursor"; the `oplog` caller discards the bool (oplog has no streaming, so behavior is unchanged).
- A new `pendingQuickSearch` field on the revisions model records an unresolved search; `appendRowsBatchMsg` re-runs the search as each batch lands and requests more rows while `hasMore` stays true. Cleared on `RevisionsQuickSearchClear` and on a fresh `streamingReadyMsg`.

Closes #638

## Test plan

- [x] `go test ./...` passes
- [x] New tests in `internal/ui/revisions/revisions_quicksearch_test.go`: streams-until-match, stops-when-exhausted, doesn't-arm-when-hasMore-false, clear-cancels-pending
- [x] Updated `internal/ui/common/search_test.go` for the new return signature
- [x] Manual: `jjui -r 'all()'` on a large repo, `/` for an old string — cursor now lands on the match