### PR TITLE
fix(details): add shift+p binding for preview_toggle_bottom

### DIFF
--- a/internal/config/default/bindings.toml
+++ b/internal/config/default/bindings.toml
@@ -166,6 +166,7 @@ bindings = [
     { key = "shift+a", action = "revisions.details.absorb", scope = "revisions.details", desc = "absorb" },
     { key = "*", action = "revisions.details.revisions_changing_file", scope = "revisions.details", desc = "revisions changing file" },
     { key = "p", action = "ui.preview_toggle", scope = "revisions.details", desc = "preview" },
+    { key = "shift+p", action = "ui.preview_toggle_bottom", scope = "revisions.details", desc = "move preview to bottom" },
     { key = ["left", "h"], action = "revisions.details.confirmation.prev", scope = "revisions.details.confirmation", desc = "prev" },
     { key = ["right", "l"], action = "revisions.details.confirmation.next", scope = "revisions.details.confirmation", desc = "next" },
     { key = "enter", action = "revisions.details.confirmation.apply", scope = "revisions.details.confirmation", desc = "apply" },


### PR DESCRIPTION
## Summary

The `revisions`, `revisions.evolog`, and `oplog` scopes all bind `shift+p` to `ui.preview_toggle_bottom` (move preview between side and bottom position), but the `revisions.details` scope only has `p` → `ui.preview_toggle` and is missing the corresponding `shift+p` binding.

This means that once a user enters the details view (pressing `l` on a revision), they lose the ability to toggle the preview position until they go back to the revisions view — even though `p` still toggles the preview on/off in details mode.

## Change

Add the missing binding in `internal/config/default/bindings.toml`:

```toml
{ key = "shift+p", action = "ui.preview_toggle_bottom", scope = "revisions.details", desc = "move preview to bottom" },
```

The action `ui.preview_toggle_bottom` is an existing built-in — no code changes required, and the action catalog does not need to be regenerated.

## Verification

- `go build ./cmd/jjui` — OK
- `go test ./...` — all packages pass
- Manually tested: in details view, `shift+p` now toggles preview between side and bottom positions, matching the behavior in `revisions`, `revisions.evolog`, and `oplog`.