### PR TITLE
refactor: inline theme styles into renderers

### DIFF
--- a/internal/ui/bookmarks/bookmarks.go
+++ b/internal/ui/bookmarks/bookmarks.go
@@ -43,24 +43,6 @@ func (m itemScrollMsg) SetDelta(delta int, horizontal bool) tea.Msg {
 	return m
 }
 
-type menuStyles struct {
-	title            lipgloss.Style
-	shortcut         lipgloss.Style
-	shortcutSelected lipgloss.Style
-	dimmed           lipgloss.Style
-	selected         lipgloss.Style
-	matched          lipgloss.Style
-	text             lipgloss.Style
-	border           lipgloss.Style
-}
-
-type remoteStyles struct {
-	promptStyle   lipgloss.Style
-	textStyle     lipgloss.Style
-	selectedStyle lipgloss.Style
-	noRemoteStyle lipgloss.Style
-}
-
 type filterState int
 
 const (
@@ -88,8 +70,6 @@ type Model struct {
 	filterText          string
 	categoryFilter      string
 	ensureCursorVisible bool
-	menuStyles          menuStyles
-	remoteStyles        remoteStyles
 	title               string
 }
 
@@ -485,20 +465,25 @@ func (m *Model) ViewRect(dl *render.DisplayContext, box layout.Box) {
 		return
 	}
 
+	menuTitleStyle := common.DefaultPalette.Get("bookmarks menu title")
+	menuTextStyle := common.DefaultPalette.Get("bookmarks menu text")
+	menuMatchedStyle := common.DefaultPalette.Get("bookmarks menu matched")
+	borderStyle := common.DefaultPalette.GetBorder("bookmarks menu border", lipgloss.NormalBorder())
+
 	dl.AddBackdrop(box.R, render.ZMenuBorder-1)
 	contentBox := frame.Inset(1)
 	if contentBox.R.Dx() <= 0 || contentBox.R.Dy() <= 0 {
 		return
 	}
-	dl.AddFill(contentBox.R, ' ', m.menuStyles.text, render.ZMenuContent)
+	dl.AddFill(contentBox.R, ' ', menuTextStyle, render.ZMenuContent)
 
 	borderBase := lipgloss.NewStyle().Width(contentBox.R.Dx()).Height(contentBox.R.Dy()).Render("")
-	dl.AddDraw(frame.R, m.menuStyles.border.Render(borderBase), render.ZMenuBorder)
+	dl.AddDraw(frame.R, borderStyle.Render(borderBase), render.ZMenuBorder)
 
 	titleBox, contentBox := contentBox.CutTop(1)
 	dl.
 		Text(titleBox.R.Min.X, titleBox.R.Min.Y, render.ZMenuContent).
-		Styled(m.title, m.menuStyles.title).
+		Styled(m.title, menuTitleStyle).
 		Done()
 
 	_, contentBox = contentBox.CutTop(1)
@@ -508,6 +493,12 @@ func (m *Model) ViewRect(dl *render.DisplayContext, box layout.Box) {
 	_, contentBox = contentBox.CutTop(1)
 	filterBox, contentBox := contentBox.CutTop(1)
 	if m.filterState == filterEditing {
+		fis := m.filterInput.Styles()
+		fis.Focused.Prompt = menuMatchedStyle.PaddingLeft(1)
+		fis.Focused.Text = menuTextStyle
+		fis.Blurred.Prompt = menuMatchedStyle.PaddingLeft(1)
+		fis.Blurred.Text = menuTextStyle
+		m.filterInput.SetStyles(fis)
 		m.filterInput.SetWidth(max(contentBox.R.Dx()-2, 0))
 		dl.AddDraw(filterBox.R, m.filterInput.View(), render.ZMenuContent)
 	} else {
@@ -522,24 +513,31 @@ func (m *Model) renderRemotes(dl *render.DisplayContext, lineBox layout.Box) {
 	if lineBox.R.Dx() <= 0 || lineBox.R.Dy() <= 0 {
 		return
 	}
-	dl.AddFill(lineBox.R, ' ', m.menuStyles.text, render.ZMenuContent)
+
+	remotePromptStyle := common.DefaultPalette.Get("bookmarks title")
+	menuTextStyle := common.DefaultPalette.Get("bookmarks menu text")
+	remoteTextStyle := common.DefaultPalette.Get("bookmarks dimmed")
+	remoteSelectedStyle := common.DefaultPalette.Get("bookmarks menu selected")
+	noRemoteStyle := common.DefaultPalette.Get("bookmarks error")
+
+	dl.AddFill(lineBox.R, ' ', menuTextStyle, render.ZMenuContent)
 
 	// Render above menu content
 	tb := dl.Text(lineBox.R.Min.X, lineBox.R.Min.Y, render.ZMenuContent+1).
-		Styled(" ", m.menuStyles.text).
-		Styled("Remotes: ", m.remoteStyles.promptStyle)
+		Styled(" ", menuTextStyle).
+		Styled("Remotes: ", remotePromptStyle)
 
 	if len(m.remoteNames) == 0 {
-		tb.Styled("NO REMOTE FOUND", m.remoteStyles.noRemoteStyle).Done()
+		tb.Styled("NO REMOTE FOUND", noRemoteStyle).Done()
 		return
 	}
 
 	for idx, remoteName := range m.remoteNames {
-		style := m.remoteStyles.textStyle
+		style := remoteTextStyle
 		if idx == m.selectedRemoteIdx {
-			style = m.remoteStyles.selectedStyle
+			style = remoteSelectedStyle
 		}
-		tb.Clickable(remoteName, style, SelectRemoteMsg{Index: idx}).Styled(" ", m.menuStyles.text)
+		tb.Clickable(remoteName, style, SelectRemoteMsg{Index: idx}).Styled(" ", menuTextStyle)
 	}
 
 	tb.Done()
@@ -577,21 +575,12 @@ func NewModel(c *context.MainContext, current *jj.Commit, commitIds []string) *M
 	// Add "local" as the first option to view local bookmark operations
 	remotes = append([]string{"local"}, remotes...)
 
-	remoteStyles := remoteStyles{
-		promptStyle:   common.DefaultPalette.Get("title"),
-		textStyle:     common.DefaultPalette.Get("dimmed"),
-		selectedStyle: common.DefaultPalette.Get("menu selected"),
-		noRemoteStyle: common.DefaultPalette.Get("error"),
-	}
-
 	m := &Model{
 		context:           c,
 		current:           current,
 		distanceMap:       calcDistanceMap(current.CommitId, commitIds),
 		remoteNames:       remotes,
 		selectedRemoteIdx: 0,
-		remoteStyles:      remoteStyles,
-		menuStyles:        createMenuStyles("bookmarks"),
 		listRenderer:      render.NewListRenderer(itemScrollMsg{}),
 		title:             "Bookmark Operations",
 		allItems:          make([]item, 0),
@@ -600,31 +589,9 @@ func NewModel(c *context.MainContext, current *jj.Commit, commitIds []string) *M
 
 	m.filterInput = textinput.New()
 	m.filterInput.Prompt = "Filter: "
-	fis := m.filterInput.Styles()
-	fis.Focused.Prompt = m.menuStyles.matched.PaddingLeft(1)
-	fis.Focused.Text = m.menuStyles.text
-	fis.Blurred.Prompt = m.menuStyles.matched.PaddingLeft(1)
-	fis.Blurred.Text = m.menuStyles.text
-	m.filterInput.SetStyles(fis)
 	m.applyFilters(true)
 
 	return m
-}
-
-func createMenuStyles(prefix string) menuStyles {
-	if prefix != "" {
-		prefix += " "
-	}
-	return menuStyles{
-		title:            common.DefaultPalette.Get(prefix+"menu title").Padding(0, 1, 0, 1),
-		selected:         common.DefaultPalette.Get(prefix + "menu selected"),
-		matched:          common.DefaultPalette.Get(prefix + "menu matched"),
-		dimmed:           common.DefaultPalette.Get(prefix + "menu dimmed"),
-		shortcut:         common.DefaultPalette.Get(prefix + "menu shortcut"),
-		shortcutSelected: common.DefaultPalette.Get(prefix + "menu selected shortcut"),
-		text:             common.DefaultPalette.Get(prefix + "menu text"),
-		border:           common.DefaultPalette.GetBorder(prefix+"menu border", lipgloss.NormalBorder()),
-	}
 }
 
 func (m *Model) visibleItems() []item {
@@ -763,8 +730,10 @@ func (m *Model) renderFilterView(dl *render.DisplayContext, box layout.Box) {
 		return
 	}
 	width := box.R.Dx()
-	labelStyle := m.menuStyles.text.PaddingLeft(1).PaddingRight(1)
-	valueStyle := m.menuStyles.matched
+	menuTextStyle := common.DefaultPalette.Get("bookmarks menu text")
+	menuMatchedStyle := common.DefaultPalette.Get("bookmarks menu matched")
+	labelStyle := menuTextStyle.PaddingLeft(1).PaddingRight(1)
+	valueStyle := menuMatchedStyle
 
 	action := "all actions"
 	if m.categoryFilter != "" {
@@ -792,7 +761,7 @@ func (m *Model) renderFilterView(dl *render.DisplayContext, box layout.Box) {
 		)
 	}
 
-	dl.AddDraw(box.R, m.menuStyles.text.Width(width).Render(lipgloss.JoinHorizontal(0, parts...)), render.ZMenuContent)
+	dl.AddDraw(box.R, menuTextStyle.Width(width).Render(lipgloss.JoinHorizontal(0, parts...)), render.ZMenuContent)
 }
 
 func (m *Model) renderList(dl *render.DisplayContext, listBox layout.Box) {
@@ -820,7 +789,7 @@ func (m *Model) renderList(dl *render.DisplayContext, listBox layout.Box) {
 			if index < 0 || index >= itemCount {
 				return
 			}
-			renderItem(dl, rect, listWidth, m.menuStyles, m.categoryFilter != "", m.cursor, index, items[index])
+			renderItem(dl, rect, listWidth, m.categoryFilter != "", m.cursor, index, items[index])
 		},
 		func(index int, _ tea.Mouse) tea.Msg { return itemClickMsg{Index: index} },
 	)
@@ -828,7 +797,7 @@ func (m *Model) renderList(dl *render.DisplayContext, listBox layout.Box) {
 	m.ensureCursorVisible = false
 }
 
-func renderItem(dl *render.DisplayContext, rect layout.Rectangle, width int, styles menuStyles, showShortcuts bool, cursor int, index int, item item) {
+func renderItem(dl *render.DisplayContext, rect layout.Rectangle, width int, showShortcuts bool, cursor int, index int, item item) {
 	var (
 		title string
 		desc  string
@@ -851,29 +820,29 @@ func renderItem(dl *render.DisplayContext, rect layout.Rectangle, width int, sty
 		desc = desc[:width-1] + "…"
 	}
 
-	titleStyle := styles.text
-	descStyle := styles.dimmed
-	shortcutStyle := styles.shortcut
+	textStyle := common.DefaultPalette.Get("bookmarks menu text")
+	descStyle := common.DefaultPalette.Get("bookmarks menu dimmed")
+	shortcutStyle := common.DefaultPalette.Get("bookmarks menu shortcut")
 
 	if index == cursor {
-		titleStyle = styles.selected
-		descStyle = styles.selected
-		shortcutStyle = styles.shortcutSelected
+		textStyle = common.DefaultPalette.Get("bookmarks menu selected text")
+		descStyle = common.DefaultPalette.Get("bookmarks menu selected dimmed")
+		shortcutStyle = common.DefaultPalette.Get("bookmarks menu selected shortcut")
 	}
 
 	titleLine := ""
 	if shortcut != "" {
-		titleLine = lipgloss.JoinHorizontal(0, shortcutStyle.PaddingLeft(1).Render(shortcut), titleStyle.PaddingLeft(1).Render(title))
+		titleLine = lipgloss.JoinHorizontal(0, shortcutStyle.PaddingLeft(1).Render(shortcut), textStyle.PaddingLeft(1).Render(title))
 	} else {
-		titleLine = titleStyle.PaddingLeft(1).Render(title)
+		titleLine = textStyle.PaddingLeft(1).Render(title)
 	}
-	titleLine = lipgloss.PlaceHorizontal(width+2, 0, titleLine, lipgloss.WithWhitespaceStyle(titleStyle))
+	titleLine = lipgloss.PlaceHorizontal(width+2, 0, titleLine, lipgloss.WithWhitespaceStyle(textStyle))
 
 	descStyle = descStyle.PaddingLeft(1).PaddingRight(1).Width(width + 2)
 	descLine := descStyle.Render(desc)
-	descLine = lipgloss.PlaceHorizontal(width+2, 0, descLine, lipgloss.WithWhitespaceStyle(titleStyle))
+	descLine = lipgloss.PlaceHorizontal(width+2, 0, descLine, lipgloss.WithWhitespaceStyle(textStyle))
 
-	spacerLine := styles.text.Width(width + 2).Render("")
+	spacerLine := textStyle.Width(width + 2).Render("")
 	content := lipgloss.JoinVertical(lipgloss.Left, titleLine, descLine, spacerLine)
 	if content == "" {
 		return

--- a/internal/ui/choose/choose.go
+++ b/internal/ui/choose/choose.go
@@ -43,21 +43,12 @@ type Model struct {
 	filteredOptions     []string
 	selected            int
 	title               string
-	styles              styles
 	listRenderer        *render.ListRenderer
 	ensureCursorVisible bool
 	filterable          bool
 	filtering           bool
 	ordered             bool
 	input               textinput.Model
-}
-
-type styles struct {
-	border   lipgloss.Style
-	text     lipgloss.Style
-	title    lipgloss.Style
-	selected lipgloss.Style
-	input    lipgloss.Style
 }
 
 const maxVisibleItems = 20
@@ -81,17 +72,10 @@ func NewWithOptions(options []string, title string, filterable bool, ordered boo
 		options:         options,
 		filteredOptions: options,
 		title:           title,
-		styles: styles{
-			border:   common.DefaultPalette.GetBorder("choose border", lipgloss.RoundedBorder()),
-			text:     common.DefaultPalette.Get("choose text"),
-			title:    common.DefaultPalette.Get("choose title"),
-			selected: common.DefaultPalette.Get("choose selected"),
-			input:    common.DefaultPalette.Get("choose input"),
-		},
-		listRenderer: render.NewListRenderer(itemScrollMsg{}),
-		filterable:   filterable,
-		ordered:      ordered,
-		input:        ti,
+		listRenderer:    render.NewListRenderer(itemScrollMsg{}),
+		filterable:      filterable,
+		ordered:         ordered,
+		input:           ti,
 	}
 	m.listRenderer.Z = render.ZMenuContent
 	return m
@@ -253,6 +237,21 @@ func (m *Model) ViewRect(dl *render.DisplayContext, box layout.Box) {
 		m.listRenderer = render.NewListRenderer(itemScrollMsg{})
 	}
 
+	borderStyle := common.DefaultPalette.GetBorder("choose border", lipgloss.RoundedBorder())
+	textStyle := common.DefaultPalette.Get("choose text")
+	titleStyle := common.DefaultPalette.Get("choose title")
+	selectedStyle := common.DefaultPalette.Get("choose selected")
+	inputStyle := common.DefaultPalette.Get("choose input")
+
+	inputStyles := m.input.Styles()
+	inputStyles.Focused.Text = inputStyle
+	inputStyles.Focused.Prompt = inputStyle
+	inputStyles.Focused.Placeholder = inputStyle
+	inputStyles.Blurred.Text = inputStyle
+	inputStyles.Blurred.Prompt = inputStyle
+	inputStyles.Blurred.Placeholder = inputStyle
+	m.input.SetStyles(inputStyles)
+
 	maxContentWidth := max(box.R.Dx()-2, 0)
 	maxContentHeight := max(box.R.Dy()-2, 0)
 	if maxContentWidth <= 0 || maxContentHeight <= 0 {
@@ -311,19 +310,19 @@ func (m *Model) ViewRect(dl *render.DisplayContext, box layout.Box) {
 	}
 
 	borderBase := lipgloss.NewStyle().Width(contentBox.R.Dx()).Height(contentBox.R.Dy()).Render("")
-	dl.AddDraw(frame.R, m.styles.border.Render(borderBase), render.ZMenuBorder)
+	dl.AddDraw(frame.R, borderStyle.Render(borderBase), render.ZMenuBorder)
 
 	listBox := contentBox
 	if titleHeight > 0 {
 		var titleBox layout.Box
 		titleBox, listBox = contentBox.CutTop(1)
-		dl.AddDraw(titleBox.R, m.styles.title.Render(m.title), render.ZMenuContent)
+		dl.AddDraw(titleBox.R, titleStyle.Render(m.title), render.ZMenuContent)
 	}
 
 	if inputHeight > 0 {
 		var inputBox layout.Box
 		inputBox, listBox = listBox.CutTop(1)
-		dl.AddDraw(inputBox.R, m.styles.input.Render(m.input.View()), render.ZMenuContent)
+		dl.AddDraw(inputBox.R, inputStyle.Render(m.input.View()), render.ZMenuContent)
 	}
 
 	if listBox.R.Dx() <= 0 || listBox.R.Dy() <= 0 {
@@ -343,9 +342,9 @@ func (m *Model) ViewRect(dl *render.DisplayContext, box layout.Box) {
 			if index < 0 || index >= itemCount || rect.Dx() <= 0 || rect.Dy() <= 0 {
 				return
 			}
-			style := m.styles.text
+			style := textStyle
 			if index == m.selected {
-				style = m.styles.selected
+				style = selectedStyle
 			}
 			label := m.filteredOptions[index]
 			if m.ordered && index < 9 {

--- a/internal/ui/flash/render.go
+++ b/internal/ui/flash/render.go
@@ -11,19 +11,10 @@ import (
 const commandMarkWidth = 3
 
 type CardRenderer struct {
-	successStyle lipgloss.Style
-	errorStyle   lipgloss.Style
-	textStyle    lipgloss.Style
-	matchedStyle lipgloss.Style
 }
 
 func NewCardRenderer() CardRenderer {
-	return CardRenderer{
-		successStyle: common.DefaultPalette.Get("flash success"),
-		errorStyle:   common.DefaultPalette.Get("flash error"),
-		textStyle:    common.DefaultPalette.Get("flash text"),
-		matchedStyle: common.DefaultPalette.Get("flash matched"),
-	}
+	return CardRenderer{}
 }
 
 func (r CardRenderer) RenderMessage(command, text string, commandErr error, maxWidth int) string {
@@ -41,14 +32,16 @@ func (r CardRenderer) RenderRunningCommand(command, indicator string, maxWidth i
 	return r.wrapCard(
 		r.renderCommandLine(command, nil, true, indicator),
 		maxWidth,
-		r.textStyle,
 	)
 }
 
 func (r CardRenderer) renderCard(command, text string, commandErr error, maxWidth int, showBody bool, highlight bool) string {
-	statusStyle := r.successStyle
+	successStyle := common.DefaultPalette.Get("flash success")
+	errorStyle := common.DefaultPalette.Get("flash error")
+
+	statusStyle := successStyle
 	if commandErr != nil {
-		statusStyle = r.errorStyle
+		statusStyle = errorStyle
 	}
 
 	var parts []string
@@ -77,15 +70,19 @@ func (r CardRenderer) renderCard(command, text string, commandErr error, maxWidt
 	return r.wrapCard(strings.Join(parts, "\n"), maxWidth, borderStyle)
 }
 
-func (r CardRenderer) wrapCard(content string, maxWidth int, borderStyle lipgloss.Style) string {
+func (r CardRenderer) wrapCard(content string, maxWidth int, borderStyle ...lipgloss.Style) string {
 	if render.BlockWidth(content) > maxWidth {
 		content = lipgloss.NewStyle().Width(maxWidth).Render(content)
+	}
+	style := common.DefaultPalette.Get("flash text")
+	if len(borderStyle) > 0 && borderStyle[0].GetForeground() != nil {
+		style = borderStyle[0]
 	}
 	return lipgloss.NewStyle().
 		Border(lipgloss.NormalBorder()).
 		PaddingLeft(1).
 		PaddingRight(1).
-		BorderForeground(borderStyle.GetForeground()).
+		BorderForeground(style.GetForeground()).
 		Render(content)
 }
 
@@ -93,13 +90,18 @@ func (r CardRenderer) renderCommandLine(command string, commandErr error, runnin
 	if command == "" {
 		return ""
 	}
-	mark := r.successStyle.Width(commandMarkWidth).Render("✓ ")
+	successStyle := common.DefaultPalette.Get("flash success")
+	errorStyle := common.DefaultPalette.Get("flash error")
+	textStyle := common.DefaultPalette.Get("flash text")
+	matchedStyle := common.DefaultPalette.Get("flash matched")
+
+	mark := successStyle.Width(commandMarkWidth).Render("✓ ")
 	if running {
-		mark = r.textStyle.Width(commandMarkWidth).Render(indicator + " ")
+		mark = textStyle.Width(commandMarkWidth).Render(indicator + " ")
 	} else if commandErr != nil {
-		mark = r.errorStyle.Width(commandMarkWidth).Render("✗ ")
+		mark = errorStyle.Width(commandMarkWidth).Render("✗ ")
 	}
-	return mark + colorizeCommand(command, r.textStyle, r.matchedStyle)
+	return mark + colorizeCommand(command, textStyle, matchedStyle)
 }
 
 func colorizeCommand(cmd string, textStyle, matchedStyle lipgloss.Style) string {

--- a/internal/ui/fuzzy_files/fuzzy_files.go
+++ b/internal/ui/fuzzy_files/fuzzy_files.go
@@ -35,7 +35,6 @@ type fuzzyFiles struct {
 	paths   []string
 	max     int
 	matches fuzzy.Matches
-	styles  fuzzy_search.Styles
 }
 
 var debounceDuration = 250 * time.Millisecond
@@ -156,10 +155,6 @@ func (fzf *fuzzyFiles) moveCursor(inc int) {
 	fzf.cursor = n
 }
 
-func (fzf *fuzzyFiles) Styles() fuzzy_search.Styles {
-	return fzf.styles
-}
-
 func (fzf *fuzzyFiles) Max() int {
 	return fzf.max
 }
@@ -205,7 +200,7 @@ func (fzf *fuzzyFiles) viewContent() string {
 	if shown == 0 {
 		return ""
 	}
-	title := fzf.styles.SelectedMatch.Render(
+	title := common.DefaultPalette.Get("status title").Render(
 		"  ",
 		strconv.Itoa(shown),
 		"of",
@@ -225,7 +220,6 @@ func NewModel(msg common.FileSearchMsg) fuzzy_search.Model {
 		max:             30,
 		commit:          msg.Commit,
 		paths:           buildPathEntries(msg.RawFileOut),
-		styles:          fuzzy_search.NewStyles(),
 	}
 	return model
 }

--- a/internal/ui/fuzzy_files/fuzzy_files_test.go
+++ b/internal/ui/fuzzy_files/fuzzy_files_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/idursun/jjui/internal/ui/common"
-	"github.com/idursun/jjui/internal/ui/fuzzy_search"
 	"github.com/sahilm/fuzzy"
 	"github.com/stretchr/testify/assert"
 )
@@ -13,7 +12,6 @@ func TestUpdateRevSet_WithPath(t *testing.T) {
 	model := &fuzzyFiles{
 		revset: "all()",
 		paths:  []string{"file1.txt", "path/to/file2.go", "special file.txt"},
-		styles: fuzzy_search.NewStyles(),
 	}
 
 	// a match being selected
@@ -37,7 +35,6 @@ func TestUpdateRevSet_WithPathContainingSpaces(t *testing.T) {
 	model := &fuzzyFiles{
 		revset: "all()",
 		paths:  []string{"file with spaces.txt"},
-		styles: fuzzy_search.NewStyles(),
 	}
 
 	model.matches = fuzzy.Matches{
@@ -58,7 +55,6 @@ func TestUpdateRevSet_WithPathContainingBraces(t *testing.T) {
 	model := &fuzzyFiles{
 		revset: "all()",
 		paths:  []string{"file{with}braces.txt"},
-		styles: fuzzy_search.NewStyles(),
 	}
 
 	model.matches = fuzzy.Matches{
@@ -79,7 +75,6 @@ func TestUpdateRevSet_WithDirectory(t *testing.T) {
 	model := &fuzzyFiles{
 		revset: "all()",
 		paths:  []string{"path/to/"},
-		styles: fuzzy_search.NewStyles(),
 	}
 
 	model.matches = fuzzy.Matches{{Index: 0, Str: "path/to/"}}
@@ -97,7 +92,6 @@ func TestUpdateRevSet_NoPath(t *testing.T) {
 		revset:  "all()",
 		paths:   []string{},
 		matches: fuzzy.Matches{},
-		styles:  fuzzy_search.NewStyles(),
 	}
 
 	cmd := model.updateRevSet()
@@ -115,7 +109,6 @@ func TestUpdateRevSet_EmptyMatches(t *testing.T) {
 		paths:   []string{"file1.txt"},
 		matches: fuzzy.Matches{},
 		cursor:  0,
-		styles:  fuzzy_search.NewStyles(),
 	}
 
 	cmd := model.updateRevSet()

--- a/internal/ui/fuzzy_input/fuzzy_input.go
+++ b/internal/ui/fuzzy_input/fuzzy_input.go
@@ -11,6 +11,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 	"github.com/idursun/jjui/internal/config"
+	"github.com/idursun/jjui/internal/ui/common"
 	"github.com/idursun/jjui/internal/ui/fuzzy_search"
 	"github.com/idursun/jjui/internal/ui/intents"
 	"github.com/idursun/jjui/internal/ui/layout"
@@ -24,7 +25,6 @@ type model struct {
 	cursor      int
 	max         int
 	matches     fuzzy.Matches
-	styles      fuzzy_search.Styles
 	suggestMode config.SuggestMode
 }
 
@@ -92,10 +92,6 @@ func (fzf *model) moveCursor(inc int) {
 		fzf.input.SetValue(fzf.String(n))
 		fzf.input.CursorEnd()
 	}
-}
-
-func (fzf *model) Styles() fuzzy_search.Styles {
-	return fzf.styles
 }
 
 func (fzf *model) Max() int {
@@ -181,7 +177,7 @@ func (fzf *model) viewContent() string {
 		strconv.Itoa(matches),
 		strconv.Itoa(fzf.Len()),
 	)
-	title = fzf.styles.SelectedMatch.Render(title)
+	title = common.DefaultPalette.Get("status title").Render(title)
 	return lipgloss.JoinVertical(0, title, view)
 }
 
@@ -198,7 +194,6 @@ func NewModel(input *textinput.Model, suggestions []string) fuzzy_search.Model {
 		input:       input,
 		suggestions: suggestions,
 		max:         30,
-		styles:      fuzzy_search.NewStyles(),
 		suggestMode: suggestMode,
 	}
 	return fzf

--- a/internal/ui/fuzzy_search/fuzzy_search.go
+++ b/internal/ui/fuzzy_search/fuzzy_search.go
@@ -12,33 +12,16 @@ import (
 	"github.com/sahilm/fuzzy"
 )
 
-type Styles struct {
-	Dimmed        lipgloss.Style
-	DimmedMatch   lipgloss.Style
-	Selected      lipgloss.Style
-	SelectedMatch lipgloss.Style
-}
-
 type Model interface {
 	fuzzy.Source
 	common.ImmediateModel
 	Max() int
 	Matches() fuzzy.Matches
 	SelectedMatch() int
-	Styles() Styles
 }
 
 type SearchMsg struct {
 	Input string
-}
-
-func NewStyles() Styles {
-	return Styles{
-		Dimmed:        common.DefaultPalette.Get("status dimmed"),
-		DimmedMatch:   common.DefaultPalette.Get("status shortcut"),
-		Selected:      common.DefaultPalette.Get("selected"),
-		SelectedMatch: common.DefaultPalette.Get("status title"),
-	}
 }
 
 func Search(input string) tea.Cmd {
@@ -63,22 +46,25 @@ func SelectedMatch(model Model) string {
 func View(fzf Model) string {
 	shown := []string{}
 	max := fzf.Max()
-	styles := fzf.Styles()
+	dimmedStyle := common.DefaultPalette.Get("status dimmed")
+	dimmedMatchStyle := common.DefaultPalette.Get("status shortcut")
+	selectedStyle := common.DefaultPalette.Get("selected")
+	selectedMatchStyle := common.DefaultPalette.Get("status title")
 	selected := fzf.SelectedMatch()
 	for i, match := range fzf.Matches() {
 		if i == max {
 			break
 		}
 		sel := " "
-		selStyle := styles.SelectedMatch
-		lineStyle := styles.Dimmed
-		matchStyle := styles.DimmedMatch
+		selStyle := selectedMatchStyle
+		lineStyle := dimmedStyle
+		matchStyle := dimmedMatchStyle
 
 		entry := fzf.String(match.Index)
 		if i == selected {
 			sel = "◆"
-			lineStyle = styles.Selected
-			matchStyle = styles.SelectedMatch
+			lineStyle = selectedStyle
+			matchStyle = selectedMatchStyle
 		}
 
 		entry = HighlightMatched(entry, match, lineStyle, matchStyle)

--- a/internal/ui/fuzzy_search/fuzzy_search_test.go
+++ b/internal/ui/fuzzy_search/fuzzy_search_test.go
@@ -51,7 +51,6 @@ type stubModel struct {
 func (m stubModel) Max() int                                        { return len(m.matches) }
 func (m stubModel) Matches() fuzzy.Matches                          { return m.matches }
 func (m stubModel) SelectedMatch() int                              { return m.selected }
-func (m stubModel) Styles() Styles                                  { return NewStyles() }
 func (m stubModel) Init() tea.Cmd                                   { return nil }
 func (m stubModel) Update(msg tea.Msg) tea.Cmd                      { return nil }
 func (m stubModel) ViewRect(_ *render.DisplayContext, _ layout.Box) {}

--- a/internal/ui/git/git.go
+++ b/internal/ui/git/git.go
@@ -69,24 +69,6 @@ func (m itemScrollMsg) SetDelta(delta int, horizontal bool) tea.Msg {
 	return m
 }
 
-type menuStyles struct {
-	title            lipgloss.Style
-	shortcut         lipgloss.Style
-	shortcutSelected lipgloss.Style
-	dimmed           lipgloss.Style
-	selected         lipgloss.Style
-	matched          lipgloss.Style
-	text             lipgloss.Style
-	border           lipgloss.Style
-}
-
-type remoteStyles struct {
-	promptStyle   lipgloss.Style
-	textStyle     lipgloss.Style
-	selectedStyle lipgloss.Style
-	noRemoteStyle lipgloss.Style
-}
-
 type filterState int
 
 const (
@@ -113,8 +95,6 @@ type Model struct {
 	revisions           jj.SelectedRevisions
 	remoteNames         []string
 	selectedRemoteIdx   int
-	menuStyles          menuStyles
-	remoteStyles        remoteStyles
 	title               string
 }
 
@@ -324,6 +304,11 @@ func (m *Model) executeDefaultForFilter(kind intents.GitFilterKind) tea.Cmd {
 }
 
 func (m *Model) ViewRect(dl *render.DisplayContext, box layout.Box) {
+	menuTitleStyle := common.DefaultPalette.Get("git menu title")
+	menuTextStyle := common.DefaultPalette.Get("git menu text")
+	menuMatchedStyle := common.DefaultPalette.Get("git menu matched")
+	borderStyle := common.DefaultPalette.GetBorder("git menu border", lipgloss.NormalBorder())
+
 	pw, ph := box.R.Dx(), box.R.Dy()
 	contentWidth := max(min(pw, 80)-4, 0)
 	contentHeight := max(min(ph, 40)-4, 0)
@@ -339,15 +324,15 @@ func (m *Model) ViewRect(dl *render.DisplayContext, box layout.Box) {
 	if contentBox.R.Dx() <= 0 || contentBox.R.Dy() <= 0 {
 		return
 	}
-	dl.AddFill(contentBox.R, ' ', m.menuStyles.text, render.ZMenuContent)
+	dl.AddFill(contentBox.R, ' ', menuTextStyle, render.ZMenuContent)
 
 	borderBase := lipgloss.NewStyle().Width(contentBox.R.Dx()).Height(contentBox.R.Dy()).Render("")
-	dl.AddDraw(frame.R, m.menuStyles.border.Render(borderBase), render.ZMenuBorder)
+	dl.AddDraw(frame.R, borderStyle.Render(borderBase), render.ZMenuBorder)
 
 	titleBox, contentBox := contentBox.CutTop(1)
 	dl.
 		Text(titleBox.R.Min.X, titleBox.R.Min.Y, render.ZMenuContent).
-		Styled(m.title, m.menuStyles.title).
+		Styled(m.title, menuTitleStyle).
 		Done()
 
 	_, contentBox = contentBox.CutTop(1)
@@ -357,6 +342,12 @@ func (m *Model) ViewRect(dl *render.DisplayContext, box layout.Box) {
 	_, contentBox = contentBox.CutTop(1)
 	filterBox, contentBox := contentBox.CutTop(1)
 	if m.filterState == filterEditing {
+		gfis := m.filterInput.Styles()
+		gfis.Focused.Prompt = menuMatchedStyle.PaddingLeft(1)
+		gfis.Focused.Text = menuTextStyle
+		gfis.Blurred.Prompt = menuMatchedStyle.PaddingLeft(1)
+		gfis.Blurred.Text = menuTextStyle
+		m.filterInput.SetStyles(gfis)
 		m.filterInput.SetWidth(max(contentBox.R.Dx()-2, 0))
 		dl.AddDraw(filterBox.R, m.filterInput.View(), render.ZMenuContent)
 	} else {
@@ -372,22 +363,28 @@ func (m *Model) renderRemotes(dl *render.DisplayContext, lineBox layout.Box) {
 		return
 	}
 
+	remotePromptStyle := common.DefaultPalette.Get("git title")
+	menuTextStyle := common.DefaultPalette.Get("git menu text")
+	remoteTextStyle := common.DefaultPalette.Get("git dimmed")
+	remoteSelectedStyle := common.DefaultPalette.Get("git menu selected")
+	noRemoteStyle := common.DefaultPalette.Get("git error")
+
 	// Render above menu content
 	tb := dl.Text(lineBox.R.Min.X, lineBox.R.Min.Y, render.ZMenuContent+1).
-		Styled(" ", m.menuStyles.text).
-		Styled("Remotes: ", m.remoteStyles.promptStyle)
+		Styled(" ", menuTextStyle).
+		Styled("Remotes: ", remotePromptStyle)
 
 	if len(m.remoteNames) == 0 {
-		tb.Styled("NO REMOTE FOUND", m.remoteStyles.noRemoteStyle).Done()
+		tb.Styled("NO REMOTE FOUND", noRemoteStyle).Done()
 		return
 	}
 
 	for idx, remoteName := range m.remoteNames {
-		style := m.remoteStyles.textStyle
+		style := remoteTextStyle
 		if idx == m.selectedRemoteIdx {
-			style = m.remoteStyles.selectedStyle
+			style = remoteSelectedStyle
 		}
-		tb.Clickable(remoteName, style, SelectRemoteMsg{Index: idx}).Styled(" ", m.menuStyles.text)
+		tb.Clickable(remoteName, style, SelectRemoteMsg{Index: idx}).Styled(" ", menuTextStyle)
 	}
 
 	tb.Done()
@@ -408,20 +405,11 @@ func loadRemoteNames(c context.CommandRunner) []string {
 func NewModel(c *context.MainContext, revisions jj.SelectedRevisions) *Model {
 	remotes := loadRemoteNames(c)
 
-	remoteStyles := remoteStyles{
-		promptStyle:   common.DefaultPalette.Get("title"),
-		textStyle:     common.DefaultPalette.Get("dimmed"),
-		selectedStyle: common.DefaultPalette.Get("menu selected"),
-		noRemoteStyle: common.DefaultPalette.Get("error"),
-	}
-
 	m := &Model{
 		context:           c,
 		revisions:         revisions,
 		remoteNames:       remotes,
 		selectedRemoteIdx: 0,
-		menuStyles:        createMenuStyles("git"),
-		remoteStyles:      remoteStyles,
 		listRenderer:      render.NewListRenderer(itemScrollMsg{}),
 		title:             "Git Operations",
 	}
@@ -432,31 +420,9 @@ func NewModel(c *context.MainContext, revisions jj.SelectedRevisions) *Model {
 	m.filteredItems = items
 	m.filterInput = textinput.New()
 	m.filterInput.Prompt = "Filter: "
-	gfis := m.filterInput.Styles()
-	gfis.Focused.Prompt = m.menuStyles.matched.PaddingLeft(1)
-	gfis.Focused.Text = m.menuStyles.text
-	gfis.Blurred.Prompt = m.menuStyles.matched.PaddingLeft(1)
-	gfis.Blurred.Text = m.menuStyles.text
-	m.filterInput.SetStyles(gfis)
 	m.applyFilters(true)
 
 	return m
-}
-
-func createMenuStyles(prefix string) menuStyles {
-	if prefix != "" {
-		prefix += " "
-	}
-	return menuStyles{
-		title:            common.DefaultPalette.Get(prefix+"menu title").Padding(0, 1, 0, 1),
-		selected:         common.DefaultPalette.Get(prefix + "menu selected"),
-		matched:          common.DefaultPalette.Get(prefix + "menu matched"),
-		dimmed:           common.DefaultPalette.Get(prefix + "menu dimmed"),
-		shortcut:         common.DefaultPalette.Get(prefix + "menu shortcut"),
-		shortcutSelected: common.DefaultPalette.Get(prefix + "menu selected shortcut"),
-		text:             common.DefaultPalette.Get(prefix + "menu text"),
-		border:           common.DefaultPalette.GetBorder(prefix+"menu border", lipgloss.NormalBorder()),
-	}
 }
 
 func (m *Model) visibleItems() []item {
@@ -552,14 +518,16 @@ func (m *Model) renderFilterView(dl *render.DisplayContext, box layout.Box) {
 		return
 	}
 	width := box.R.Dx()
-	filterStyle := m.menuStyles.text.PaddingLeft(1)
-	filterValueStyle := m.menuStyles.matched
+	menuTextStyle := common.DefaultPalette.Get("git menu text")
+	menuMatchedStyle := common.DefaultPalette.Get("git menu matched")
+	filterStyle := menuTextStyle.PaddingLeft(1)
+	filterValueStyle := menuMatchedStyle
 
 	filterView := lipgloss.JoinHorizontal(0, filterStyle.Render("Showing "), filterValueStyle.Render("all"))
 	if m.categoryFilter != "" {
 		filterView = lipgloss.JoinHorizontal(0, filterStyle.Render("Showing only "), filterValueStyle.Render(m.categoryFilter))
 	}
-	dl.AddDraw(box.R, m.menuStyles.text.Width(width).Render(filterView), render.ZMenuContent)
+	dl.AddDraw(box.R, menuTextStyle.Width(width).Render(filterView), render.ZMenuContent)
 }
 
 func (m *Model) renderList(dl *render.DisplayContext, listBox layout.Box) {
@@ -587,7 +555,7 @@ func (m *Model) renderList(dl *render.DisplayContext, listBox layout.Box) {
 			if index < 0 || index >= itemCount {
 				return
 			}
-			renderItem(dl, rect, listWidth, m.menuStyles, m.categoryFilter != "", m.cursor, index, items[index])
+			renderItem(dl, rect, listWidth, m.categoryFilter != "", m.cursor, index, items[index])
 		},
 		func(index int, _ tea.Mouse) tea.Msg { return itemClickMsg{Index: index} },
 	)
@@ -595,7 +563,7 @@ func (m *Model) renderList(dl *render.DisplayContext, listBox layout.Box) {
 	m.ensureCursorVisible = false
 }
 
-func renderItem(dl *render.DisplayContext, rect layout.Rectangle, width int, styles menuStyles, showShortcuts bool, cursor int, index int, item item) {
+func renderItem(dl *render.DisplayContext, rect layout.Rectangle, width int, showShortcuts bool, cursor int, index int, item item) {
 	var (
 		title string
 		desc  string
@@ -618,29 +586,29 @@ func renderItem(dl *render.DisplayContext, rect layout.Rectangle, width int, sty
 		desc = desc[:width-1] + "…"
 	}
 
-	titleStyle := styles.text
-	descStyle := styles.dimmed
-	shortcutStyle := styles.shortcut
+	textStyle := common.DefaultPalette.Get("git menu text")
+	descStyle := common.DefaultPalette.Get("git menu dimmed")
+	shortcutStyle := common.DefaultPalette.Get("git menu shortcut")
 
 	if index == cursor {
-		titleStyle = styles.selected
-		descStyle = styles.selected
-		shortcutStyle = styles.shortcutSelected
+		textStyle = common.DefaultPalette.Get("git menu selected text")
+		descStyle = common.DefaultPalette.Get("git menu selected dimmed")
+		shortcutStyle = common.DefaultPalette.Get("git menu selected shortcut")
 	}
 
 	titleLine := ""
 	if shortcut != "" {
-		titleLine = lipgloss.JoinHorizontal(0, shortcutStyle.PaddingLeft(1).Render(shortcut), titleStyle.PaddingLeft(1).Render(title))
+		titleLine = lipgloss.JoinHorizontal(0, shortcutStyle.PaddingLeft(1).Render(shortcut), textStyle.PaddingLeft(1).Render(title))
 	} else {
-		titleLine = titleStyle.PaddingLeft(1).Render(title)
+		titleLine = textStyle.PaddingLeft(1).Render(title)
 	}
-	titleLine = lipgloss.PlaceHorizontal(width+2, 0, titleLine, lipgloss.WithWhitespaceStyle(titleStyle))
+	titleLine = lipgloss.PlaceHorizontal(width+2, 0, titleLine, lipgloss.WithWhitespaceStyle(textStyle))
 
 	descStyle = descStyle.PaddingLeft(1).PaddingRight(1).Width(width + 2)
 	descLine := descStyle.Render(desc)
-	descLine = lipgloss.PlaceHorizontal(width+2, 0, descLine, lipgloss.WithWhitespaceStyle(titleStyle))
+	descLine = lipgloss.PlaceHorizontal(width+2, 0, descLine, lipgloss.WithWhitespaceStyle(textStyle))
 
-	spacerLine := styles.text.Width(width + 2).Render("")
+	spacerLine := textStyle.Width(width + 2).Render("")
 	content := lipgloss.JoinVertical(lipgloss.Left, titleLine, descLine, spacerLine)
 	if content == "" {
 		return

--- a/internal/ui/help/help.go
+++ b/internal/ui/help/help.go
@@ -94,19 +94,9 @@ var scopeOrder = []string{
 	"ui.preview",
 }
 
-type styles struct {
-	border   lipgloss.Style
-	title    lipgloss.Style
-	heading  lipgloss.Style
-	shortcut lipgloss.Style
-	desc     lipgloss.Style
-	dimmed   lipgloss.Style
-}
-
 type Model struct {
 	groups    []ScopeGroup
 	scroll    int
-	styles    styles
 	input     textinput.Model
 	filtering bool
 	filtered  []ScopeGroup
@@ -236,6 +226,20 @@ func (m *Model) applyFilter() {
 }
 
 func (m *Model) ViewRect(dl *render.DisplayContext, box layout.Box) {
+	borderStyle := common.DefaultPalette.GetBorder("help border", lipgloss.NormalBorder()).Padding(0)
+	titleStyle := common.DefaultPalette.Get("help title")
+	headingStyle := titleStyle
+	shortcutStyle := common.DefaultPalette.Get("help shortcut")
+	dimmedStyle := common.DefaultPalette.Get("help dimmed")
+	descStyle := common.DefaultPalette.Get("help desc").Inherit(dimmedStyle)
+
+	inputStyles := m.input.Styles()
+	inputStyles.Focused.Text = shortcutStyle
+	inputStyles.Focused.Placeholder = dimmedStyle
+	inputStyles.Blurred.Text = shortcutStyle
+	inputStyles.Blurred.Placeholder = dimmedStyle
+	m.input.SetStyles(inputStyles)
+
 	pw, ph := box.R.Dx(), box.R.Dy()
 	contentWidth := max(min(pw, 90)-4, 0)
 	contentHeight := max(min(ph, 50)-4, 0)
@@ -251,13 +255,13 @@ func (m *Model) ViewRect(dl *render.DisplayContext, box layout.Box) {
 	if contentBox.R.Dx() <= 0 || contentBox.R.Dy() <= 0 {
 		return
 	}
-	dl.AddFill(contentBox.R, ' ', m.styles.dimmed, render.ZMenuContent)
+	dl.AddFill(contentBox.R, ' ', dimmedStyle, render.ZMenuContent)
 
 	borderBase := lipgloss.NewStyle().Width(contentBox.R.Dx()).Height(contentBox.R.Dy()).Render("")
-	dl.AddDraw(frame.R, m.styles.border.Render(borderBase), render.ZMenuBorder)
+	dl.AddDraw(frame.R, borderStyle.Render(borderBase), render.ZMenuBorder)
 
 	titleBox, contentBox := contentBox.CutTop(1)
-	title := m.styles.title.Render("  Keybindings  ")
+	title := titleStyle.Render("  Keybindings  ")
 	dl.AddDraw(titleBox.R, title, render.ZMenuContent)
 
 	filterBox, contentBox := contentBox.CutTop(1)
@@ -270,7 +274,7 @@ func (m *Model) ViewRect(dl *render.DisplayContext, box layout.Box) {
 	if m.filtered != nil {
 		groups = m.filtered
 	}
-	lines := m.renderGroups(groups, contentBox.R.Dx())
+	lines := m.renderGroups(groups, contentBox.R.Dx(), headingStyle, shortcutStyle, descStyle)
 
 	// clamp scroll
 	maxScroll := max(0, len(lines)-contentBox.R.Dy())
@@ -291,22 +295,22 @@ func (m *Model) ViewRect(dl *render.DisplayContext, box layout.Box) {
 	}
 }
 
-func (m *Model) renderGroups(groups []ScopeGroup, width int) []string {
+func (m *Model) renderGroups(groups []ScopeGroup, width int, headingStyle, shortcutStyle, descStyle lipgloss.Style) []string {
 	var lines []string
 	for i, group := range groups {
 		if i > 0 {
 			lines = append(lines, "")
 		}
-		header := m.styles.heading.Width(width).Render("  " + group.Name + " ")
+		header := headingStyle.Width(width).Render("  " + group.Name + " ")
 		lines = append(lines, header)
 
-		entryLines := m.renderEntries(group.Entries, width)
+		entryLines := m.renderEntries(group.Entries, width, shortcutStyle, descStyle)
 		lines = append(lines, entryLines...)
 	}
 	return lines
 }
 
-func (m *Model) renderEntries(entries []Entry, width int) []string {
+func (m *Model) renderEntries(entries []Entry, width int, shortcutStyle, descStyle lipgloss.Style) []string {
 	maxLabelWidth := 0
 	for _, e := range entries {
 		if w := render.StringWidth(e.Label); w > maxLabelWidth {
@@ -328,8 +332,8 @@ func (m *Model) renderEntries(entries []Entry, width int) []string {
 				continue
 			}
 			e := entries[idx]
-			label := m.styles.shortcut.Width(maxLabelWidth + 1).Render(e.Label)
-			desc := m.styles.desc.Render(e.Desc)
+			label := shortcutStyle.Width(maxLabelWidth + 1).Render(e.Label)
+			desc := descStyle.Render(e.Desc)
 			entry := "  " + label + " " + desc
 			entryWidth := render.StringWidth(entry)
 			if col < numCols-1 {
@@ -345,30 +349,13 @@ func (m *Model) renderEntries(entries []Entry, width int) []string {
 func New() *Model {
 	groups := buildGroups(config.Current.Bindings)
 
-	palette := common.DefaultPalette
-	s := styles{
-		border:   palette.GetBorder("help border", lipgloss.NormalBorder()).Padding(0),
-		title:    palette.Get("help title"),
-		heading:  palette.Get("help title"),
-		shortcut: palette.Get("help shortcut"),
-		desc:     palette.Get("help desc").Inherit(palette.Get("help dimmed")),
-		dimmed:   palette.Get("help dimmed"),
-	}
-
 	ti := textinput.New()
 	ti.Placeholder = "search"
 	ti.Prompt = "/ "
 	ti.SetWidth(40)
-	ts := ti.Styles()
-	ts.Focused.Text = s.shortcut
-	ts.Focused.Placeholder = s.dimmed
-	ts.Blurred.Text = s.shortcut
-	ts.Blurred.Placeholder = s.dimmed
-	ti.SetStyles(ts)
 
 	return &Model{
 		groups: groups,
-		styles: s,
 		input:  ti,
 	}
 }

--- a/internal/ui/input/input.go
+++ b/internal/ui/input/input.go
@@ -27,17 +27,10 @@ type Model struct {
 	input  textinput.Model
 	title  string
 	prompt string
-	styles styles
 }
 
 func (m *Model) IsFocused() bool {
 	return true
-}
-
-type styles struct {
-	border lipgloss.Style
-	text   lipgloss.Style
-	title  lipgloss.Style
 }
 
 func New() *Model {
@@ -45,19 +38,10 @@ func New() *Model {
 }
 
 func NewWithTitle(title string, prompt string) *Model {
-	styles := styles{
-		border: common.DefaultPalette.GetBorder("input border", lipgloss.RoundedBorder()),
-		text:   common.DefaultPalette.Get("input text"),
-		title:  common.DefaultPalette.Get("input title"),
-	}
 	ti := textinput.New()
 	ti.SetWidth(40)
 	ti.Focus()
 	ti.Prompt = prompt
-	is := ti.Styles()
-	is.Focused.Prompt = styles.text
-	is.Blurred.Prompt = styles.text
-	ti.SetStyles(is)
 	if ti.Prompt == "" {
 		ti.Prompt = "> "
 	}
@@ -66,7 +50,6 @@ func NewWithTitle(title string, prompt string) *Model {
 		input:  ti,
 		title:  title,
 		prompt: prompt,
-		styles: styles,
 	}
 }
 
@@ -115,15 +98,24 @@ func (m *Model) selectCurrent() tea.Cmd {
 }
 
 func (m *Model) ViewRect(dl *render.DisplayContext, box layout.Box) {
+	borderStyle := common.DefaultPalette.GetBorder("input border", lipgloss.RoundedBorder())
+	textStyle := common.DefaultPalette.Get("input text")
+	titleStyle := common.DefaultPalette.Get("input title")
+
 	var rows []string
 	if m.title != "" {
-		rows = append(rows, m.styles.title.Render(m.title))
+		rows = append(rows, titleStyle.Render(m.title))
 	}
+	is := m.input.Styles()
+	is.Focused.Prompt = textStyle
+	is.Blurred.Prompt = textStyle
+	m.input.SetStyles(is)
+
 	m.input.SetWidth(min(box.R.Dx()-2, 40))
 	rows = append(rows, m.input.View())
 
 	content := lipgloss.JoinVertical(0, rows...)
-	content = m.styles.border.Padding(0, 1).Render(content)
+	content = borderStyle.Padding(0, 1).Render(content)
 	box = box.Center(lipgloss.Size(content))
 	dl.AddBackdrop(box.R, render.ZDialogs)
 	dl.AddDraw(box.R, content, render.ZDialogs)

--- a/internal/ui/operations/abandon/abandon.go
+++ b/internal/ui/operations/abandon/abandon.go
@@ -41,11 +41,6 @@ type Operation struct {
 	selectedRevisions jj.SelectedRevisions
 	selections        selections
 	current           *jj.Commit
-	styles            styles
-}
-
-type styles struct {
-	sourceMarker lipgloss.Style
 }
 
 type addSelectionMsg struct {
@@ -119,11 +114,13 @@ func (a *Operation) Render(commit *jj.Commit, pos operations.RenderPosition) str
 	if pos != operations.RenderBeforeChangeId {
 		return ""
 	}
+
+	sourceMarkerStyle := common.DefaultPalette.Get("abandon source_marker")
 	if a.selections.has(commit.GetChangeId(), selectionTypeDescendants) {
-		return a.styles.sourceMarker.Render("<< abandon descendants of >>")
+		return sourceMarkerStyle.Render("<< abandon descendants of >>")
 	}
 	if a.selections.has(commit.GetChangeId(), selectionTypeRevision) {
-		return a.styles.sourceMarker.Render("<< abandon >>")
+		return sourceMarkerStyle.Render("<< abandon >>")
 	}
 	return ""
 }
@@ -155,9 +152,6 @@ func (a *Operation) Name() string {
 }
 
 func NewOperation(context *context.MainContext, selectedRevisions jj.SelectedRevisions) *Operation {
-	styles := styles{
-		sourceMarker: common.DefaultPalette.Get("abandon source_marker"),
-	}
 	selectionItems := make(map[string]selectionType, len(selectedRevisions.Revisions))
 	for _, revision := range selectedRevisions.Revisions {
 		if revision == nil {
@@ -173,7 +167,6 @@ func NewOperation(context *context.MainContext, selectedRevisions jj.SelectedRev
 		context:           context,
 		selectedRevisions: selectedRevisions,
 		selections:        selections{items: selectionItems},
-		styles:            styles,
 	}
 }
 

--- a/internal/ui/operations/absorb/absorb.go
+++ b/internal/ui/operations/absorb/absorb.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	tea "charm.land/bubbletea/v2"
-	"charm.land/lipgloss/v2"
 	"github.com/idursun/jjui/internal/jj"
 	"github.com/idursun/jjui/internal/ui/actions"
 	"github.com/idursun/jjui/internal/ui/common"
@@ -30,13 +29,6 @@ type Operation struct {
 	current  *jj.Commit
 	defaults map[string]bool
 	targets  map[string]bool
-	styles   styles
-}
-
-type styles struct {
-	sourceMarker lipgloss.Style
-	targetMarker lipgloss.Style
-	dimmed       lipgloss.Style
 }
 
 func (o *Operation) IsFocused() bool {
@@ -117,15 +109,19 @@ func (o *Operation) Render(commit *jj.Commit, pos operations.RenderPosition) str
 	if pos != operations.RenderBeforeChangeId {
 		return ""
 	}
+	sourceMarkerStyle := common.DefaultPalette.Get("absorb source_marker")
+	targetMarkerStyle := common.DefaultPalette.Get("absorb target_marker")
+	dimmedStyle := common.DefaultPalette.Get("absorb dimmed")
+
 	changeId := commit.GetChangeId()
 	if changeId == o.source.GetChangeId() {
-		return o.styles.sourceMarker.Render("<< absorb >>")
+		return sourceMarkerStyle.Render("<< absorb >>")
 	}
 	if o.targets[changeId] {
-		return o.styles.targetMarker.Render("<< into >>")
+		return targetMarkerStyle.Render("<< into >>")
 	}
 	if o.defaults[changeId] {
-		return o.styles.dimmed.Render("<< default >>")
+		return dimmedStyle.Render("<< default >>")
 	}
 	return ""
 }
@@ -135,11 +131,6 @@ func (o *Operation) Name() string {
 }
 
 func NewOperation(ctx *context.MainContext, source *jj.Commit) *Operation {
-	s := styles{
-		sourceMarker: common.DefaultPalette.Get("absorb source_marker"),
-		targetMarker: common.DefaultPalette.Get("absorb target_marker"),
-		dimmed:       common.DefaultPalette.Get("absorb dimmed"),
-	}
 	defaultIds := loadDefaultTargets(ctx, source)
 	defaults := make(map[string]bool, len(defaultIds))
 	targets := make(map[string]bool, len(defaultIds))
@@ -152,7 +143,6 @@ func NewOperation(ctx *context.MainContext, source *jj.Commit) *Operation {
 		source:   source,
 		defaults: defaults,
 		targets:  targets,
-		styles:   s,
 	}
 }
 

--- a/internal/ui/operations/bookmark/set_bookmark.go
+++ b/internal/ui/operations/bookmark/set_bookmark.go
@@ -108,22 +108,11 @@ func (s *SetBookmarkOperation) Name() string {
 }
 
 func NewSetBookmarkOperation(context *context.MainContext, changeId string) *SetBookmarkOperation {
-	dimmedStyle := common.DefaultPalette.Get("revisions dimmed").Inline(true)
-	textStyle := common.DefaultPalette.Get("revisions text").Inline(true)
 	t := textinput.New()
 	t.ShowSuggestions = true
 	t.CharLimit = 120
 	t.Prompt = ""
-	s := textinput.DefaultDarkStyles()
-	s.Focused.Text = textStyle
-	s.Focused.Prompt = textStyle
-	s.Focused.Suggestion = dimmedStyle
-	s.Focused.Placeholder = dimmedStyle
-	s.Blurred.Text = textStyle
-	s.Blurred.Prompt = textStyle
-	s.Blurred.Suggestion = dimmedStyle
-	s.Blurred.Placeholder = dimmedStyle
-	t.SetStyles(s)
+
 	t.SetValue("")
 	t.Focus()
 
@@ -138,6 +127,19 @@ func NewSetBookmarkOperation(context *context.MainContext, changeId string) *Set
 }
 
 func (s *SetBookmarkOperation) viewContent() string {
+	dimmedStyle := common.DefaultPalette.Get("revisions dimmed").Inline(true)
+	textStyle := common.DefaultPalette.Get("revisions text").Inline(true)
+	styles := s.name.Styles()
+	styles.Focused.Text = textStyle
+	styles.Focused.Prompt = textStyle
+	styles.Focused.Suggestion = dimmedStyle
+	styles.Focused.Placeholder = dimmedStyle
+	styles.Blurred.Text = textStyle
+	styles.Blurred.Prompt = textStyle
+	styles.Blurred.Suggestion = dimmedStyle
+	styles.Blurred.Placeholder = dimmedStyle
+	s.name.SetStyles(styles)
+
 	return s.name.View()
 }
 

--- a/internal/ui/operations/describe/describe.go
+++ b/internal/ui/operations/describe/describe.go
@@ -58,7 +58,7 @@ func (o *Operation) Render(commit *jj.Commit, pos operations.RenderPosition) str
 	if pos != operations.RenderOverDescription {
 		return ""
 	}
-	return o.renderTextarea(80, 0).View()
+	return o.resizeInput(80, 0).View()
 }
 
 func (o *Operation) CanEmbed(_ *jj.Commit, pos operations.RenderPosition) bool {
@@ -69,7 +69,7 @@ func (o *Operation) EmbeddedHeight(commit *jj.Commit, pos operations.RenderPosit
 	if !o.CanEmbed(commit, pos) {
 		return 0
 	}
-	return o.renderTextarea(width, 0).Height()
+	return o.resizeInput(width, 0).Height()
 }
 
 func (o *Operation) Name() string {
@@ -139,7 +139,14 @@ func (o *Operation) Init() tea.Cmd {
 }
 
 func (o *Operation) ViewRect(dl *render.DisplayContext, box layout.Box) {
-	input := o.renderTextarea(box.R.Dx(), box.R.Dy())
+	input := o.resizeInput(box.R.Dx(), box.R.Dy())
+
+	selectedStyle := common.DefaultPalette.Get("revisions selected")
+	ds := input.Styles()
+	ds.Focused.Base = selectedStyle.Underline(false).Strikethrough(false).Reverse(false).Blink(false)
+	ds.Focused.CursorLine = ds.Focused.Base
+	input.SetStyles(ds)
+
 	rect := layout.Rect(box.R.Min.X, box.R.Min.Y, box.R.Dx(), input.Height())
 	dl.AddDraw(rect, input.View(), 0)
 }
@@ -155,18 +162,13 @@ func NewOperation(context *context.MainContext, revision *jj.Commit) *Operation 
 	// clear the stashed description regardless
 	stashed = nil
 
-	selectedStyle := common.DefaultPalette.Get("revisions selected")
-
 	input := textarea.New()
 	input.CharLimit = 0
 	input.Prompt = ""
 	input.ShowLineNumbers = false
 	input.DynamicHeight = true
 	input.MinHeight = 1
-	ds := input.Styles()
-	ds.Focused.Base = selectedStyle.Underline(false).Strikethrough(false).Reverse(false).Blink(false)
-	ds.Focused.CursorLine = ds.Focused.Base
-	input.SetStyles(ds)
+
 	input.SetValue(desc)
 	input.Focus()
 
@@ -178,7 +180,7 @@ func NewOperation(context *context.MainContext, revision *jj.Commit) *Operation 
 	}
 }
 
-func (o *Operation) renderTextarea(width, maxHeight int) textarea.Model {
+func (o *Operation) resizeInput(width, maxHeight int) textarea.Model {
 	input := o.input
 	if width <= 0 {
 		width = 80

--- a/internal/ui/operations/details/details.go
+++ b/internal/ui/operations/details/details.go
@@ -45,7 +45,6 @@ type Operation struct {
 	Current      *jj.Commit
 	revision     *jj.Commit
 	confirmation *confirmation.Model
-	styles       styles
 }
 
 func (s *Operation) IsOverlay() bool {
@@ -332,7 +331,8 @@ func (s *Operation) handleIntentInner(intent intents.Intent) (tea.Cmd, bool) {
 }
 
 func (s *Operation) ViewRect(dl *render.DisplayContext, box layout.Box) {
-	background := lipgloss.NewStyle().Background(s.styles.Text.GetBackground())
+	textStyle := common.DefaultPalette.Get("revisions details text")
+	background := lipgloss.NewStyle().Background(textStyle.GetBackground())
 	dl.AddFill(box.R, ' ', background, 0)
 	s.renderIntoRect(dl, box.R)
 }
@@ -375,7 +375,8 @@ func (s *Operation) EmbeddedHeight(commit *jj.Commit, pos operations.RenderPosit
 func (s *Operation) renderIntoRect(dl *render.DisplayContext, rect layout.Rectangle) int {
 	if s.Len() == 0 {
 		// Render "No changes" message
-		content := s.styles.Dimmed.Render("No changes")
+		dimmedStyle := common.DefaultPalette.Get("revisions details dimmed")
+		content := dimmedStyle.Render("No changes")
 		dl.AddDraw(layout.Rect(rect.Min.X, rect.Min.Y, rect.Dx(), 1), content, 0)
 		return 1
 	}
@@ -512,24 +513,11 @@ func (s *Operation) load(revision string) tea.Cmd {
 }
 
 func NewOperation(context *context.MainContext, selected *jj.Commit) *Operation {
-	s := styles{
-		Added:    common.DefaultPalette.Get("revisions details added"),
-		Deleted:  common.DefaultPalette.Get("revisions details deleted"),
-		Modified: common.DefaultPalette.Get("revisions details modified"),
-		Renamed:  common.DefaultPalette.Get("revisions details renamed"),
-		Copied:   common.DefaultPalette.Get("revisions details copied"),
-		Selected: common.DefaultPalette.Get("revisions details selected"),
-		Dimmed:   common.DefaultPalette.Get("revisions details dimmed"),
-		Text:     common.DefaultPalette.Get("revisions details text"),
-		Conflict: common.DefaultPalette.Get("revisions details conflict"),
-	}
-
-	l := NewDetailsList(s)
+	l := NewDetailsList()
 	op := &Operation{
 		DetailsList: l,
 		context:     context,
 		revision:    selected,
-		styles:      s,
 	}
 	return op
 }

--- a/internal/ui/operations/details/details_list.go
+++ b/internal/ui/operations/details/details_list.go
@@ -3,6 +3,7 @@ package details
 import (
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
+	"github.com/idursun/jjui/internal/ui/common"
 	"github.com/idursun/jjui/internal/ui/layout"
 	"github.com/idursun/jjui/internal/ui/render"
 )
@@ -28,17 +29,15 @@ type DetailsList struct {
 	listRenderer     *render.ListRenderer
 	selectedHint     string
 	unselectedHint   string
-	styles           styles
 	ensureCursorView bool
 }
 
-func NewDetailsList(styles styles) *DetailsList {
+func NewDetailsList() *DetailsList {
 	d := &DetailsList{
 		files:          []*item{},
 		cursor:         -1,
 		selectedHint:   "",
 		unselectedHint: "",
-		styles:         styles,
 	}
 	d.listRenderer = render.NewListRenderer(FileListScrollMsg{})
 	return d
@@ -111,6 +110,9 @@ func (d *DetailsList) RenderFileList(dl *render.DisplayContext, viewRect layout.
 		return 1
 	}
 
+	selectedStyle := common.DefaultPalette.Get("revisions details selected")
+	textStyle := common.DefaultPalette.Get("revisions details text")
+
 	// Render function - renders each visible item
 	renderItem := func(dl *render.DisplayContext, index int, rect layout.Rectangle) {
 		item := d.files[index]
@@ -118,9 +120,9 @@ func (d *DetailsList) RenderFileList(dl *render.DisplayContext, viewRect layout.
 
 		baseStyle := d.getStatusStyle(item.status)
 		if isSelected {
-			baseStyle = d.styles.Selected.Inherit(baseStyle)
+			baseStyle = selectedStyle.Inherit(baseStyle)
 		} else {
-			baseStyle = baseStyle.Background(d.styles.Text.GetBackground())
+			baseStyle = baseStyle.Background(textStyle.GetBackground())
 		}
 		background := lipgloss.NewStyle().Background(baseStyle.GetBackground())
 		dl.AddFill(rect, ' ', background, 0)
@@ -163,11 +165,15 @@ func (d *DetailsList) renderItemContent(tb *render.TextBuilder, item *item, inde
 
 	tb.Styled(title, style.PaddingRight(1))
 
+	dimmedStyle := common.DefaultPalette.Get("revisions details dimmed")
+	conflictStyle := common.DefaultPalette.Get("revisions details conflict")
+	selectedStyle := common.DefaultPalette.Get("revisions details selected")
+
 	// Add conflict marker
 	if item.conflict {
-		conflictStyle := d.styles.Conflict
+		conflictStyle := conflictStyle
 		if selected {
-			conflictStyle = d.styles.Selected.Inherit(conflictStyle)
+			conflictStyle = selectedStyle.Inherit(conflictStyle)
 		}
 		tb.Styled("conflict ", conflictStyle)
 	}
@@ -181,28 +187,35 @@ func (d *DetailsList) renderItemContent(tb *render.TextBuilder, item *item, inde
 		}
 	}
 	if hint != "" {
-		hintStyle := d.styles.Dimmed
+		hintStyle := dimmedStyle
 		if selected {
-			hintStyle = d.styles.Selected.Inherit(hintStyle)
+			hintStyle = selectedStyle.Inherit(hintStyle)
 		}
 		tb.Styled(hint, hintStyle)
 	}
 }
 
 func (d *DetailsList) getStatusStyle(s status) lipgloss.Style {
+	addedStyle := common.DefaultPalette.Get("revisions details added")
+	deletedStyle := common.DefaultPalette.Get("revisions details deleted")
+	modifiedStyle := common.DefaultPalette.Get("revisions details modified")
+	renamedStyle := common.DefaultPalette.Get("revisions details renamed")
+	copiedStyle := common.DefaultPalette.Get("revisions details copied")
+	textStyle := common.DefaultPalette.Get("revisions details text")
+
 	switch s {
 	case Added:
-		return d.styles.Added
+		return addedStyle
 	case Deleted:
-		return d.styles.Deleted
+		return deletedStyle
 	case Modified:
-		return d.styles.Modified
+		return modifiedStyle
 	case Renamed:
-		return d.styles.Renamed
+		return renamedStyle
 	case Copied:
-		return d.styles.Copied
+		return copiedStyle
 	default:
-		return d.styles.Text
+		return textStyle
 	}
 }
 

--- a/internal/ui/operations/details/item.go
+++ b/internal/ui/operations/details/item.go
@@ -2,8 +2,6 @@ package details
 
 import (
 	"fmt"
-
-	"charm.land/lipgloss/v2"
 )
 
 type status uint8
@@ -43,15 +41,3 @@ func (f item) Title() string {
 }
 func (f item) Description() string { return "" }
 func (f item) FilterValue() string { return f.name }
-
-type styles struct {
-	Added    lipgloss.Style
-	Deleted  lipgloss.Style
-	Modified lipgloss.Style
-	Renamed  lipgloss.Style
-	Copied   lipgloss.Style
-	Selected lipgloss.Style
-	Dimmed   lipgloss.Style
-	Text     lipgloss.Style
-	Conflict lipgloss.Style
-}

--- a/internal/ui/operations/duplicate/duplicate_operation.go
+++ b/internal/ui/operations/duplicate/duplicate_operation.go
@@ -25,13 +25,6 @@ var (
 	}
 )
 
-type styles struct {
-	changeId     lipgloss.Style
-	dimmed       lipgloss.Style
-	targetMarker lipgloss.Style
-	sourceMarker lipgloss.Style
-}
-
 var _ operations.Operation = (*Operation)(nil)
 var _ common.Focusable = (*Operation)(nil)
 var _ dispatch.ScopeProvider = (*Operation)(nil)
@@ -43,7 +36,6 @@ type Operation struct {
 	To          *jj.Commit
 	Target      intents.ModeTarget
 	targetName  string
-	styles      styles
 }
 
 func (r *Operation) IsFocused() bool {
@@ -109,16 +101,21 @@ func (r *Operation) SetSelectedRevision(commit *jj.Commit) tea.Cmd {
 }
 
 func (r *Operation) Render(commit *jj.Commit, pos operations.RenderPosition) string {
+	changeIdStyle := common.DefaultPalette.Get("duplicate change_id")
+	dimmedStyle := common.DefaultPalette.Get("duplicate dimmed")
+	sourceMarker := common.DefaultPalette.Get("duplicate source_marker")
+	targetMarkerStyle := common.DefaultPalette.Get("duplicate target_marker")
+
 	if pos == operations.RenderBeforeChangeId {
 		changeId := commit.GetChangeId()
 		if r.From.Contains(commit) {
-			return r.styles.sourceMarker.Render("<< duplicate >>")
+			return sourceMarker.Render("<< duplicate >>")
 		}
 		if r.Target == intents.ModeTargetInsert && r.InsertStart != nil && r.InsertStart.GetChangeId() == changeId {
-			return r.styles.sourceMarker.Render("<< after this >>")
+			return sourceMarker.Render("<< after this >>")
 		}
 		if r.Target == intents.ModeTargetInsert && r.To != nil && r.To.GetChangeId() == changeId {
-			return r.styles.sourceMarker.Render("<< before this >>")
+			return sourceMarker.Render("<< before this >>")
 		}
 		return ""
 	}
@@ -153,24 +150,24 @@ func (r *Operation) Render(commit *jj.Commit, pos operations.RenderPosition) str
 	if r.Target == intents.ModeTargetInsert {
 		return lipgloss.JoinHorizontal(
 			lipgloss.Left,
-			r.styles.targetMarker.Render("<< insert >>"),
+			targetMarkerStyle.Render("<< insert >>"),
 			" ",
-			r.styles.dimmed.Render("duplicate "),
-			r.styles.changeId.Render(strings.Join(r.From.GetIds(), " ")),
-			r.styles.dimmed.Render(" between "),
-			r.styles.changeId.Render(r.InsertStart.GetChangeId()),
-			r.styles.dimmed.Render(" and "),
-			r.styles.changeId.Render(r.To.GetChangeId()),
+			dimmedStyle.Render("duplicate "),
+			changeIdStyle.Render(strings.Join(r.From.GetIds(), " ")),
+			dimmedStyle.Render(" between "),
+			changeIdStyle.Render(r.InsertStart.GetChangeId()),
+			dimmedStyle.Render(" and "),
+			changeIdStyle.Render(r.To.GetChangeId()),
 		)
 	}
 
 	return lipgloss.JoinHorizontal(
 		lipgloss.Left,
-		r.styles.targetMarker.Render("<< "+ret+" >>"),
-		r.styles.dimmed.Render(" duplicate "),
-		r.styles.changeId.Render(strings.Join(r.From.GetIds(), " ")),
-		r.styles.dimmed.Render("", ret, ""),
-		r.styles.changeId.Render(r.To.GetChangeId()),
+		targetMarkerStyle.Render("<< "+ret+" >>"),
+		dimmedStyle.Render(" duplicate "),
+		changeIdStyle.Render(strings.Join(r.From.GetIds(), " ")),
+		dimmedStyle.Render("", ret, ""),
+		changeIdStyle.Render(r.To.GetChangeId()),
 	)
 }
 
@@ -191,16 +188,9 @@ func (r *Operation) targetArg() string {
 }
 
 func NewOperation(context *appContext.MainContext, from jj.SelectedRevisions, target intents.ModeTarget) *Operation {
-	styles := styles{
-		changeId:     common.DefaultPalette.Get("duplicate change_id"),
-		dimmed:       common.DefaultPalette.Get("duplicate dimmed"),
-		sourceMarker: common.DefaultPalette.Get("duplicate source_marker"),
-		targetMarker: common.DefaultPalette.Get("duplicate target_marker"),
-	}
 	return &Operation{
 		context: context,
 		From:    from,
 		Target:  target,
-		styles:  styles,
 	}
 }

--- a/internal/ui/operations/evolog/evolog_operation.go
+++ b/internal/ui/operations/evolog/evolog_operation.go
@@ -56,7 +56,6 @@ type Operation struct {
 	rows             []parser.Row
 	cursor           int
 	target           *jj.Commit
-	styles           styles
 	ensureCursorView bool
 }
 
@@ -106,15 +105,6 @@ func (o *Operation) Init() tea.Cmd {
 
 func (o *Operation) ViewRect(dl *render.DisplayContext, box layout.Box) {
 	o.renderListToDisplayContext(dl, box.R, o.ensureCursorView)
-}
-
-type styles struct {
-	dimmedStyle   lipgloss.Style
-	commitIdStyle lipgloss.Style
-	changeIdStyle lipgloss.Style
-	markerStyle   lipgloss.Style
-	textStyle     lipgloss.Style
-	selectedStyle lipgloss.Style
 }
 
 func (o *Operation) SetSelectedRevision(commit *jj.Commit) tea.Cmd {
@@ -234,13 +224,19 @@ func (o *Operation) updateSelection() tea.Cmd {
 
 func (o *Operation) Render(commit *jj.Commit, pos operations.RenderPosition) string {
 	if o.mode == restoreMode && pos == operations.RenderPositionBefore && o.target != nil && o.target.GetChangeId() == commit.GetChangeId() {
+
+		dimmedStyle := common.DefaultPalette.Get("evolog dimmed")
+		commitIdStyle := common.DefaultPalette.Get("evolog commit_id")
+		changeIdStyle := common.DefaultPalette.Get("evolog change_id")
+		markerStyle := common.DefaultPalette.Get("evolog target_marker")
+
 		selectedCommitId := o.getSelectedEvolog().CommitId
 		return lipgloss.JoinHorizontal(0,
-			o.styles.markerStyle.Render("<< restore >>"),
-			o.styles.dimmedStyle.PaddingLeft(1).Render("restore from "),
-			o.styles.commitIdStyle.Render(selectedCommitId),
-			o.styles.dimmedStyle.Render(" into "),
-			o.styles.changeIdStyle.Render(o.target.GetChangeId()),
+			markerStyle.Render("<< restore >>"),
+			dimmedStyle.PaddingLeft(1).Render("restore from "),
+			commitIdStyle.Render(selectedCommitId),
+			dimmedStyle.Render(" into "),
+			changeIdStyle.Render(o.target.GetChangeId()),
 		)
 	}
 
@@ -291,20 +287,11 @@ func (o *Operation) load() tea.Msg {
 }
 
 func NewOperation(context *context.MainContext, revision *jj.Commit) *Operation {
-	styles := styles{
-		dimmedStyle:   common.DefaultPalette.Get("evolog dimmed"),
-		commitIdStyle: common.DefaultPalette.Get("evolog commit_id"),
-		changeIdStyle: common.DefaultPalette.Get("evolog change_id"),
-		markerStyle:   common.DefaultPalette.Get("evolog target_marker"),
-		textStyle:     common.DefaultPalette.Get("evolog text"),
-		selectedStyle: common.DefaultPalette.Get("evolog selected"),
-	}
 	o := &Operation{
 		context:    context,
 		revision:   revision,
 		rows:       nil,
 		cursor:     0,
-		styles:     styles,
 		dlRenderer: render.NewListRenderer(EvologScrollMsg{}),
 	}
 	return o
@@ -320,6 +307,8 @@ func (o *Operation) renderListToDisplayContext(
 		dl.AddDraw(layout.Rect(rect.Min.X, rect.Min.Y, rect.Dx(), 1), content, 0)
 		return 1
 	}
+	textStyle := common.DefaultPalette.Get("evolog text")
+	selectedStyle := common.DefaultPalette.Get("evolog selected")
 
 	totalHeight := 0
 	for _, row := range o.rows {
@@ -334,9 +323,9 @@ func (o *Operation) renderListToDisplayContext(
 	renderItem := func(dl *render.DisplayContext, index int, itemRect layout.Rectangle) {
 		row := o.rows[index]
 		isItemSelected := index == o.cursor
-		styleOverride := o.styles.textStyle
+		styleOverride := textStyle
 		if isItemSelected {
-			styleOverride = o.styles.selectedStyle
+			styleOverride = selectedStyle
 		}
 
 		y := itemRect.Min.Y
@@ -354,7 +343,7 @@ func (o *Operation) renderListToDisplayContext(
 			dl.AddDraw(lineRect, lineContent, 0)
 
 			if isItemSelected {
-				dl.AddHighlight(lineRect, o.styles.selectedStyle, 1)
+				dl.AddHighlight(lineRect, selectedStyle, 1)
 			}
 			y++
 		}

--- a/internal/ui/operations/rebase/rebase_operation.go
+++ b/internal/ui/operations/rebase/rebase_operation.go
@@ -41,14 +41,6 @@ var (
 	}
 )
 
-type styles struct {
-	shortcut     lipgloss.Style
-	dimmed       lipgloss.Style
-	sourceMarker lipgloss.Style
-	targetMarker lipgloss.Style
-	changeId     lipgloss.Style
-}
-
 var (
 	_ operations.Operation   = (*Operation)(nil)
 	_ common.Focusable       = (*Operation)(nil)
@@ -64,7 +56,6 @@ type Operation struct {
 	Target         intents.ModeTarget
 	targetName     string
 	highlightedIds []string
-	styles         styles
 	SkipEmptied    bool
 }
 
@@ -184,6 +175,11 @@ func (r *Operation) SetSelectedRevision(commit *jj.Commit) tea.Cmd {
 }
 
 func (r *Operation) Render(commit *jj.Commit, pos operations.RenderPosition) string {
+	changeIdStyle := common.DefaultPalette.Get("rebase change_id")
+	dimmedStyle := common.DefaultPalette.Get("rebase dimmed")
+	sourceMarkerStyle := common.DefaultPalette.Get("rebase source_marker")
+	targetMarkerStyle := common.DefaultPalette.Get("rebase target_marker")
+
 	if pos == operations.RenderBeforeChangeId {
 		changeId := commit.GetChangeId()
 		marker := ""
@@ -199,7 +195,7 @@ func (r *Operation) Render(commit *jj.Commit, pos operations.RenderPosition) str
 		if r.SkipEmptied && marker != "" {
 			marker += " (skip emptied)"
 		}
-		return r.styles.sourceMarker.Render(marker)
+		return sourceMarkerStyle.Render(marker)
 	}
 	expectedPos := operations.RenderPositionBefore
 	if r.Target == intents.ModeTargetBefore || r.Target == intents.ModeTargetInsert {
@@ -248,27 +244,27 @@ func (r *Operation) Render(commit *jj.Commit, pos operations.RenderPosition) str
 	if r.Target == intents.ModeTargetInsert {
 		return lipgloss.JoinHorizontal(
 			lipgloss.Left,
-			r.styles.targetMarker.Render("<< insert >>"),
+			targetMarkerStyle.Render("<< insert >>"),
 			" ",
-			r.styles.dimmed.Render(source),
-			r.styles.changeId.Render(strings.Join(r.From.GetIds(), " ")),
-			r.styles.dimmed.Render(" between "),
-			r.styles.changeId.Render(r.InsertStart.GetChangeId()),
-			r.styles.dimmed.Render(" and "),
-			r.styles.changeId.Render(r.To.GetChangeId()),
+			dimmedStyle.Render(source),
+			changeIdStyle.Render(strings.Join(r.From.GetIds(), " ")),
+			dimmedStyle.Render(" between "),
+			changeIdStyle.Render(r.InsertStart.GetChangeId()),
+			dimmedStyle.Render(" and "),
+			changeIdStyle.Render(r.To.GetChangeId()),
 		)
 	}
 
 	return lipgloss.JoinHorizontal(
 		lipgloss.Left,
-		r.styles.targetMarker.Render("<< "+ret+" >>"),
-		r.styles.dimmed.Render(" rebase "),
-		r.styles.dimmed.Render(source),
-		r.styles.changeId.Render(strings.Join(r.From.GetIds(), " ")),
-		r.styles.dimmed.Render(" "),
-		r.styles.dimmed.Render(ret),
-		r.styles.dimmed.Render(" "),
-		r.styles.changeId.Render(r.To.GetChangeId()),
+		targetMarkerStyle.Render("<< "+ret+" >>"),
+		dimmedStyle.Render(" rebase "),
+		dimmedStyle.Render(source),
+		changeIdStyle.Render(strings.Join(r.From.GetIds(), " ")),
+		dimmedStyle.Render(" "),
+		dimmedStyle.Render(ret),
+		dimmedStyle.Render(" "),
+		changeIdStyle.Render(r.To.GetChangeId()),
 	)
 }
 
@@ -289,18 +285,10 @@ func (r *Operation) targetArg() string {
 }
 
 func NewOperation(context *context.MainContext, from jj.SelectedRevisions, source Source, target intents.ModeTarget) *Operation {
-	styles := styles{
-		changeId:     common.DefaultPalette.Get("rebase change_id"),
-		shortcut:     common.DefaultPalette.Get("rebase shortcut"),
-		dimmed:       common.DefaultPalette.Get("rebase dimmed"),
-		sourceMarker: common.DefaultPalette.Get("rebase source_marker"),
-		targetMarker: common.DefaultPalette.Get("rebase target_marker"),
-	}
 	return &Operation{
 		context: context,
 		From:    from,
 		Source:  source,
 		Target:  target,
-		styles:  styles,
 	}
 }

--- a/internal/ui/operations/revert/revert_operation.go
+++ b/internal/ui/operations/revert/revert_operation.go
@@ -26,13 +26,6 @@ var (
 	}
 )
 
-type styles struct {
-	dimmed       lipgloss.Style
-	sourceMarker lipgloss.Style
-	targetMarker lipgloss.Style
-	changeId     lipgloss.Style
-}
-
 var _ operations.Operation = (*Operation)(nil)
 var _ common.Focusable = (*Operation)(nil)
 var _ dispatch.ScopeProvider = (*Operation)(nil)
@@ -45,7 +38,6 @@ type Operation struct {
 	Target         intents.ModeTarget
 	targetName     string
 	highlightedIds []string
-	styles         styles
 }
 
 func (r *Operation) IsFocused() bool {
@@ -114,16 +106,21 @@ func (r *Operation) SetSelectedRevision(commit *jj.Commit) tea.Cmd {
 }
 
 func (r *Operation) Render(commit *jj.Commit, pos operations.RenderPosition) string {
+	changeIdStyle := common.DefaultPalette.Get("revert change_id")
+	dimmedStyle := common.DefaultPalette.Get("revert dimmed")
+	sourceMarkerStyle := common.DefaultPalette.Get("revert source_marker")
+	targetMarkerStyle := common.DefaultPalette.Get("revert target_marker")
+
 	if pos == operations.RenderBeforeChangeId {
 		changeId := commit.GetChangeId()
 		if slices.Contains(r.highlightedIds, changeId) {
-			return r.styles.sourceMarker.Render("<< revert >>")
+			return sourceMarkerStyle.Render("<< revert >>")
 		}
 		if r.Target == intents.ModeTargetInsert && r.InsertStart.GetChangeId() == commit.GetChangeId() {
-			return r.styles.sourceMarker.Render("<< after this >>")
+			return sourceMarkerStyle.Render("<< after this >>")
 		}
 		if r.Target == intents.ModeTargetInsert && r.To.GetChangeId() == commit.GetChangeId() {
-			return r.styles.sourceMarker.Render("<< before this >>")
+			return sourceMarkerStyle.Render("<< before this >>")
 		}
 		return ""
 	}
@@ -166,27 +163,27 @@ func (r *Operation) Render(commit *jj.Commit, pos operations.RenderPosition) str
 	if r.Target == intents.ModeTargetInsert {
 		return lipgloss.JoinHorizontal(
 			lipgloss.Left,
-			r.styles.targetMarker.Render("<< insert >>"),
+			targetMarkerStyle.Render("<< insert >>"),
 			" ",
-			r.styles.dimmed.Render(source),
-			r.styles.changeId.Render(strings.Join(r.From.GetIds(), " ")),
-			r.styles.dimmed.Render(" between "),
-			r.styles.changeId.Render(r.InsertStart.GetChangeId()),
-			r.styles.dimmed.Render(" and "),
-			r.styles.changeId.Render(r.To.GetChangeId()),
+			dimmedStyle.Render(source),
+			changeIdStyle.Render(strings.Join(r.From.GetIds(), " ")),
+			dimmedStyle.Render(" between "),
+			changeIdStyle.Render(r.InsertStart.GetChangeId()),
+			dimmedStyle.Render(" and "),
+			changeIdStyle.Render(r.To.GetChangeId()),
 		)
 	}
 
 	return lipgloss.JoinHorizontal(
 		lipgloss.Left,
-		r.styles.targetMarker.Render("<< "+ret+" >>"),
-		r.styles.dimmed.Render(" revert "),
-		r.styles.dimmed.Render(source),
-		r.styles.changeId.Render(strings.Join(r.From.GetIds(), " ")),
-		r.styles.dimmed.Render(" "),
-		r.styles.dimmed.Render(ret),
-		r.styles.dimmed.Render(" "),
-		r.styles.changeId.Render(r.To.GetChangeId()),
+		targetMarkerStyle.Render("<< "+ret+" >>"),
+		dimmedStyle.Render(" revert "),
+		dimmedStyle.Render(source),
+		changeIdStyle.Render(strings.Join(r.From.GetIds(), " ")),
+		dimmedStyle.Render(" "),
+		dimmedStyle.Render(ret),
+		dimmedStyle.Render(" "),
+		changeIdStyle.Render(r.To.GetChangeId()),
 	)
 }
 
@@ -207,16 +204,9 @@ func (r *Operation) targetArg() string {
 }
 
 func NewOperation(context *context.MainContext, from jj.SelectedRevisions, target intents.ModeTarget) *Operation {
-	styles := styles{
-		changeId:     common.DefaultPalette.Get("revert change_id"),
-		dimmed:       common.DefaultPalette.Get("revert dimmed"),
-		sourceMarker: common.DefaultPalette.Get("revert source_marker"),
-		targetMarker: common.DefaultPalette.Get("revert target_marker"),
-	}
 	return &Operation{
 		context: context,
 		From:    from,
 		Target:  target,
-		styles:  styles,
 	}
 }

--- a/internal/ui/operations/set_parents/set_parents_operation.go
+++ b/internal/ui/operations/set_parents/set_parents_operation.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	tea "charm.land/bubbletea/v2"
-	"charm.land/lipgloss/v2"
 	"github.com/idursun/jjui/internal/jj"
 	"github.com/idursun/jjui/internal/ui/actions"
 	"github.com/idursun/jjui/internal/ui/common"
@@ -28,7 +27,6 @@ type Model struct {
 	current  *jj.Commit
 	toRemove map[string]bool
 	toAdd    []string
-	styles   styles
 	parents  []string
 }
 
@@ -60,12 +58,6 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 }
 
 func (m *Model) ViewRect(_ *render.DisplayContext, _ layout.Box) {}
-
-type styles struct {
-	sourceMarker lipgloss.Style
-	targetMarker lipgloss.Style
-	dimmed       lipgloss.Style
-}
 
 func (m *Model) SetSelectedRevision(commit *jj.Commit) tea.Cmd {
 	m.current = commit
@@ -119,18 +111,22 @@ func (m *Model) Render(commit *jj.Commit, renderPosition operations.RenderPositi
 	if renderPosition != operations.RenderBeforeChangeId {
 		return ""
 	}
+	sourceMarker := common.DefaultPalette.Get("set_parents source_marker")
+	targetMarker := common.DefaultPalette.Get("set_parents target_marker")
+	dimmedStyle := common.DefaultPalette.Get("set_parents dimmed")
+
 	if slices.Contains(m.toAdd, commit.GetChangeId()) {
-		return m.styles.sourceMarker.Render("<< add >>")
+		return sourceMarker.Render("<< add >>")
 	}
 	if m.toRemove[commit.GetChangeId()] {
-		return m.styles.sourceMarker.Render("<< remove >>")
+		return sourceMarker.Render("<< remove >>")
 	}
 
 	if slices.Contains(m.parents, commit.CommitId) {
-		return m.styles.dimmed.Render("<< parent >>")
+		return dimmedStyle.Render("<< parent >>")
 	}
 	if commit.GetChangeId() == m.target.GetChangeId() {
-		return m.styles.targetMarker.Render("<< to >>")
+		return targetMarker.Render("<< to >>")
 	}
 	return ""
 }
@@ -140,11 +136,6 @@ func (m *Model) Name() string {
 }
 
 func NewModel(ctx *context.MainContext, to *jj.Commit) *Model {
-	styles := styles{
-		sourceMarker: common.DefaultPalette.Get("set_parents source_marker"),
-		targetMarker: common.DefaultPalette.Get("set_parents target_marker"),
-		dimmed:       common.DefaultPalette.Get("set_parents dimmed"),
-	}
 	output, err := ctx.RunCommandImmediate(jj.GetParents(to.GetChangeId()))
 	if err != nil {
 		log.Println("Failed to get parents for commit", to.GetChangeId())
@@ -156,6 +147,5 @@ func NewModel(ctx *context.MainContext, to *jj.Commit) *Model {
 		toRemove: make(map[string]bool),
 		toAdd:    []string{},
 		target:   to,
-		styles:   styles,
 	}
 }

--- a/internal/ui/operations/squash/squash_operation.go
+++ b/internal/ui/operations/squash/squash_operation.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 
 	tea "charm.land/bubbletea/v2"
-	"charm.land/lipgloss/v2"
 	"github.com/idursun/jjui/internal/jj"
 	"github.com/idursun/jjui/internal/ui/actions"
 	"github.com/idursun/jjui/internal/ui/common"
@@ -33,7 +32,6 @@ type Operation struct {
 	keepEmptied           bool
 	useDestinationMessage bool
 	interactive           bool
-	styles                styles
 }
 
 func (s *Operation) IsFocused() bool {
@@ -48,11 +46,6 @@ func (s *Operation) Scopes() []dispatch.Scope {
 			Handler: s,
 		},
 	}
-}
-
-type styles struct {
-	sourceMarker lipgloss.Style
-	targetMarker lipgloss.Style
 }
 
 func (s *Operation) Init() tea.Cmd {
@@ -112,6 +105,8 @@ func (s *Operation) Render(commit *jj.Commit, pos operations.RenderPosition) str
 	if pos != operations.RenderBeforeChangeId {
 		return ""
 	}
+	sourceMarkerStyle := common.DefaultPalette.Get("squash source_marker")
+	targetMarkerStyle := common.DefaultPalette.Get("squash target_marker")
 
 	isSelected := s.current != nil && s.current.GetChangeId() == commit.GetChangeId()
 	if isSelected {
@@ -119,7 +114,7 @@ func (s *Operation) Render(commit *jj.Commit, pos operations.RenderPosition) str
 		if s.useDestinationMessage {
 			marker = "<< use this message >>"
 		}
-		return s.styles.targetMarker.Render(marker)
+		return targetMarkerStyle.Render(marker)
 	}
 	sourceIds := s.from.GetIds()
 	if slices.Contains(sourceIds, commit.ChangeId) {
@@ -130,7 +125,7 @@ func (s *Operation) Render(commit *jj.Commit, pos operations.RenderPosition) str
 		if s.interactive {
 			marker += " (interactive)"
 		}
-		return s.styles.sourceMarker.Render(marker)
+		return sourceMarkerStyle.Render(marker)
 	}
 	return ""
 }
@@ -158,14 +153,9 @@ func WithFiles(files []string) Option {
 }
 
 func NewOperation(context *context.MainContext, from jj.SelectedRevisions, opts ...Option) *Operation {
-	styles := styles{
-		sourceMarker: common.DefaultPalette.Get("squash source_marker"),
-		targetMarker: common.DefaultPalette.Get("squash target_marker"),
-	}
 	o := &Operation{
 		context: context,
 		from:    from,
-		styles:  styles,
 	}
 	for _, opt := range opts {
 		opt(o)

--- a/internal/ui/operations/target_picker/target_picker.go
+++ b/internal/ui/operations/target_picker/target_picker.go
@@ -53,21 +53,9 @@ type Model struct {
 	input               textinput.Model
 	cursor              int
 	matches             fuzzy.Matches
-	styles              styles
 	fzfSource           *fuzzy_search.RefinedSource
 	listRenderer        *render.ListRenderer
 	ensureCursorVisible bool
-}
-
-type styles struct {
-	bookmarkPill       lipgloss.Style
-	selected           lipgloss.Style
-	selectedDimmed     lipgloss.Style
-	selectedText       lipgloss.Style
-	selectedMatchStyle lipgloss.Style
-	dimmed             lipgloss.Style
-	matchStyle         lipgloss.Style
-	border             lipgloss.Style
 }
 
 type itemsLoadedMsg struct {
@@ -115,34 +103,15 @@ func (m *Model) Scopes() []dispatch.Scope {
 }
 
 func NewModel(ctx *context.MainContext) *Model {
-	palette := common.DefaultPalette
-	text := palette.Get("picker text")
-	dimmed := palette.Get("picker dimmed")
 	ti := textinput.New()
 	ti.Prompt = "> "
-	tis := ti.Styles()
-	tis.Focused.Prompt = dimmed
-	tis.Focused.Text = text
-	tis.Blurred.Prompt = dimmed
-	tis.Blurred.Text = text
-	ti.SetStyles(tis)
 	ti.CharLimit = 0
 	ti.Focus()
 
 	m := &Model{
-		context: ctx,
-		input:   ti,
-		cursor:  0,
-		styles: styles{
-			bookmarkPill:       palette.Get("picker bookmark"),
-			selected:           palette.Get("picker selected"),
-			selectedDimmed:     palette.Get("picker selected dimmed"),
-			selectedText:       palette.Get("picker selected text"),
-			selectedMatchStyle: palette.Get("picker selected matched"),
-			dimmed:             dimmed,
-			matchStyle:         palette.Get("picker matched"),
-			border:             palette.GetBorder("picker border", lipgloss.NormalBorder()),
-		},
+		context:             ctx,
+		input:               ti,
+		cursor:              0,
 		listRenderer:        render.NewListRenderer(itemScrollMsg{}),
 		ensureCursorVisible: true,
 	}
@@ -216,18 +185,35 @@ func (m *Model) ViewRect(dl *render.DisplayContext, box layout.Box) {
 		return
 	}
 
+	bookmarkPillStyle := common.DefaultPalette.Get("picker bookmark")
+	selectedStyle := common.DefaultPalette.Get("picker selected")
+	selectedDimmedStyle := common.DefaultPalette.Get("picker selected dimmed")
+	selectedTextStyle := common.DefaultPalette.Get("picker selected text")
+	selectedMatchStyle := common.DefaultPalette.Get("picker selected matched")
+	matchedStyle := common.DefaultPalette.Get("picker matched")
+	borderStyle := common.DefaultPalette.GetBorder("picker border", lipgloss.NormalBorder())
+	textStyle := common.DefaultPalette.Get("picker text")
+	dimmedStyle := common.DefaultPalette.Get("picker dimmed")
+
 	maxW := min(maxWidth, box.R.Dx())
 	maxH := min(maxHeight, box.R.Dy())
 	centeredBox := box.Center(maxW, maxH)
 
 	frame := centeredBox
 	dl.AddBackdrop(box.R, render.ZMenuBorder-1)
-	borderContent := m.styles.border.Width(frame.R.Dx()).Height(frame.R.Dy()).Render("")
+	borderContent := borderStyle.Width(frame.R.Dx()).Height(frame.R.Dy()).Render("")
 	dl.AddDraw(frame.R, borderContent, render.ZMenuBorder)
 	centeredBox = centeredBox.Inset(1)
 
 	inputBox, listBox := centeredBox.CutTop(1)
 	m.input.SetWidth(inputBox.R.Dx())
+
+	tis := m.input.Styles()
+	tis.Focused.Prompt = dimmedStyle
+	tis.Focused.Text = textStyle
+	tis.Blurred.Prompt = dimmedStyle
+	tis.Blurred.Text = textStyle
+	m.input.SetStyles(tis)
 
 	dl.AddDraw(inputBox.R, m.input.View(), render.ZMenuContent)
 
@@ -247,14 +233,14 @@ func (m *Model) ViewRect(dl *render.DisplayContext, box layout.Box) {
 			y := rect.Min.Y
 
 			isSelected := index == m.cursor
-			pillStyle := m.styles.dimmed
-			lineStyle := m.styles.bookmarkPill
-			matchStyle := m.styles.matchStyle
+			pillStyle := dimmedStyle
+			lineStyle := bookmarkPillStyle
+			matchStyle := matchedStyle
 			if isSelected {
-				pillStyle = m.styles.selectedDimmed
-				lineStyle = m.styles.selectedText
-				matchStyle = m.styles.selectedMatchStyle
-				dl.AddFill(rect, ' ', m.styles.selected, render.ZMenuContent-1)
+				pillStyle = selectedDimmedStyle
+				lineStyle = selectedTextStyle
+				matchStyle = selectedMatchStyle
+				dl.AddFill(rect, ' ', selectedStyle, render.ZMenuContent-1)
 			} else {
 				matchStyle = matchStyle.Inherit(lineStyle)
 			}

--- a/internal/ui/oplog/operation_log.go
+++ b/internal/ui/oplog/operation_log.go
@@ -42,9 +42,6 @@ type Model struct {
 	listRenderer     *render.ListRenderer
 	rows             []row
 	cursor           int
-	textStyle        lipgloss.Style
-	selectedStyle    lipgloss.Style
-	matchedStyle     lipgloss.Style
 	ensureCursorView bool
 	quickSearch      string
 }
@@ -250,12 +247,16 @@ func (m *Model) ViewRect(dl *render.DisplayContext, box layout.Box) {
 		return len(m.rows[index].Lines)
 	}
 
+	textStyle := common.DefaultPalette.Get("oplog text")
+	selectedStyle := common.DefaultPalette.Get("oplog selected")
+	matchedStyle := common.DefaultPalette.Get("oplog matched")
+
 	renderItem := func(dl *render.DisplayContext, index int, itemRect layout.Rectangle) {
 		row := m.rows[index]
 		isSelected := index == m.cursor
-		styleOverride := m.textStyle
+		styleOverride := textStyle
 		if isSelected {
-			styleOverride = m.selectedStyle
+			styleOverride = selectedStyle
 		}
 
 		y := itemRect.Min.Y
@@ -279,7 +280,7 @@ func (m *Model) ViewRect(dl *render.DisplayContext, box layout.Box) {
 						if idx > lastEnd {
 							content.WriteString(style.Render(text[lastEnd:idx]))
 						}
-						content.WriteString(m.matchedStyle.Inherit(styleOverride).Render(text[idx : idx+len(lowerSearch)]))
+						content.WriteString(matchedStyle.Inherit(styleOverride).Render(text[idx : idx+len(lowerSearch)]))
 						lastEnd = idx + len(lowerSearch)
 					}
 				} else {
@@ -326,12 +327,9 @@ func (m *Model) load() tea.Cmd {
 
 func New(context *context.MainContext) *Model {
 	m := &Model{
-		context:       context,
-		rows:          nil,
-		cursor:        0,
-		textStyle:     common.DefaultPalette.Get("oplog text"),
-		selectedStyle: common.DefaultPalette.Get("oplog selected"),
-		matchedStyle:  common.DefaultPalette.Get("oplog matched"),
+		context: context,
+		rows:    nil,
+		cursor:  0,
 	}
 	m.listRenderer = render.NewListRenderer(OpLogScrollMsg{})
 	return m

--- a/internal/ui/password/password.go
+++ b/internal/ui/password/password.go
@@ -17,28 +17,15 @@ var _ common.ImmediateModel = (*Model)(nil)
 type Model struct {
 	textInput  textinput.Model
 	passwordCh chan<- []byte
-	styles     styles
-}
-
-type styles struct {
-	border lipgloss.Style
 }
 
 func New(msg common.TogglePasswordMsg) *Model {
-	styles := styles{
-		border: common.DefaultPalette.GetBorder("password border", lipgloss.NormalBorder()).Padding(1),
-	}
 	ti := textinput.New()
 	ti.Prompt = msg.Prompt
 	ti.EchoMode = textinput.EchoPassword
-	ps := ti.Styles()
-	ps.Focused.Prompt = common.DefaultPalette.Get("password title")
-	ps.Blurred.Prompt = common.DefaultPalette.Get("password title")
-	ti.SetStyles(ps)
 	ti.Focus()
 
 	return &Model{
-		styles:     styles,
 		textInput:  ti,
 		passwordCh: msg.Password,
 	}
@@ -89,7 +76,13 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 }
 
 func (m *Model) ViewRect(dl *render.DisplayContext, box layout.Box) {
-	v := m.styles.border.Width(max(box.R.Dx()-2, 0)).Render(m.textInput.View())
+	borderStyle := common.DefaultPalette.GetBorder("password border", lipgloss.NormalBorder()).Padding(1)
+	ps := m.textInput.Styles()
+	ps.Focused.Prompt = common.DefaultPalette.Get("password title")
+	ps.Blurred.Prompt = common.DefaultPalette.Get("password title")
+	m.textInput.SetStyles(ps)
+
+	v := borderStyle.Width(max(box.R.Dx()-2, 0)).Render(m.textInput.View())
 	box = box.Center(lipgloss.Size(v))
 	dl.AddDraw(box.R, v, render.ZPassword)
 }

--- a/internal/ui/redo/redo.go
+++ b/internal/ui/redo/redo.go
@@ -56,6 +56,7 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 }
 
 func (m *Model) ViewRect(dl *render.DisplayContext, box layout.Box) {
+	m.confirmation.Styles.Border = common.DefaultPalette.GetBorder("redo border", lipgloss.NormalBorder()).Padding(1)
 	v := m.confirmation.View()
 	w, h := lipgloss.Size(v)
 	pw, ph := box.R.Dx(), box.R.Dy()
@@ -76,7 +77,6 @@ func NewModel(context *context.MainContext) *Model {
 		confirmation.WithOption("Yes", context.RunCommand(jj.Redo(), common.Refresh, common.Close), key.NewBinding(key.WithKeys("y"), key.WithHelp("y", "yes"))),
 		confirmation.WithOption("No", common.Close, key.NewBinding(key.WithKeys("n", "esc"), key.WithHelp("n/esc", "no"))),
 	)
-	model.Styles.Border = common.DefaultPalette.GetBorder("redo border", lipgloss.NormalBorder()).Padding(1)
 	return &Model{
 		confirmation: model,
 	}

--- a/internal/ui/revisions/displaycontext_renderer.go
+++ b/internal/ui/revisions/displaycontext_renderer.go
@@ -85,13 +85,9 @@ func (ir *itemRenderer) renderSegmentForLine(tb *render.TextBuilder, segment *sc
 }
 
 // NewDisplayContextRenderer creates a new DisplayContext-based renderer
-func NewDisplayContextRenderer(textStyle, dimmedStyle, selectedStyle, matchedStyle lipgloss.Style) *DisplayContextRenderer {
+func NewDisplayContextRenderer() *DisplayContextRenderer {
 	return &DisplayContextRenderer{
-		listRenderer:  render.NewListRenderer(ViewportScrollMsg{}),
-		textStyle:     textStyle,
-		dimmedStyle:   dimmedStyle,
-		selectedStyle: selectedStyle,
-		matchedStyle:  matchedStyle,
+		listRenderer: render.NewListRenderer(ViewportScrollMsg{}),
 	}
 }
 

--- a/internal/ui/revisions/displaycontext_renderer_test.go
+++ b/internal/ui/revisions/displaycontext_renderer_test.go
@@ -7,7 +7,6 @@ import (
 
 	uv "github.com/charmbracelet/ultraviolet"
 
-	"charm.land/lipgloss/v2"
 	"github.com/idursun/jjui/internal/jj"
 	"github.com/idursun/jjui/internal/parser"
 	"github.com/idursun/jjui/internal/ui/layout"
@@ -45,7 +44,7 @@ func TestDisplayContextRenderer_DetailsRendersBeforeElidedMarker(t *testing.T) {
 	test.SimulateModel(op, op.Init())
 
 	// Render just the target row with the details operation active.
-	r := NewDisplayContextRenderer(lipgloss.NewStyle(), lipgloss.NewStyle(), lipgloss.NewStyle(), lipgloss.NewStyle())
+	r := NewDisplayContextRenderer()
 	r.SetSelections(nil)
 
 	width, height := 100, 15
@@ -95,7 +94,7 @@ func TestDisplayContextRenderer_SingleRowDescriptionOverlay(t *testing.T) {
 	ctx := test.NewTestContext(commandRunner)
 	op := describe.NewOperation(ctx, targetRow.Commit)
 
-	r := NewDisplayContextRenderer(lipgloss.NewStyle(), lipgloss.NewStyle(), lipgloss.NewStyle(), lipgloss.NewStyle())
+	r := NewDisplayContextRenderer()
 	r.SetSelections(nil)
 
 	width, height := 70, 10

--- a/internal/ui/revisions/revisions.go
+++ b/internal/ui/revisions/revisions.go
@@ -69,10 +69,6 @@ type Model struct {
 	previousOpLogId        string
 	isLoading              bool
 	displayContextRenderer *DisplayContextRenderer
-	textStyle              lipgloss.Style
-	dimmedStyle            lipgloss.Style
-	selectedStyle          lipgloss.Style
-	matchedStyle           lipgloss.Style
 	ensureCursorView       bool
 	requestInFlight        bool
 }
@@ -1073,6 +1069,16 @@ func (m *Model) updateGraphRows(rows []parser.Row, selectedRevision string) {
 }
 
 func (m *Model) ViewRect(dl *render.DisplayContext, box layout.Box) {
+	textStyle := common.DefaultPalette.Get("revisions text")
+	dimmedStyle := common.DefaultPalette.Get("revisions dimmed")
+	selectedStyle := common.DefaultPalette.Get("revisions selected")
+	matchedStyle := common.DefaultPalette.Get("revisions matched")
+
+	m.displayContextRenderer.textStyle = textStyle
+	m.displayContextRenderer.dimmedStyle = dimmedStyle
+	m.displayContextRenderer.selectedStyle = selectedStyle
+	m.displayContextRenderer.matchedStyle = matchedStyle
+
 	if len(m.rows) == 0 {
 		content := ""
 		if m.isLoading {
@@ -1223,12 +1229,8 @@ func New(c *appContext.MainContext) *Model {
 		baseOp:        operations.NewDefault(),
 		layers:        nil,
 		cursor:        0,
-		textStyle:     common.DefaultPalette.Get("revisions text"),
-		dimmedStyle:   common.DefaultPalette.Get("revisions dimmed"),
-		selectedStyle: common.DefaultPalette.Get("revisions selected"),
-		matchedStyle:  common.DefaultPalette.Get("revisions matched"),
 	}
-	m.displayContextRenderer = NewDisplayContextRenderer(m.textStyle, m.dimmedStyle, m.selectedStyle, m.matchedStyle)
+	m.displayContextRenderer = NewDisplayContextRenderer()
 	return &m
 }
 

--- a/internal/ui/revset/revset.go
+++ b/internal/ui/revset/revset.go
@@ -51,26 +51,10 @@ type Model struct {
 	History            []string
 	MaxHistoryItems    int
 	context            *appContext.MainContext
-	styles             styles
 	listRenderer       *render.ListRenderer
 	completionItems    []CompletionItem
 	selectedIndex      int
 	userInput          string // tracks what the user actually typed (separate from preview)
-}
-
-type styles struct {
-	title lipgloss.Style
-	text  lipgloss.Style
-
-	// Completion overlay styles
-	completionText       lipgloss.Style
-	completionMatched    lipgloss.Style
-	completionSelected   lipgloss.Style
-	completionTextSel    lipgloss.Style
-	completionMatchedSel lipgloss.Style
-	completionDimmedSel  lipgloss.Style
-	completionDimmed     lipgloss.Style
-	completionBackground lipgloss.Style
 }
 
 func (m *Model) Scopes() []dispatch.Scope {
@@ -95,20 +79,6 @@ func (m *Model) GetValue() string {
 }
 
 func New(context *appContext.MainContext) *Model {
-	palette := common.DefaultPalette
-	styles := styles{
-		title:                palette.Get("revset title"),
-		text:                 palette.Get("revset text"),
-		completionText:       palette.Get("revset completion text"),
-		completionMatched:    palette.Get("revset completion matched"),
-		completionSelected:   palette.Get("revset completion selected"),
-		completionTextSel:    palette.Get("revset completion selected text"),
-		completionMatchedSel: palette.Get("revset completion selected matched"),
-		completionDimmedSel:  palette.Get("revset completion selected dimmed"),
-		completionDimmed:     palette.Get("revset completion dimmed"),
-		completionBackground: palette.Get("revset completion"),
-	}
-
 	revsetAliases := context.JJConfig.RevsetAliases
 	completionProvider := NewCompletionProvider(revsetAliases)
 	autoComplete := autocompletion.New(
@@ -127,7 +97,6 @@ func New(context *appContext.MainContext) *Model {
 		completionProvider: completionProvider,
 		History:            []string{},
 		MaxHistoryItems:    50,
-		styles:             styles,
 		listRenderer:       render.NewListRenderer(completionScrollMsg{}),
 		selectedIndex:      -1, // no selection initially
 	}
@@ -355,14 +324,18 @@ func (m *Model) HandleIntent(intent intents.Intent) (tea.Cmd, bool) {
 }
 
 func (m *Model) ViewRect(dl *render.DisplayContext, box layout.Box) {
-	// Render the prompt and text input line
+
+	titleStyle := common.DefaultPalette.Get("revset title")
+	textStyle := common.DefaultPalette.Get("revset text")
+	completionDimmed := common.DefaultPalette.Get("revset completion dimmed")
+
 	tb := dl.Text(box.R.Min.X, box.R.Min.Y, render.ZFuzzyInput)
-	tb.Styled("revset: ", m.styles.title)
+	tb.Styled("revset: ", titleStyle)
 	if m.Editing {
 		// Only render the text input part, not the completions from autoComplete.View()
 		tb.Write(m.autoComplete.TextInput.View())
 	} else {
-		tb.Styled(m.context.CurrentRevset, m.styles.text)
+		tb.Styled(m.context.CurrentRevset, textStyle)
 	}
 	tb.Done()
 
@@ -378,7 +351,7 @@ func (m *Model) ViewRect(dl *render.DisplayContext, box layout.Box) {
 		// Show "No suggestions" when there's input but no matches
 		if m.autoComplete.Value() != "" {
 			noSuggestionsRect := layout.Rect(box.R.Min.X, box.R.Max.Y, box.R.Dx(), 1)
-			noSuggestionsText := m.styles.completionDimmed.Render("No suggestions")
+			noSuggestionsText := completionDimmed.Render("No suggestions")
 			dl.AddDraw(noSuggestionsRect, noSuggestionsText, render.ZRevsetOverlay)
 		}
 		return
@@ -387,7 +360,7 @@ func (m *Model) ViewRect(dl *render.DisplayContext, box layout.Box) {
 	// If no items but we have signature help, show it
 	if len(items) == 0 && signatureHelp != "" {
 		sigRect := layout.Rect(box.R.Min.X, box.R.Max.Y, box.R.Dx(), 1)
-		sigText := m.styles.completionDimmed.Render(signatureHelp)
+		sigText := completionDimmed.Render(signatureHelp)
 		dl.AddDraw(sigRect, sigText, render.ZRevsetOverlay)
 		return
 	}
@@ -397,7 +370,9 @@ func (m *Model) ViewRect(dl *render.DisplayContext, box layout.Box) {
 	overlayWidth := box.R.Dx()
 	outerBox := layout.NewBox(layout.Rect(box.R.Min.X, box.R.Max.Y, overlayWidth, overlayHeight))
 	// Fill the background to prevent underlying content from showing through
-	dl.AddFill(outerBox.R, ' ', m.styles.completionBackground, render.ZRevsetOverlay-1)
+	dl.AddFill(outerBox.R, ' ', common.DefaultPalette.Get("revset completion"), render.ZRevsetOverlay-1)
+	completionText := common.DefaultPalette.Get("revset completion text")
+	completionMatched := common.DefaultPalette.Get("revset completion matched")
 
 	m.listRenderer.Render(
 		dl,
@@ -413,27 +388,29 @@ func (m *Model) ViewRect(dl *render.DisplayContext, box layout.Box) {
 			isSelected := index == m.selectedIndex
 
 			item := items[index]
-			completionText := m.styles.completionText
-			completionMatched := m.styles.completionMatched
-			completionDimmed := m.styles.completionDimmed
+
+			ts := completionText
+			ms := completionMatched
+			ds := completionDimmed
+
 			if isSelected {
-				completionText = m.styles.completionTextSel
-				completionMatched = m.styles.completionMatchedSel
-				completionDimmed = m.styles.completionDimmedSel
-				dl.AddFill(rect, ' ', m.styles.completionSelected.Inherit(m.styles.completionBackground), render.ZRevsetOverlay-1)
+				ts = common.DefaultPalette.Get("revset completion selected text")
+				ms = common.DefaultPalette.Get("revset completion selected matched")
+				ds = common.DefaultPalette.Get("revset completion selected dimmed")
+				dl.AddFill(rect, ' ', common.DefaultPalette.Get("revset completion selected"), render.ZRevsetOverlay-1)
 			}
 
 			tb := dl.Text(rect.Min.X, rect.Min.Y, render.ZRevsetOverlay)
-			pillStyle := completionDimmed.Width(pillWidth).Align(lipgloss.Right)
+			pillStyle := ds.Width(pillWidth).Align(lipgloss.Right)
 			tb.Styled(pillLabel(item.Kind), pillStyle)
-			tb.Styled(" ", completionText)
-			tb.Styled(item.MatchedPart, completionMatched)
-			tb.Styled(item.RestPart, completionText)
-			tb.Styled(" ", completionText)
+			tb.Styled(" ", ts)
+			tb.Styled(item.MatchedPart, ms)
+			tb.Styled(item.RestPart, ts)
+			tb.Styled(" ", ts)
 
 			if item.SignatureHelp != "" && item.Kind != KindHistory {
 				sigDisplay := m.formatSignature(item)
-				tb.Styled(sigDisplay, completionDimmed)
+				tb.Styled(sigDisplay, ds)
 			}
 			tb.Done()
 		},
@@ -461,14 +438,10 @@ func pillLabel(kind CompletionKind) string {
 
 func (m *Model) formatSignature(item CompletionItem) string {
 	sig := item.SignatureHelp
-	// The signature format is "name(args): description"
-	// We want to show just the description or "(args): desc" if different from name
 	if _, after, ok := strings.Cut(sig, "):"); ok {
-		// Return description part after "): "
 		return strings.TrimSpace(after)
 	}
 	if _, after, ok := strings.Cut(sig, ":"); ok {
-		// Return description part after ": "
 		return strings.TrimSpace(after)
 	}
 	return sig

--- a/internal/ui/status/status.go
+++ b/internal/ui/status/status.go
@@ -42,16 +42,8 @@ type Model struct {
 	mode            string
 	focusKind       FocusKind
 	fuzzy           fuzzy_search.Model
-	styles          styles
 	statusExpanded  bool
 	statusTruncated bool
-}
-
-type styles struct {
-	shortcut lipgloss.Style
-	dimmed   lipgloss.Style
-	text     lipgloss.Style
-	title    lipgloss.Style
 }
 
 func (m *Model) IsFocused() bool {
@@ -220,41 +212,55 @@ func (m *Model) loadEditingSuggestions() {
 }
 
 func (m *Model) ViewRect(dl *render.DisplayContext, box layout.Box) {
+	shortcutStyle := common.DefaultPalette.Get("status shortcut")
+	dimmedStyle := common.DefaultPalette.Get("status dimmed")
+	textStyle := common.DefaultPalette.Get("status text")
+	titleStyle := common.DefaultPalette.Get("status title").PaddingLeft(1).PaddingRight(1)
+
+	inputStyles := m.input.Styles()
+	inputStyles.Focused.Text = textStyle
+	inputStyles.Focused.Suggestion = dimmedStyle
+	inputStyles.Focused.Placeholder = dimmedStyle
+	inputStyles.Blurred.Text = textStyle
+	inputStyles.Blurred.Suggestion = dimmedStyle
+	inputStyles.Blurred.Placeholder = dimmedStyle
+	m.input.SetStyles(inputStyles)
+
 	width := box.R.Dx()
 	modeWidth := max(10, len(m.mode)+2)
-	mode := m.styles.title.Width(modeWidth).Render(m.mode)
+	mode := titleStyle.Width(modeWidth).Render(m.mode)
 
 	var statusLine string
 	if m.IsFocused() {
-		content := m.renderContent(width, modeWidth)
-		statusLine = lipgloss.JoinHorizontal(lipgloss.Left, mode, m.styles.text.Render(" "), content)
+		content := m.renderContent(width, modeWidth, shortcutStyle, dimmedStyle)
+		statusLine = lipgloss.JoinHorizontal(lipgloss.Left, mode, textStyle.Render(" "), content)
 	} else {
-		helpBar := m.renderHelpBar(width, modeWidth)
-		statusLine = lipgloss.JoinHorizontal(lipgloss.Left, mode, m.styles.text.Render(" "), helpBar)
+		helpBar := m.renderHelpBar(width, modeWidth, textStyle, shortcutStyle, dimmedStyle)
+		statusLine = lipgloss.JoinHorizontal(lipgloss.Left, mode, textStyle.Render(" "), helpBar)
 	}
 
 	dl.AddDraw(box.R, statusLine, 0)
-	m.renderExpandedStatus(dl, box, width)
+	m.renderExpandedStatus(dl, box, width, textStyle, titleStyle, shortcutStyle, dimmedStyle)
 	m.renderFuzzyOverlay(dl, box)
 }
 
 // renderHelpBar renders the help keybindings bar when idle.
-func (m *Model) renderHelpBar(width, modeWidth int) string {
+func (m *Model) renderHelpBar(width, modeWidth int, textStyle, shortcutStyle, dimmedStyle lipgloss.Style) string {
 	if len(m.groups) == 0 || m.statusExpanded {
-		return m.styles.text.Render(" ")
+		return textStyle.Render(" ")
 	}
 
 	availableWidth := max(0, width-modeWidth-2)
-	helpContent, truncated := m.groupedHelpView(m.groups, availableWidth)
+	helpContent, truncated := m.groupedHelpView(m.groups, availableWidth, shortcutStyle, dimmedStyle)
 	m.statusTruncated = truncated
-	return lipgloss.PlaceHorizontal(width, 0, helpContent, lipgloss.WithWhitespaceStyle(m.styles.text))
+	return lipgloss.PlaceHorizontal(width, 0, helpContent, lipgloss.WithWhitespaceStyle(textStyle))
 }
 
 // renderContent handles input display when focused
-func (m *Model) renderContent(width, modeWidth int) string {
+func (m *Model) renderContent(width, modeWidth int, shortcutStyle, dimmedStyle lipgloss.Style) string {
 	var editHelp string
 	if len(m.groups) > 0 {
-		editHelp, _ = m.groupedHelpView(m.groups, 0)
+		editHelp, _ = m.groupedHelpView(m.groups, 0, shortcutStyle, dimmedStyle)
 	}
 
 	promptWidth := render.StringWidth(m.input.Prompt) + 2
@@ -263,26 +269,26 @@ func (m *Model) renderContent(width, modeWidth int) string {
 }
 
 // renderExpandedStatus orchestrates expanded help overlay
-func (m *Model) renderExpandedStatus(dl *render.DisplayContext, box layout.Box, width int) {
+func (m *Model) renderExpandedStatus(dl *render.DisplayContext, box layout.Box, width int, textStyle, titleStyle, shortcutStyle, dimmedStyle lipgloss.Style) {
 	if !m.statusExpanded || len(m.groups) == 0 || m.IsFocused() {
 		return
 	}
 
-	expandedHelp, contentLineCount := m.expandedStatusView(m.groups, max(0, width-4))
+	expandedHelp, contentLineCount := m.expandedStatusView(m.groups, max(0, width-4), titleStyle, shortcutStyle, dimmedStyle)
 	expandedLines := strings.Split(expandedHelp, "\n")
 	startY := box.R.Min.Y - contentLineCount
 
-	m.renderExpandedStatusBorder(dl, box, width, startY)
-	m.renderExpandedStatusContent(dl, box, width, startY, expandedLines)
+	m.renderExpandedStatusBorder(dl, box, width, startY, dimmedStyle)
+	m.renderExpandedStatusContent(dl, box, width, startY, expandedLines, textStyle)
 }
 
 // renderExpandedStatusBorder draws the top border of expanded status
-func (m *Model) renderExpandedStatusBorder(dl *render.DisplayContext, box layout.Box, width, startY int) {
+func (m *Model) renderExpandedStatusBorder(dl *render.DisplayContext, box layout.Box, width, startY int, dimmedStyle lipgloss.Style) {
 	if startY < 0 {
 		return
 	}
 	borderLine := strings.Repeat("─", max(0, width))
-	topBorder := m.styles.dimmed.Render(borderLine)
+	topBorder := dimmedStyle.Render(borderLine)
 	borderRect := layout.Rect(box.R.Min.X, startY, width, 1)
 	dl.AddDraw(borderRect, topBorder, render.ZExpandedStatus)
 }
@@ -293,7 +299,7 @@ func (m *Model) renderExpandedStatusBorder(dl *render.DisplayContext, box layout
 // Each line is left-padded with 2 spaces and right-padded to fill the
 // available width, accounting for 4 total characters of horizontal padding
 // (2 left + 2 reserved for borders).
-func (m *Model) renderExpandedStatusContent(dl *render.DisplayContext, box layout.Box, width, startY int, lines []string) {
+func (m *Model) renderExpandedStatusContent(dl *render.DisplayContext, box layout.Box, width, startY int, lines []string, textStyle lipgloss.Style) {
 	for i, line := range lines {
 		// Position each line below the border, offset by its index
 		y := startY + 1 + i
@@ -311,7 +317,7 @@ func (m *Model) renderExpandedStatusContent(dl *render.DisplayContext, box layou
 		paddedLine := "  " + line + strings.Repeat(" ", padding)
 
 		// render the line with the text style and draw at the overlay z-index
-		contentLine := m.styles.text.Render(paddedLine)
+		contentLine := textStyle.Render(paddedLine)
 		contentRect := layout.Rect(box.R.Min.X, y, width, 1)
 		dl.AddDraw(contentRect, contentLine, render.ZExpandedStatus)
 	}
@@ -408,9 +414,9 @@ func (m *Model) InputValue() string {
 	return m.input.Value()
 }
 
-func (m *Model) expandedStatusView(groups []help.ScopeGroup, maxWidth int) (string, int) {
+func (m *Model) expandedStatusView(groups []help.ScopeGroup, maxWidth int, titleStyle, shortcutStyle, dimmedStyle lipgloss.Style) (string, int) {
 	expandKey := m.expandStatusKey(groups)
-	closeHint := m.styles.shortcut.Render(expandKey+"/esc") + m.styles.dimmed.PaddingLeft(1).Render("close help")
+	closeHint := shortcutStyle.Render(expandKey+"/esc") + dimmedStyle.PaddingLeft(1).Render("close help")
 
 	var allLines []string
 	for i, group := range groups {
@@ -418,10 +424,10 @@ func (m *Model) expandedStatusView(groups []help.ScopeGroup, maxWidth int) (stri
 			allLines = append(allLines, "")
 		}
 		if group.Name != "" {
-			header := m.styles.title.Render(group.Name)
+			header := titleStyle.Render(group.Name)
 			allLines = append(allLines, header)
 		}
-		rendered, maxEntryWidth := m.collectGroupEntries(group.Entries)
+		rendered, maxEntryWidth := m.collectGroupEntries(group.Entries, shortcutStyle, dimmedStyle)
 		lines := m.buildHelpGrid(rendered, maxEntryWidth, maxWidth)
 		allLines = append(allLines, lines...)
 	}
@@ -429,7 +435,7 @@ func (m *Model) expandedStatusView(groups []help.ScopeGroup, maxWidth int) (stri
 	return strings.Join(allLines, "\n"), len(allLines)
 }
 
-func (m *Model) collectGroupEntries(entries []help.Entry) ([]string, int) {
+func (m *Model) collectGroupEntries(entries []help.Entry, shortcutStyle, dimmedStyle lipgloss.Style) ([]string, int) {
 	var rendered []string
 	maxEntryWidth := 0
 
@@ -439,9 +445,9 @@ func (m *Model) collectGroupEntries(entries []help.Entry) ([]string, int) {
 		}
 		var e string
 		if entry.Overridden {
-			e = m.styles.dimmed.Strikethrough(true).Render(entry.Label + " " + entry.Desc)
+			e = dimmedStyle.Strikethrough(true).Render(entry.Label + " " + entry.Desc)
 		} else {
-			e = m.styles.shortcut.Render(entry.Label) + m.styles.dimmed.PaddingLeft(1).Render(entry.Desc)
+			e = shortcutStyle.Render(entry.Label) + dimmedStyle.PaddingLeft(1).Render(entry.Desc)
 		}
 		rendered = append(rendered, e)
 		if w := render.StringWidth(e); w > maxEntryWidth {
@@ -481,11 +487,11 @@ func (m *Model) buildHelpGrid(entries []string, maxEntryWidth, maxWidth int) []s
 }
 
 // groupedHelpView renders the collapsed help bar with groups separated by │.
-func (m *Model) groupedHelpView(groups []help.ScopeGroup, maxWidth int) (string, bool) {
-	separator := m.styles.dimmed.Render(" • ")
-	groupSeparator := m.styles.dimmed.Render(" │ ")
+func (m *Model) groupedHelpView(groups []help.ScopeGroup, maxWidth int, shortcutStyle, dimmedStyle lipgloss.Style) (string, bool) {
+	separator := dimmedStyle.Render(" • ")
+	groupSeparator := dimmedStyle.Render(" │ ")
 	expandKey := m.expandStatusKey(groups)
-	moreHint := separator + m.styles.shortcut.Render(expandKey) + m.styles.dimmed.PaddingLeft(1).Render("more")
+	moreHint := separator + shortcutStyle.Render(expandKey) + dimmedStyle.PaddingLeft(1).Render("more")
 
 	separatorWidth := render.StringWidth(separator)
 	groupSeparatorWidth := render.StringWidth(groupSeparator)
@@ -503,7 +509,7 @@ func (m *Model) groupedHelpView(groups []help.ScopeGroup, maxWidth int) (string,
 				continue
 			}
 
-			e := m.styles.shortcut.Render(entry.Label) + m.styles.dimmed.PaddingLeft(1).Render(entry.Desc)
+			e := shortcutStyle.Render(entry.Label) + dimmedStyle.PaddingLeft(1).Render(entry.Desc)
 			entryWidth := render.StringWidth(e)
 
 			addedWidth := entryWidth
@@ -556,27 +562,11 @@ func (m *Model) expandStatusKey(groups []help.ScopeGroup) string {
 }
 
 func New(context *context.MainContext) *Model {
-	styles := styles{
-		shortcut: common.DefaultPalette.Get("status shortcut"),
-		dimmed:   common.DefaultPalette.Get("status dimmed"),
-		text:     common.DefaultPalette.Get("status text"),
-		title:    common.DefaultPalette.Get("status title").PaddingLeft(1).PaddingRight(1),
-	}
-
 	t := textinput.New()
 	t.SetWidth(50)
-	ts := t.Styles()
-	ts.Focused.Text = styles.text
-	ts.Focused.Suggestion = styles.dimmed
-	ts.Focused.Placeholder = styles.dimmed
-	ts.Blurred.Text = styles.text
-	ts.Blurred.Suggestion = styles.dimmed
-	ts.Blurred.Placeholder = styles.dimmed
-	t.SetStyles(ts)
 
 	return &Model{
 		context: context,
 		input:   t,
-		styles:  styles,
 	}
 }

--- a/internal/ui/undo/undo.go
+++ b/internal/ui/undo/undo.go
@@ -56,6 +56,7 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 }
 
 func (m *Model) ViewRect(dl *render.DisplayContext, box layout.Box) {
+	m.confirmation.Styles.Border = common.DefaultPalette.GetBorder("undo border", lipgloss.NormalBorder()).Padding(1)
 	v := m.confirmation.View()
 	w, h := lipgloss.Size(v)
 	pw, ph := box.R.Dx(), box.R.Dy()
@@ -76,7 +77,6 @@ func NewModel(context *context.MainContext) *Model {
 		confirmation.WithOption("Yes", context.RunCommand(jj.Undo(), common.Refresh, common.Close), key.NewBinding(key.WithKeys("y"), key.WithHelp("y", "yes"))),
 		confirmation.WithOption("No", common.Close, key.NewBinding(key.WithKeys("n", "esc"), key.WithHelp("n/esc", "no"))),
 	)
-	model.Styles.Border = common.DefaultPalette.GetBorder("undo border", lipgloss.NormalBorder()).Padding(1)
 	return &Model{
 		confirmation: model,
 	}


### PR DESCRIPTION
We store the resolved styles in the `CurrentPalette` instance but also models had a reference to `styles` instances during runtime. This PR moves style resolution to ViewRect functions so that we only rely on the palette cache, effectively allowing theme change during runtime just by updating the palette.

Prerequisite for #641 