### PR TITLE
Add `golangci-lint` in CI

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -19,6 +19,10 @@ jobs:
           go fmt ./...
           go mod tidy
           git diff --exit-code
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@v9
+        with:
+          version: latest
   test:
     strategy:
       matrix:

--- a/nix/shells.nix
+++ b/nix/shells.nix
@@ -8,6 +8,7 @@
           # Go toolchain
           go_1_25
           gotools
+          golangci-lint
 
           jujutsu
         ];


### PR DESCRIPTION
Add `golangci-lint` in CI. Maybe the tool is a bit opinionated but would surely be useful with a right config.