### PR TITLE
Dynamic light/dark switching

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,7 +83,7 @@ This produces `catalog_gen.go` and `builtins_gen.go`. A staleness test will fail
 - Configuration handling is in the `internal/config/` directory
 - Default configuration and key bindings are in the `internal/config/default` directory
 - Operations (rebase, squash, split, etc.) are implemented as operations the `internal/ui/operations/` directory
-- Set `DEBUG=1` environment variable for printing debug messages to `debug.log` file
+- Set `JJUI_DEBUG=1` environment variable for printing debug messages to `debug.log` file
 
 ## Contributing Documentation
 

--- a/cmd/jjui/main.go
+++ b/cmd/jjui/main.go
@@ -222,37 +222,13 @@ func run() int {
 		appContext.TerminalThemeDetected = true
 	}
 
-	var defaultThemeName string
-	if appContext.TerminalHasDarkBackground {
-		defaultThemeName = "default_dark"
-	} else {
-		defaultThemeName = "default_light"
-	}
-
-	theme, err = config.LoadEmbeddedTheme(defaultThemeName)
+	theme, err = config.ResolveTheme(appContext.TerminalHasDarkBackground, appContext.JJConfig.GetApplicableColors())
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error loading default theme '%s': %v\n", defaultThemeName, err)
+		fmt.Fprintf(os.Stderr, "Error loading theme: %v\n", err)
 		return 1
 	}
 
-	var userThemeName string
-	if appContext.TerminalHasDarkBackground {
-		userThemeName = config.Current.UI.Theme.Dark
-	} else {
-		userThemeName = config.Current.UI.Theme.Light
-	}
-
-	if userThemeName != "" {
-		theme, err = config.LoadTheme(userThemeName, theme)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error loading user theme '%s': %v\n", userThemeName, err)
-			return 1
-		}
-	}
-
 	common.DefaultPalette.Update(theme)
-	common.DefaultPalette.Update(appContext.JJConfig.GetApplicableColors())
-	common.DefaultPalette.Update(config.Current.UI.Colors)
 
 	if period >= 0 {
 		config.Current.UI.AutoRefreshInterval = period

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -293,3 +293,42 @@ func ensureLuaRC(luaRCPath, typesPath string) (bool, error) {
 	}
 	return true, nil
 }
+
+// ResolveTheme loads the full color map for the given background mode.
+// It layers the embedded default theme, optional user theme, jj VCS colors,
+// and inline [ui.colors] overrides in the correct order.
+func ResolveTheme(isDark bool, jjColors map[string]Color) (map[string]Color, error) {
+	defaultThemeName := "default_light"
+	if isDark {
+		defaultThemeName = "default_dark"
+	}
+
+	theme, err := LoadEmbeddedTheme(defaultThemeName)
+	if err != nil {
+		return nil, fmt.Errorf("loading default theme %q: %w", defaultThemeName, err)
+	}
+
+	userThemeName := Current.UI.Theme.Light
+	if isDark {
+		userThemeName = Current.UI.Theme.Dark
+	}
+
+	if userThemeName != "" {
+		theme, err = LoadTheme(userThemeName, theme)
+		if err != nil {
+			return nil, fmt.Errorf("loading user theme %q: %w", userThemeName, err)
+		}
+	}
+
+	// Layer jj VCS colors
+	if jjColors != nil {
+		maps.Copy(theme, jjColors)
+	}
+
+	// Layer inline [ui.colors] overrides
+	if Current.UI.Colors != nil {
+		maps.Copy(theme, Current.UI.Colors)
+	}
+
+	return theme, nil
+}

--- a/internal/ui/common/msgs.go
+++ b/internal/ui/common/msgs.go
@@ -101,6 +101,11 @@ func Quit() tea.Cmd {
 	return tea.Sequence(tea.Raw(ansi.ResetModeLightDark), tea.Quit)
 }
 
