### PR TITLE
fix(ui): unable to dismiss flash message after split command error

### DIFF
--- a/internal/ui/operations/details/details.go
+++ b/internal/ui/operations/details/details.go
@@ -30,12 +30,13 @@ type updateCommitStatusMsg struct {
 }
 
 var (
-	_ operations.Operation         = (*Operation)(nil)
-	_ operations.EmbeddedOperation = (*Operation)(nil)
-	_ common.Focusable             = (*Operation)(nil)
-	_ common.Editable              = (*Operation)(nil)
-	_ common.Overlay               = (*Operation)(nil)
-	_ dispatch.ScopeProvider       = (*Operation)(nil)
+	_ operations.Operation                = (*Operation)(nil)
+	_ operations.EmbeddedOperation        = (*Operation)(nil)
+	_ operations.CheckedItemsSynchronizer = (*Operation)(nil)
+	_ common.Focusable                    = (*Operation)(nil)
+	_ common.Editable                     = (*Operation)(nil)
+	_ common.Overlay                      = (*Operation)(nil)
+	_ dispatch.ScopeProvider              = (*Operation)(nil)
 )
 
 type Operation struct {
@@ -130,7 +131,7 @@ func (s *Operation) internalUpdate(msg tea.Msg) tea.Cmd {
 			prevCursor := s.cursor
 			s.setCursor(msg.Index)
 			s.rangeSelect(prevCursor, msg.Index)
-			s.syncCheckedItems()
+			s.SyncCheckedItems()
 		case msg.Ctrl:
 			s.setCursor(msg.Index)
 			if current := s.current(); current != nil {
@@ -406,7 +407,7 @@ func (s *Operation) Name() string {
 	return "details"
 }
 
-func (s *Operation) syncCheckedItems() {
+func (s *Operation) SyncCheckedItems() {
 	s.context.ClearCheckedItems(reflect.TypeFor[context.SelectedFile]())
 	for _, f := range s.files {
 		if f.selected {

--- a/internal/ui/operations/operation.go
+++ b/internal/ui/operations/operation.go
@@ -36,6 +36,10 @@ type TracksSelectedRevision interface {
 	SetSelectedRevision(commit *jj.Commit) tea.Cmd
 }
 
+type CheckedItemsSynchronizer interface {
+	SyncCheckedItems()
+}
+
 type SegmentRenderer interface {
 	RenderSegment(currentStyle lipgloss.Style, segment *screen.Segment, row parser.Row) string
 }

--- a/internal/ui/revisions/revisions.go
+++ b/internal/ui/revisions/revisions.go
@@ -186,12 +186,21 @@ func (m *Model) popLayer() tea.Cmd {
 	return m.updateSelection()
 }
 
+func (m *Model) clearCheckedItemsForBaseOperation() {
+	switch m.baseOp.(type) {
+	case *details.Operation:
+		m.context.ClearCheckedItems(reflect.TypeFor[appContext.SelectedFile]())
+	}
+}
+
 func (m *Model) resetOperations() {
+	m.clearCheckedItemsForBaseOperation()
 	m.baseOp = operations.NewDefault()
 	m.layers = nil
 }
 
 func (m *Model) setBaseOperation(op operations.Operation) tea.Cmd {
+	m.clearCheckedItemsForBaseOperation()
 	m.baseOp = op
 	m.layers = nil
 
@@ -395,8 +404,12 @@ func (m *Model) internalUpdate(msg tea.Msg) tea.Cmd {
 		return m.updateSelection()
 	case common.RestoreOperationMsg:
 		if op, ok := msg.Operation.(operations.Operation); ok {
+			m.clearCheckedItemsForBaseOperation()
 			m.baseOp = op
 			m.layers = nil
+			if syncer, ok := op.(operations.CheckedItemsSynchronizer); ok {
+				syncer.SyncCheckedItems()
+			}
 			return m.updateSelection()
 		}
 		m.resetOperations()

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -512,12 +512,12 @@ func (m *Model) HandleIntent(intent intents.Intent) (tea.Cmd, bool) {
 
 	// --- Cancel fallback (only reached if no inner scope handled it) ---
 	case intents.Cancel:
-		if m.stacked != nil || m.diff != nil || m.oplog != nil {
-			return common.Close, true
-		}
 		if m.flash.Any() {
 			m.flash.DeleteOldest()
 			return nil, true
+		}
+		if m.stacked != nil || m.diff != nil || m.oplog != nil {
+			return common.Close, true
 		}
 		if m.status.StatusExpanded() {
 			m.status.ToggleStatusExpand()

--- a/internal/ui/ui_test.go
+++ b/internal/ui/ui_test.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
@@ -1173,16 +1174,12 @@ func Test_Update_InlineDescribeDispatcherKeysWorkWhileEditing(t *testing.T) {
 	assert.NotNil(t, cmd, "alt+enter should trigger inline_describe_accept via dispatcher")
 }
 
-func Test_Update_DetailsCancelPrecedenceOverFlashDismissal(t *testing.T) {
-	origBindings := config.Current.Bindings
-	defer func() {
-		config.Current.Bindings = origBindings
-	}()
-	config.Current.Bindings = []config.BindingConfig{
-		{Action: "revisions.details.cancel", Scope: "revisions.details", Key: config.StringList{"h"}},
-	}
+func Test_Update_DetailsCloseClearsSelectedFiles(t *testing.T) {
+	const statusOutput = "false false $\nM file.txt\nA newfile.txt\n"
 
 	commandRunner := test.NewTestCommandRunner(t)
+	commandRunner.Expect(jj.Snapshot())
+	commandRunner.Expect(jj.Status("abc123")).SetOutput([]byte(statusOutput))
 	defer commandRunner.Verify()
 
 	ctx := test.NewTestContext(commandRunner)
@@ -1190,14 +1187,40 @@ func Test_Update_DetailsCancelPrecedenceOverFlashDismissal(t *testing.T) {
 
 	op := details.NewOperation(ctx, &jj.Commit{ChangeId: "abc123", CommitId: "def456"})
 	model.Update(common.RestoreOperationMsg{Operation: op})
+	test.SimulateModel(model, op.Init())
 	require.False(t, model.revisions.InNormalMode(), "details operation should be active")
 
-	model.Update(intents.AddMessage{Text: "flash", Sticky: true})
-	require.True(t, model.flash.Any(), "flash should be visible before cancel")
+	test.SimulateModel(model, func() tea.Msg { return intents.DetailsToggleSelect{} })
+	require.Len(t, ctx.CheckedItems, 1, "details selection should be tracked before close")
 
-	test.SimulateModel(model, test.Type("h"))
-	assert.True(t, model.revisions.InNormalMode(), "details cancel should close details operation")
-	assert.True(t, model.flash.Any(), "details cancel should not dismiss flash first")
+	test.SimulateModel(model, test.Press(tea.KeyEsc))
+	assert.True(t, model.revisions.InNormalMode(), "esc should close details")
+	assert.Empty(t, ctx.CheckedItems, "closing details should clear selected files from context")
+}
+
+func Test_Update_RestoreDetailsOperationResyncsSelectedFiles(t *testing.T) {
+	const statusOutput = "false false $\nM file.txt\nA newfile.txt\n"
+
+	commandRunner := test.NewTestCommandRunner(t)
+	commandRunner.Expect(jj.Snapshot())
+	commandRunner.Expect(jj.Status("abc123")).SetOutput([]byte(statusOutput))
+	defer commandRunner.Verify()
+
+	ctx := test.NewTestContext(commandRunner)
+	model := NewUI(ctx)
+
+	op := details.NewOperation(ctx, &jj.Commit{ChangeId: "abc123", CommitId: "def456"})
+	model.Update(common.RestoreOperationMsg{Operation: op})
+	test.SimulateModel(model, op.Init())
+
+	test.SimulateModel(model, func() tea.Msg { return intents.DetailsToggleSelect{} })
+	require.Len(t, ctx.CheckedItems, 1, "details selection should be tracked before close")
+
+	model.Update(common.CloseViewMsg{})
+	assert.Empty(t, ctx.CheckedItems, "closing details should clear selected files from context")
+
+	model.Update(common.RestoreOperationMsg{Operation: op})
+	assert.Len(t, ctx.CheckedItems, 1, "restoring details should resync checked files from the operation state")
 }
 
 func Test_Update_DetailsEscClosesOperation(t *testing.T) {
@@ -1251,6 +1274,37 @@ func Test_Update_DetailsEscClosesOperation_WithDefaultBindings(t *testing.T) {
 
 	model.Update(closeMsg)
 	assert.True(t, model.revisions.InNormalMode(), "default details esc should close details operation")
+}
+
+func Test_Update_CommandErrorAfterClosingDetailsWithSelectedFiles_AllowsEscToDismissFlash(t *testing.T) {
+	const statusOutput = "false false $\nM file.txt\nA newfile.txt\n"
+
+	commandRunner := test.NewTestCommandRunner(t)
+	commandRunner.Expect(jj.Snapshot())
+	commandRunner.Expect(jj.Status("abc123")).SetOutput([]byte(statusOutput))
+	defer commandRunner.Verify()
+
+	ctx := test.NewTestContext(commandRunner)
+	model := NewUI(ctx)
+
+	op := details.NewOperation(ctx, &jj.Commit{ChangeId: "abc123", CommitId: "def456"})
+	model.Update(common.RestoreOperationMsg{Operation: op})
+	test.SimulateModel(model, op.Init())
+	require.False(t, model.revisions.InNormalMode(), "details operation should be active")
+
+	test.SimulateModel(model, func() tea.Msg { return intents.DetailsToggleSelect{} })
+	require.Len(t, ctx.CheckedItems, 1, "details selection should be tracked before close")
+
+	model.Update(common.CloseViewMsg{})
+	model.Update(common.CommandCompletedMsg{Err: errors.New("split failed")})
+
+	assert.True(t, model.revisions.InNormalMode(), "closing details should return to revisions")
+	assert.True(t, model.flash.Any(), "command failure should surface as a flash message")
+	assert.Empty(t, ctx.CheckedItems, "selected files should be cleared when leaving details")
+
+	cmd := model.Update(tea.KeyPressMsg{Code: tea.KeyEsc})
+	assert.Nil(t, cmd, "esc should dismiss the flash instead of being consumed by stale checked items")
+	assert.False(t, model.flash.Any(), "esc should dismiss the split error flash")
 }
 
 func Test_Update_SetBookmarkTypingDoesNotTogglePreview(t *testing.T) {


### PR DESCRIPTION
Bug: pressing esc in details after a split command error did not dismiss the flash message.

Why it happened:
- In details scope, esc resolves to revisions.details.cancel, which maps to DetailsClose.
- That close intent was handled before the top-level ui.cancel path that dismisses flash messages.
- As a result, esc closed details (or was otherwise consumed by a close/cancel handler) instead of dismissing the visible flash.

Fix:
- Give flash dismissal priority for cancel/close-style intents in the top-level UI.
- When a flash is visible, dismiss it before routing cancel/close intents to details, oplog, help, choose, command history, or other close operations.
- Keep the original close behavior on the next esc once the flash is gone.

UX improvement:
- Dismiss flash before close operations, so transient errors are cleared first and esc behaves more predictably across views.


Bug detail:

https://github.com/user-attachments/assets/9e8a633a-132c-487e-a77a-7eb65f645ffa

