### PR TITLE
fix(bookmarks): match bookmark names exactly

### DIFF
--- a/internal/jj/commands.go
+++ b/internal/jj/commands.go
@@ -180,8 +180,12 @@ func BookmarkSet(revision string, name string) CommandArgs {
 	return []string{"bookmark", "set", "-r", revision, name}
 }
 
+func exactStringPattern(value string) string {
+	return "exact:" + strconv.Quote(value)
+}
+
 func BookmarkMove(revision string, bookmark string, extraFlags ...string) CommandArgs {
-	args := []string{"bookmark", "move", bookmark, "--to", revision}
+	args := []string{"bookmark", "move", exactStringPattern(bookmark), "--to", revision}
 	if extraFlags != nil {
 		args = append(args, extraFlags...)
 	}
@@ -189,25 +193,25 @@ func BookmarkMove(revision string, bookmark string, extraFlags ...string) Comman
 }
 
 func BookmarkDelete(name string) CommandArgs {
-	return []string{"bookmark", "delete", name}
+	return []string{"bookmark", "delete", exactStringPattern(name)}
 }
 
 func BookmarkForget(name string) CommandArgs {
-	return []string{"bookmark", "forget", name}
+	return []string{"bookmark", "forget", exactStringPattern(name)}
 }
 
 func BookmarkTrack(name string, remote string) CommandArgs {
-	args := []string{"bookmark", "track", name}
+	args := []string{"bookmark", "track", exactStringPattern(name)}
 	if remote != "" {
-		args = append(args, "--remote", remote)
+		args = append(args, "--remote", exactStringPattern(remote))
 	}
 	return args
 }
 
 func BookmarkUntrack(name string, remote string) CommandArgs {
-	args := []string{"bookmark", "untrack", name}
+	args := []string{"bookmark", "untrack", exactStringPattern(name)}
 	if remote != "" {
-		args = append(args, "--remote", remote)
+		args = append(args, "--remote", exactStringPattern(remote))
 	}
 	return args
 }

--- a/internal/jj/commands_test.go
+++ b/internal/jj/commands_test.go
@@ -1,0 +1,18 @@
+package jj
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBookmarkPatternCommandsUseExactStringPatterns(t *testing.T) {
+	name := `1.3.63-+-json-length-"fix"\branch`
+	remote := `origin+backup`
+
+	assert.Equal(t, CommandArgs{"bookmark", "move", `exact:"1.3.63-+-json-length-\"fix\"\\branch"`, "--to", "abc123"}, BookmarkMove("abc123", name))
+	assert.Equal(t, CommandArgs{"bookmark", "delete", `exact:"1.3.63-+-json-length-\"fix\"\\branch"`}, BookmarkDelete(name))
+	assert.Equal(t, CommandArgs{"bookmark", "forget", `exact:"1.3.63-+-json-length-\"fix\"\\branch"`}, BookmarkForget(name))
+	assert.Equal(t, CommandArgs{"bookmark", "track", `exact:"1.3.63-+-json-length-\"fix\"\\branch"`, "--remote", `exact:"origin+backup"`}, BookmarkTrack(name, remote))
+	assert.Equal(t, CommandArgs{"bookmark", "untrack", `exact:"1.3.63-+-json-length-\"fix\"\\branch"`, "--remote", `exact:"origin+backup"`}, BookmarkUntrack(name, remote))
+}


### PR DESCRIPTION
Updated to use `exact:"string"` to match strings exactly equal to string.

details see [Revset: String Pattern - Jujutsu docs](https://docs.jj-vcs.dev/latest/revsets/#string-patterns)

Fixes #632