+func Suspend() tea.Cmd {
+	// disable mode 2031 push notifications before suspending
+	return tea.Sequence(tea.Raw(ansi.ResetModeLightDark), tea.Suspend)
+}
+
 func CloseApplied() tea.Msg {
 	return CloseViewMsg{Applied: true}
 }

--- a/internal/ui/common/msgs.go
+++ b/internal/ui/common/msgs.go
@@ -9,8 +9,9 @@ type (
 	CloseViewMsg struct {
 		Applied bool
 	}
-	AutoRefreshMsg struct{}
-	RefreshMsg     struct {
+	AutoRefreshMsg  struct{}
+	ThemeChangedMsg struct{}
+	RefreshMsg      struct {
 		SelectedRevision string
 		KeepSelections   bool
 	}

--- a/internal/ui/common/msgs.go
+++ b/internal/ui/common/msgs.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/x/ansi"
 	"github.com/idursun/jjui/internal/jj"
 )
 
@@ -91,6 +92,13 @@ const (
 
 func Close() tea.Msg {
 	return CloseViewMsg{}
+}
+
+func Quit() tea.Cmd {
+	// bubbletea does not automatically reset the mode 2031 subscription since we
+	// enable that ourselves. Reset it explicitly so color change notifications
+	// aren't still emitted to the terminal after jjui exits.
+	return tea.Sequence(tea.Raw(ansi.ResetModeLightDark), tea.Quit)
 }
 
 func CloseApplied() tea.Msg {

--- a/internal/ui/common/msgs_test.go
+++ b/internal/ui/common/msgs_test.go
@@ -9,31 +9,44 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestQuit_ResetsMode2031BeforeQuit(t *testing.T) {
-	cmd := Quit()
-	msg := cmd()
-
-	// tea.Sequence returns an unexported sequenceMsg type ([]tea.Cmd).
-	// Use reflection to extract the underlying slice.
+// extractSequence pulls the underlying []tea.Cmd out of a tea.Sequence result.
+// tea.Sequence wraps its commands in an unexported sequenceMsg type, so we
+// have to use reflection to inspect the contents.
+func extractSequence(t *testing.T, msg tea.Msg) []tea.Cmd {
+	t.Helper()
 	val := reflect.ValueOf(msg)
 	cmdType := reflect.TypeFor[tea.Cmd]()
 	if !assert.Equal(t, reflect.Slice, val.Kind()) ||
 		!assert.True(t, val.Type().Elem().AssignableTo(cmdType)) {
-		return
+		return nil
 	}
 	cmds := make([]tea.Cmd, val.Len())
 	for i := range cmds {
 		cmds[i] = val.Index(i).Interface().(tea.Cmd)
 	}
+	return cmds
+}
 
+func TestQuit_ResetsMode2031BeforeQuit(t *testing.T) {
+	cmds := extractSequence(t, Quit()())
 	assert.Len(t, cmds, 2)
 
-	first := cmds[0]()
-	raw, ok := first.(tea.RawMsg)
+	raw, ok := cmds[0]().(tea.RawMsg)
 	assert.True(t, ok, "first cmd should produce tea.RawMsg")
 	assert.Equal(t, ansi.ResetModeLightDark, raw.Msg)
 
-	second := cmds[1]()
-	_, ok = second.(tea.QuitMsg)
+	_, ok = cmds[1]().(tea.QuitMsg)
 	assert.True(t, ok, "second cmd should produce tea.QuitMsg")
+}
+
+func TestSuspend_ResetsMode2031BeforeSuspend(t *testing.T) {
+	cmds := extractSequence(t, Suspend()())
+	assert.Len(t, cmds, 2)
+
+	raw, ok := cmds[0]().(tea.RawMsg)
+	assert.True(t, ok, "first cmd should produce tea.RawMsg")
+	assert.Equal(t, ansi.ResetModeLightDark, raw.Msg)
+
+	_, ok = cmds[1]().(tea.SuspendMsg)
+	assert.True(t, ok, "second cmd should produce tea.SuspendMsg")
 }

--- a/internal/ui/common/msgs_test.go
+++ b/internal/ui/common/msgs_test.go
@@ -1,0 +1,39 @@
+package common
+
+import (
+	"reflect"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestQuit_ResetsMode2031BeforeQuit(t *testing.T) {
+	cmd := Quit()
+	msg := cmd()
+
+	// tea.Sequence returns an unexported sequenceMsg type ([]tea.Cmd).
+	// Use reflection to extract the underlying slice.
+	val := reflect.ValueOf(msg)
+	cmdType := reflect.TypeFor[tea.Cmd]()
+	if !assert.Equal(t, reflect.Slice, val.Kind()) ||
+		!assert.True(t, val.Type().Elem().AssignableTo(cmdType)) {
+		return
+	}
+	cmds := make([]tea.Cmd, val.Len())
+	for i := range cmds {
+		cmds[i] = val.Index(i).Interface().(tea.Cmd)
+	}
+
+	assert.Len(t, cmds, 2)
+
+	first := cmds[0]()
+	raw, ok := first.(tea.RawMsg)
+	assert.True(t, ok, "first cmd should produce tea.RawMsg")
+	assert.Equal(t, ansi.ResetModeLightDark, raw.Msg)
+
+	second := cmds[1]()
+	_, ok = second.(tea.QuitMsg)
+	assert.True(t, ok, "second cmd should produce tea.QuitMsg")
+}

--- a/internal/ui/common/palette.go
+++ b/internal/ui/common/palette.go
@@ -66,6 +66,7 @@ func (p *Palette) get(fields ...string) lipgloss.Style {
 
 func (p *Palette) Update(styleMap map[string]config.Color) {
 	clear(p.cache)
+	p.root = nil
 	for key, color := range styleMap {
 		p.add(key, createStyleFrom(color))
 	}

--- a/internal/ui/common/palette.go
+++ b/internal/ui/common/palette.go
@@ -65,6 +65,7 @@ func (p *Palette) get(fields ...string) lipgloss.Style {
 }
 
 func (p *Palette) Update(styleMap map[string]config.Color) {
+	clear(p.cache)
 	for key, color := range styleMap {
 		p.add(key, createStyleFrom(color))
 	}

--- a/internal/ui/common/palette_test.go
+++ b/internal/ui/common/palette_test.go
@@ -264,6 +264,25 @@ func TestPaletteUpdate_InheritsWhenAttributeOmitted(t *testing.T) {
 	assert.True(t, got.GetUnderline())
 }
 
+func TestPaletteUpdate_ClearsCachedStyles(t *testing.T) {
+	p := NewPalette()
+	p.Update(map[string]config.Color{
+		"text": {Fg: Red},
+	})
+
+	// Populate the cache.
+	got := p.Get("text")
+	assert.Equal(t, lipgloss.Color("1"), got.GetForeground())
+
+	// A second Update with different colors should invalidate the cache.
+	p.Update(map[string]config.Color{
+		"text": {Fg: Blue},
+	})
+
+	got = p.Get("text")
+	assert.Equal(t, lipgloss.Color("4"), got.GetForeground())
+}
+
 func TestPaletteUpdate_ExplicitFalseOverridesInheritedAttribute(t *testing.T) {
 	p := NewPalette()
 	p.Update(map[string]config.Color{

--- a/internal/ui/common/palette_test.go
+++ b/internal/ui/common/palette_test.go
@@ -283,6 +283,24 @@ func TestPaletteUpdate_ClearsCachedStyles(t *testing.T) {
 	assert.Equal(t, lipgloss.Color("4"), got.GetForeground())
 }
 
+func TestPaletteUpdate_ClearsStaleKeysFromPreviousTheme(t *testing.T) {
+	p := NewPalette()
+	p.Update(map[string]config.Color{
+		"text":      {Fg: Red},
+		"dark only": {Fg: Green},
+	})
+
+	assert.Equal(t, lipgloss.Color("2"), p.Get("dark only").GetForeground())
+
+	// Switch to a theme that lacks the "dark only" key.
+	p.Update(map[string]config.Color{
+		"text": {Fg: Blue},
+	})
+
+	got := p.Get("dark only")
+	assert.Equal(t, lipgloss.NewStyle().GetForeground(), got.GetForeground())
+}
+
 func TestPaletteUpdate_ExplicitFalseOverridesInheritedAttribute(t *testing.T) {
 	p := NewPalette()
 	p.Update(map[string]config.Color{

--- a/internal/ui/operations/details/details.go
+++ b/internal/ui/operations/details/details.go
@@ -215,7 +215,7 @@ func (s *Operation) handleIntentInner(intent intents.Intent) (tea.Cmd, bool) {
 	case intents.DetailsClose:
 		return common.Close, true
 	case intents.Quit:
-		return tea.Quit, true
+		return common.Quit(), true
 	case intents.Refresh:
 		return common.Refresh, true
 	case intents.DetailsDiff:

--- a/internal/ui/operations/evolog/evolog_operation.go
+++ b/internal/ui/operations/evolog/evolog_operation.go
@@ -152,7 +152,7 @@ func (o *Operation) Update(msg tea.Msg) tea.Cmd {
 func (o *Operation) HandleIntent(intent intents.Intent) (tea.Cmd, bool) {
 	switch intent := intent.(type) {
 	case intents.Quit:
-		return tea.Quit, true
+		return common.Quit(), true
 	case intents.Cancel:
 		return common.Close, true
 	case intents.EvologNavigate:

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"fmt"
+	"log"
 	"slices"
 	"strings"
 	"time"
@@ -62,13 +63,19 @@ type Model struct {
 	height           int
 	revisionsSplit   *split
 	activeSplit      *split
+
+	// mode2031Supported is set when the terminal confirms it supports
+	// mode 2031 push. Once true, the OSC 11 polling loop stops.
+	mode2031Supported bool
 }
 
 type triggerAutoRefreshMsg struct{}
 
-const (
-	scopeUi keybindings.ScopeName = "ui"
-)
+const scopeUi keybindings.ScopeName = "ui"
+
+// colorSchemePollInterval is how often to poll the terminal for its
+// current light/dark mode.
+var colorSchemePollInterval = time.Second
 
 func (m *Model) Init() tea.Cmd {
 	return tea.Batch(m.revisions.Init(), m.scheduleAutoRefresh())
@@ -107,6 +114,10 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 				render.SetWidthMethod(ansi.GraphemeWidth)
 			}
 		}
+		// reply from initial ansi.RequestModeLightDark check
+		if msg.Mode == ansi.ModeLightDark && !msg.Value.IsNotRecognized() {
+			m.mode2031Supported = true
+		}
 		return nil
 	case tea.FocusMsg:
 		if m.state == common.Ready {
@@ -117,6 +128,13 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 		return m.applyColorScheme(true)
 	case uv.LightColorSchemeEvent:
 		return m.applyColorScheme(false)
+	case tea.BackgroundColorMsg:
+		return m.applyColorScheme(msg.IsDark())
+	case colorSchemePollTickMsg:
+		if m.mode2031Supported {
+			return nil
+		}
+		return tea.Batch(tea.RequestBackgroundColor, scheduleColorSchemePoll())
 	case tea.MouseReleaseMsg:
 		m.activeSplit = nil
 	case tea.MouseMotionMsg:
@@ -686,8 +704,9 @@ func (m *Model) updateBlockingScope(scope dispatch.Scope, msg tea.KeyMsg) tea.Cm
 var _ tea.Model = (*wrapper)(nil)
 
 type (
-	frameTickMsg struct{}
-	wrapper      struct {
+	frameTickMsg           struct{}
+	colorSchemePollTickMsg struct{}
+	wrapper                struct {
 		ui                 *Model
 		scheduledNextFrame bool
 		render             bool
@@ -696,7 +715,25 @@ type (
 )
 
 func (w *wrapper) Init() tea.Cmd {
-	return tea.Batch(w.ui.Init(), tea.Raw(ansi.SetModeLightDark))
+	return tea.Batch(
+		w.ui.Init(),
+		// Enable mode 2031 push notifications and probe whether the terminal
+		// supports it. If supported, the mode request returns a tea.ModeReportMsg
+		// with ansi.ModeLightDark, and uv.Light/DarkColorSchemeEvent are delivered
+		// on OS theme change.
+		tea.Raw(ansi.SetModeLightDark),
+		tea.Raw(ansi.RequestModeLightDark),
+		// Start OSC 11 polling as a baseline for light/dark mode detection
+		scheduleColorSchemePoll(),
+	)
+}
+
+// scheduleColorSchemePoll returns a Cmd that fires a colorSchemePollTickMsg
+// after colorSchemePollInterval.
+func scheduleColorSchemePoll() tea.Cmd {
+	return tea.Tick(colorSchemePollInterval, func(time.Time) tea.Msg {
+		return colorSchemePollTickMsg{}
+	})
 }
 
 func (w *wrapper) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
@@ -788,14 +825,20 @@ func (m *Model) initResolver() {
 }
 
 // applyColorScheme reloads the palette when the terminal's color scheme
-// changes (e.g. the OS switched between light and dark mode).
+// changes (that is, the OS switched between light and dark mode).
 func (m *Model) applyColorScheme(isDark bool) tea.Cmd {
 	if isDark == m.context.TerminalHasDarkBackground {
 		return nil
 	}
+	scheme := "light"
+	if isDark {
+		scheme = "dark"
+	}
+	log.Printf("color scheme changed to %s", scheme)
 	m.context.TerminalHasDarkBackground = isDark
 	theme, err := config.ResolveTheme(isDark, m.context.JJConfig.GetApplicableColors())
 	if err != nil {
+		log.Printf("failed to resolve %s theme: %v", scheme, err)
 		return nil
 	}
 	common.DefaultPalette.Update(theme)

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -124,6 +124,13 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 			return common.RefreshAndKeepSelections
 		}
 		return nil
+	case tea.ResumeMsg:
+		// common.Suspend disables mode 2031 on the way out, reenable it on resume.
+		// Also re-query the background color in case the theme changed while suspended.
+		return tea.Batch(
+			tea.Raw(ansi.SetModeLightDark),
+			tea.RequestBackgroundColor,
+		)
 	case uv.DarkColorSchemeEvent:
 		return m.applyColorScheme(true)
 	case uv.LightColorSchemeEvent:
@@ -531,7 +538,7 @@ func (m *Model) HandleIntent(intent intents.Intent) (tea.Cmd, bool) {
 	case intents.Quit:
 		return common.Quit(), true
 	case intents.Suspend:
-		return tea.Suspend, true
+		return common.Suspend(), true
 
 	// --- Cancel fallback (only reached if no inner scope handled it) ---
 	case intents.Cancel:

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -529,7 +529,7 @@ func (m *Model) HandleIntent(intent intents.Intent) (tea.Cmd, bool) {
 
 	// --- Quit / Suspend ---
 	case intents.Quit:
-		return tea.Quit, true
+		return common.Quit(), true
 	case intents.Suspend:
 		return tea.Suspend, true
 

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	uv "github.com/charmbracelet/ultraviolet"
 	"github.com/charmbracelet/x/ansi"
 	"github.com/idursun/jjui/internal/scripting"
 	"github.com/idursun/jjui/internal/ui/actionmeta"
@@ -112,6 +113,10 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 			return common.RefreshAndKeepSelections
 		}
 		return nil
+	case uv.DarkColorSchemeEvent:
+		return m.applyColorScheme(true)
+	case uv.LightColorSchemeEvent:
+		return m.applyColorScheme(false)
 	case tea.MouseReleaseMsg:
 		m.activeSplit = nil
 	case tea.MouseMotionMsg:
@@ -691,7 +696,7 @@ type (
 )
 
 func (w *wrapper) Init() tea.Cmd {
-	return w.ui.Init()
+	return tea.Batch(w.ui.Init(), tea.Raw(ansi.SetModeLightDark))
 }
 
 func (w *wrapper) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
@@ -780,6 +785,21 @@ func (m *Model) initResolver() {
 		return
 	}
 	m.resolver = dispatch.NewResolver(dispatcher)
+}
+
+// applyColorScheme reloads the palette when the terminal's color scheme
+// changes (e.g. the OS switched between light and dark mode).
+func (m *Model) applyColorScheme(isDark bool) tea.Cmd {
+	if isDark == m.context.TerminalHasDarkBackground {
+		return nil
+	}
+	m.context.TerminalHasDarkBackground = isDark
+	theme, err := config.ResolveTheme(isDark, m.context.JJConfig.GetApplicableColors())
+	if err != nil {
+		return nil
+	}
+	common.DefaultPalette.Update(theme)
+	return func() tea.Msg { return common.ThemeChangedMsg{} }
 }
 
 func New(c *context.MainContext) tea.Model {

--- a/internal/ui/ui_test.go
+++ b/internal/ui/ui_test.go
@@ -3,8 +3,10 @@ package ui
 import (
 	"errors"
 	"fmt"
+	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	tea "charm.land/bubbletea/v2"
 	"github.com/charmbracelet/x/ansi"
@@ -1335,7 +1337,41 @@ func Test_Update_SetBookmarkTypingDoesNotTogglePreview(t *testing.T) {
 	assert.True(t, model.previewModel.Visible(), "typing in set_bookmark should not toggle preview")
 }
 
-func Test_Init_EnablesModeLightDark(t *testing.T) {
+// withShortColorSchemePoll temporarily shortens the polling interval so
+// tests don't have to wait the full default duration for tea.Tick to fire.
+func withShortColorSchemePoll(t *testing.T) {
+	t.Helper()
+	orig := colorSchemePollInterval
+	colorSchemePollInterval = time.Millisecond
+	t.Cleanup(func() { colorSchemePollInterval = orig })
+}
+
+// drainCmds expands a Cmd tree, invoking each leaf Cmd and feeding the
+// resulting tea.BatchMsg back through the queue. visit is called once for
+// every non-batch leaf Cmd (with the Cmd itself and the message it produced,
+// which may be nil). Stop draining by returning false.
+func drainCmds(root tea.Cmd, visit func(c tea.Cmd, msg tea.Msg) bool) {
+	queue := []tea.Cmd{root}
+	for len(queue) > 0 {
+		var c tea.Cmd
+		c, queue = queue[0], queue[1:]
+		if c == nil {
+			continue
+		}
+		msg := c()
+		if batch, ok := msg.(tea.BatchMsg); ok {
+			queue = append(queue, batch...)
+			continue
+		}
+		if !visit(c, msg) {
+			return
+		}
+	}
+}
+
+func Test_Init_EnablesMode2031AndStartsPolling(t *testing.T) {
+	withShortColorSchemePoll(t)
+
 	commandRunner := test.NewTestCommandRunner(t)
 	ctx := test.NewTestContext(commandRunner)
 	w := New(ctx)
@@ -1343,24 +1379,77 @@ func Test_Init_EnablesModeLightDark(t *testing.T) {
 	cmd := w.Init()
 	require.NotNil(t, cmd)
 
-	// Drain the batch to collect all messages produced by Init.
-	var foundRaw bool
-	queue := []tea.Cmd{cmd}
-	for len(queue) > 0 {
-		var c tea.Cmd
-		c, queue = queue[0], queue[1:]
-		msg := c()
-		if msg == nil {
-			continue
-		}
+	var foundEnable2031, foundProbe2031, foundPollTick bool
+
+	drainCmds(cmd, func(c tea.Cmd, msg tea.Msg) bool {
 		switch v := msg.(type) {
-		case tea.BatchMsg:
-			queue = append(queue, v...)
 		case tea.RawMsg:
-			if v.Msg == ansi.SetModeLightDark {
-				foundRaw = true
+			switch v.Msg {
+			case ansi.SetModeLightDark:
+				foundEnable2031 = true
+			case ansi.RequestModeLightDark:
+				foundProbe2031 = true
 			}
+		case colorSchemePollTickMsg:
+			foundPollTick = true
 		}
-	}
-	assert.True(t, foundRaw)
+		return true
+	})
+
+	assert.True(t, foundEnable2031)
+	assert.True(t, foundProbe2031)
+	assert.True(t, foundPollTick)
+}
+
+func Test_PollTick_RequestsBackgroundColorAndRearms(t *testing.T) {
+	withShortColorSchemePoll(t)
+
+	commandRunner := test.NewTestCommandRunner(t)
+	ctx := test.NewTestContext(commandRunner)
+	model := NewUI(ctx)
+
+	cmd := model.Update(colorSchemePollTickMsg{})
+	require.NotNil(t, cmd)
+
+	wantRequestPC := reflect.ValueOf(tea.RequestBackgroundColor).Pointer()
+
+	var foundRequest, foundRearm bool
+	drainCmds(cmd, func(c tea.Cmd, msg tea.Msg) bool {
+		if reflect.ValueOf(c).Pointer() == wantRequestPC {
+			foundRequest = true
+			return true
+		}
+		if _, ok := msg.(colorSchemePollTickMsg); ok {
+			foundRearm = true
+		}
+		return true
+	})
+	assert.True(t, foundRequest)
+	assert.True(t, foundRearm)
+}
+
+func Test_PollTick_StopsWhenMode2031Supported(t *testing.T) {
+	commandRunner := test.NewTestCommandRunner(t)
+	ctx := test.NewTestContext(commandRunner)
+	model := NewUI(ctx)
+
+	model.Update(tea.ModeReportMsg{Mode: ansi.ModeLightDark, Value: ansi.ModeSet})
+	assert.True(t, model.mode2031Supported)
+
+	cmd := model.Update(colorSchemePollTickMsg{})
+	assert.Nil(t, cmd)
+}
+
+func Test_PollTick_ContinuesWhenMode2031NotRecognized(t *testing.T) {
+	withShortColorSchemePoll(t)
+
+	commandRunner := test.NewTestCommandRunner(t)
+	ctx := test.NewTestContext(commandRunner)
+	model := NewUI(ctx)
+
+	model.Update(tea.ModeReportMsg{Mode: ansi.ModeLightDark, Value: ansi.ModeNotRecognized})
+	assert.False(t, model.mode2031Supported)
+
+	cmd := model.Update(colorSchemePollTickMsg{})
+	assert.NotNil(t, cmd, "polling should continue when mode 2031 is not recognized")
 }

--- a/internal/ui/ui_test.go
+++ b/internal/ui/ui_test.go
@@ -1453,3 +1453,41 @@ func Test_PollTick_ContinuesWhenMode2031NotRecognized(t *testing.T) {
 	cmd := model.Update(colorSchemePollTickMsg{})
 	assert.NotNil(t, cmd, "polling should continue when mode 2031 is not recognized")
 }
+
+func Test_ResumeMsg_ReEnablesMode2031AndQueriesBackground(t *testing.T) {
+	withShortColorSchemePoll(t)
+
+	commandRunner := test.NewTestCommandRunner(t)
+	ctx := test.NewTestContext(commandRunner)
+	model := NewUI(ctx)
+
+	cmd := model.Update(tea.ResumeMsg{})
+	require.NotNil(t, cmd)
+
+	wantRequestPC := reflect.ValueOf(tea.RequestBackgroundColor).Pointer()
+
+	var foundEnable2031, foundProbe2031, foundBgRequest, foundPollTick bool
+	drainCmds(cmd, func(c tea.Cmd, msg tea.Msg) bool {
+		if reflect.ValueOf(c).Pointer() == wantRequestPC {
+			foundBgRequest = true
+			return true
+		}
+		switch v := msg.(type) {
+		case tea.RawMsg:
+			switch v.Msg {
+			case ansi.SetModeLightDark:
+				foundEnable2031 = true
+			case ansi.RequestModeLightDark:
+				foundProbe2031 = true
+			}
+		case colorSchemePollTickMsg:
+			foundPollTick = true
+		}
+		return true
+	})
+
+	assert.True(t, foundEnable2031, "resume should re-enable mode 2031")
+	assert.True(t, foundBgRequest, "resume should re-query background color")
+	assert.False(t, foundProbe2031, "resume should not re-probe mode 2031 support; the initial probe result still applies")
+	assert.False(t, foundPollTick, "resume should not restart polling; the existing poll loop survives suspension")
+}

--- a/internal/ui/ui_test.go
+++ b/internal/ui/ui_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/x/ansi"
 	"github.com/idursun/jjui/internal/config"
 	"github.com/idursun/jjui/internal/jj"
 	"github.com/idursun/jjui/internal/scripting"
@@ -1332,4 +1333,34 @@ func Test_Update_SetBookmarkTypingDoesNotTogglePreview(t *testing.T) {
 
 	test.SimulateModel(model, test.Type("p"))
 	assert.True(t, model.previewModel.Visible(), "typing in set_bookmark should not toggle preview")
+}
+
+func Test_Init_EnablesModeLightDark(t *testing.T) {
+	commandRunner := test.NewTestCommandRunner(t)
+	ctx := test.NewTestContext(commandRunner)
+	w := New(ctx)
+
+	cmd := w.Init()
+	require.NotNil(t, cmd)
+
+	// Drain the batch to collect all messages produced by Init.
+	var foundRaw bool
+	queue := []tea.Cmd{cmd}
+	for len(queue) > 0 {
+		var c tea.Cmd
+		c, queue = queue[0], queue[1:]
+		msg := c()
+		if msg == nil {
+			continue
+		}
+		switch v := msg.(type) {
+		case tea.BatchMsg:
+			queue = append(queue, v...)
+		case tea.RawMsg:
+			if v.Msg == ansi.SetModeLightDark {
+				foundRaw = true
+			}
+		}
+	}
+	assert.True(t, foundRaw)
 }


### PR DESCRIPTION
This PR adds support for dynamic color theme notifications so the color theme can change if the system switches between light and dark modes.

- The tea UI now registers for `ansi.SetLightDark`, which enables CSI 2031 mode reporting (https://contour-terminal.org/vt-extensions/color-palette-update-notifications/)
- The UI responds to palette changes by emitting a `ThemeChangedMsg`, invalidating the currently-loaded palette's cache.
- A few components have their own local caches of the current palette styles, either by design (`Revision`, `Flash`) or implicitly by wrapping bubble tea components (`Autocompletion`, `Revset`) or both (`Status`). These are now refreshed explicitly after receiving a `ThemeChangedMsg`.
- Not all terminals support the color palette update notifications. Alacritty, which is what the zed embedded terminal uses, has explicitly chosen to not support these control codes. To support these terminal implementations, I've added a once-a-second "get current color theme" poll to the tea event loop. This hooks into the same `ThemeChangedMsg` notifications, just via polling instead of eager notification.
- At init, tea now explicitly requests whether CSI 2031 is supported. If it is supported, the polling loop is disabled.
- The `DEBUG` env var in the contributing doc was incorrect, I fixed it to refer to the correct `JJUI_DEBUG` var name.

I've tested this in iTerm2 (supports CSI 2031) successfully, as well as zed terminal (only supports polling).
