### PR TITLE
feat: include directories in path entries for fuzzy_files

### DIFF
--- a/internal/jj/commands.go
+++ b/internal/jj/commands.go
@@ -29,11 +29,13 @@ const (
 	JJUIPrefix                  = "_PREFIX:"
 )
 
-type CommandArgs []string
-type CommandWithStdin struct {
-	Args  CommandArgs
-	Input string
-}
+type (
+	CommandArgs      []string
+	CommandWithStdin struct {
+		Args  CommandArgs
+		Input string
+	}
+)
 
 func ConfigListAll() CommandArgs {
 	return []string{"config", "list", "--color", "never", "--include-defaults", "--ignore-working-copy"}

--- a/internal/ui/fuzzy_files/fuzzy_files.go
+++ b/internal/ui/fuzzy_files/fuzzy_files.go
@@ -32,7 +32,7 @@ type fuzzyFiles struct {
 	debounceTag   int
 
 	// search state
-	files   []string
+	paths   []string
 	max     int
 	matches fuzzy.Matches
 	styles  fuzzy_search.Styles
@@ -138,7 +138,7 @@ func (fzf *fuzzyFiles) handleIntent(intent intents.Intent) tea.Cmd {
 		}
 		// Dispatch to ui.go which handles preview scroll intents
 		return func() tea.Msg {
-			return intents.PreviewScroll{Kind: intent.Kind}
+			return intents.PreviewScroll(intent)
 		}
 	}
 	return nil
@@ -173,15 +173,15 @@ func (fzf *fuzzyFiles) SelectedMatch() int {
 }
 
 func (fzf *fuzzyFiles) Len() int {
-	return len(fzf.files)
+	return len(fzf.paths)
 }
 
 func (fzf *fuzzyFiles) String(i int) string {
-	n := len(fzf.files)
+	n := len(fzf.paths)
 	if i < 0 || i >= n {
 		return ""
 	}
-	return fzf.files[i]
+	return fzf.paths[i]
 }
 
 func (fzf *fuzzyFiles) search(input string) {
@@ -209,8 +209,8 @@ func (fzf *fuzzyFiles) viewContent() string {
 		"  ",
 		strconv.Itoa(shown),
 		"of",
-		strconv.Itoa(len(fzf.files)),
-		"files present at revision",
+		strconv.Itoa(len(fzf.paths)),
+		"paths present at revision",
 		fzf.commit.GetChangeId(),
 		" ",
 	)
@@ -224,10 +224,45 @@ func NewModel(msg common.FileSearchMsg) fuzzy_search.Model {
 		wasPreviewShown: msg.PreviewShown,
 		max:             30,
 		commit:          msg.Commit,
-		files:           strings.Split(string(msg.RawFileOut), "\n"),
+		paths:           buildPathEntries(msg.RawFileOut),
 		styles:          fuzzy_search.NewStyles(),
 	}
 	return model
+}
+
+func buildPathEntries(rawFileOut []byte) []string {
+	lines := strings.Split(string(rawFileOut), "\n")
+	entries := make([]string, 0, len(lines))
+	seen := make(map[string]struct{}, len(lines))
+
+	add := func(entry string) {
+		if entry == "" {
+			return
+		}
+		if _, ok := seen[entry]; ok {
+			return
+		}
+		seen[entry] = struct{}{}
+		entries = append(entries, entry)
+	}
+
+	for _, file := range lines {
+		if file == "" {
+			continue
+		}
+
+		// jj repo paths are slash-separated on all platforms.
+		// Add each ancestor directory (e.g. "a/b/c.go" adds "a/" then "a/b/").
+		for i := 0; i < len(file); i++ {
+			if file[i] == '/' {
+				add(file[:i+1])
+			}
+		}
+
+		add(file)
+	}
+
+	return entries
 }
 
 func fileSearchNavigateDelta(delta int) int {

--- a/internal/ui/fuzzy_files/fuzzy_files_test.go
+++ b/internal/ui/fuzzy_files/fuzzy_files_test.go
@@ -12,7 +12,7 @@ import (
 func TestUpdateRevSet_WithPath(t *testing.T) {
 	model := &fuzzyFiles{
 		revset: "all()",
-		files:  []string{"file1.txt", "path/to/file2.go", "special file.txt"},
+		paths:  []string{"file1.txt", "path/to/file2.go", "special file.txt"},
 		styles: fuzzy_search.NewStyles(),
 	}
 
@@ -36,7 +36,7 @@ func TestUpdateRevSet_WithPath(t *testing.T) {
 func TestUpdateRevSet_WithPathContainingSpaces(t *testing.T) {
 	model := &fuzzyFiles{
 		revset: "all()",
-		files:  []string{"file with spaces.txt"},
+		paths:  []string{"file with spaces.txt"},
 		styles: fuzzy_search.NewStyles(),
 	}
 
@@ -57,7 +57,7 @@ func TestUpdateRevSet_WithPathContainingSpaces(t *testing.T) {
 func TestUpdateRevSet_WithPathContainingBraces(t *testing.T) {
 	model := &fuzzyFiles{
 		revset: "all()",
-		files:  []string{"file{with}braces.txt"},
+		paths:  []string{"file{with}braces.txt"},
 		styles: fuzzy_search.NewStyles(),
 	}
 
@@ -75,10 +75,27 @@ func TestUpdateRevSet_WithPathContainingBraces(t *testing.T) {
 	assert.Equal(t, "files('file{with}braces.txt')", string(updateMsg))
 }
 
+func TestUpdateRevSet_WithDirectory(t *testing.T) {
+	model := &fuzzyFiles{
+		revset: "all()",
+		paths:  []string{"path/to/"},
+		styles: fuzzy_search.NewStyles(),
+	}
+
+	model.matches = fuzzy.Matches{{Index: 0, Str: "path/to/"}}
+	model.cursor = 0
+
+	cmd := model.updateRevSet()
+	msg := cmd()
+	updateMsg, ok := msg.(common.UpdateRevSetMsg)
+	assert.True(t, ok)
+	assert.Equal(t, "files('path/to/')", string(updateMsg))
+}
+
 func TestUpdateRevSet_NoPath(t *testing.T) {
 	model := &fuzzyFiles{
 		revset:  "all()",
-		files:   []string{},
+		paths:   []string{},
 		matches: fuzzy.Matches{},
 		styles:  fuzzy_search.NewStyles(),
 	}
@@ -95,7 +112,7 @@ func TestUpdateRevSet_NoPath(t *testing.T) {
 func TestUpdateRevSet_EmptyMatches(t *testing.T) {
 	model := &fuzzyFiles{
 		revset:  "@",
-		files:   []string{"file1.txt"},
+		paths:   []string{"file1.txt"},
 		matches: fuzzy.Matches{},
 		cursor:  0,
 		styles:  fuzzy_search.NewStyles(),
@@ -108,4 +125,20 @@ func TestUpdateRevSet_EmptyMatches(t *testing.T) {
 
 	// when matches is empty, SelectedMatch returns empty string
 	assert.Equal(t, "@", string(updateMsg))
+}
+
+func TestBuildPathEntries_IncludesDirectories(t *testing.T) {
+	entries := buildPathEntries([]byte("src/pkg/main.go\nsrc/other.go\nREADME.md\n"))
+
+	assert.Equal(t, []string{
+		"src/",
+		"src/pkg/",
+		"src/pkg/main.go",
+		"src/other.go",
+		"README.md",
+	}, entries)
+}
+
+func TestBuildPathEntries_EmptyOutput(t *testing.T) {
+	assert.Empty(t, buildPathEntries(nil))
 }


### PR DESCRIPTION
Rename files→paths and add directory entries (e.g. "src/", "src/pkg/")
to the fuzzy file search so users can filter by directory. The
buildPathEntries helper scans each path for '/' separators and adds
every ancestor prefix before the file itself, deduplicating with a
seen set.

Also simplify the PreviewScroll construction to a direct type
conversion, and group the CommandArgs/CommandWithStdin type block.