### PR TITLE
feat(ui): config setting to completely disable mouse support

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -110,8 +110,9 @@ type UIConfig struct {
 	SetWindowTitle bool             `toml:"set_window_title"`
 	// TODO(ilyagr): It might make sense to rename this to `auto_refresh_period` to match `--period` option
 	// once we have a mechanism to deprecate the old name softly.
-	AutoRefreshInterval        int `toml:"auto_refresh_interval"`
-	FlashMessageDisplaySeconds int `toml:"flash_message_display_seconds"`
+	AutoRefreshInterval        int  `toml:"auto_refresh_interval"`
+	FlashMessageDisplaySeconds int  `toml:"flash_message_display_seconds"`
+	NoMouse                    bool `toml:"no_mouse"`
 }
 
 func GetExpiringFlashMessageTimeout(c *Config) time.Duration {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -115,22 +115,6 @@ type UIConfig struct {
 	MouseSupport               bool `toml:"mouse_support"`
 }
 
-func (u *UIConfig) UnmarshalTOML(data any) error {
-	switch v := data.(type) {
-	case map[string]any:
-		if p, ok := v["mouse_support"]; ok {
-			if pBool, isBool := p.(bool); isBool {
-				u.MouseSupport = pBool
-			} else {
-				return fmt.Errorf("invalid type for 'mouse_support' in ui configuration: expected bool, got %T", p)
-			}
-		} else {
-			u.MouseSupport = true
-		}
-	}
-	return nil
-}
-
 func GetExpiringFlashMessageTimeout(c *Config) time.Duration {
 	return time.Duration(c.UI.FlashMessageDisplaySeconds) * time.Second
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -112,7 +112,23 @@ type UIConfig struct {
 	// once we have a mechanism to deprecate the old name softly.
 	AutoRefreshInterval        int  `toml:"auto_refresh_interval"`
 	FlashMessageDisplaySeconds int  `toml:"flash_message_display_seconds"`
-	NoMouse                    bool `toml:"no_mouse"`
+	MouseSupport               bool `toml:"mouse_support"`
+}
+
+func (u *UIConfig) UnmarshalTOML(data any) error {
+	switch v := data.(type) {
+	case map[string]any:
+		if p, ok := v["mouse_support"]; ok {
+			if pBool, isBool := p.(bool); isBool {
+				u.MouseSupport = pBool
+			} else {
+				return fmt.Errorf("invalid type for 'mouse_support' in ui configuration: expected bool, got %T", p)
+			}
+		} else {
+			u.MouseSupport = true
+		}
+	}
+	return nil
 }
 
 func GetExpiringFlashMessageTimeout(c *Config) time.Duration {

--- a/internal/config/default/config.toml
+++ b/internal/config/default/config.toml
@@ -7,6 +7,7 @@ bindings_profile = ":builtin"
   set_window_title = true
   auto_refresh_interval = 0
   flash_message_display_seconds = 4 # 0 means display until manually dismissed
+  mouse_support = true
   [ui.colors]
 
 [suggest]

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -724,6 +724,9 @@ func (w *wrapper) View() tea.View {
 	v.AltScreen = true
 	v.ReportFocus = true
 	v.MouseMode = tea.MouseModeCellMotion
+	if config.Current.UI.NoMouse {
+		v.MouseMode = tea.MouseModeNone
+	}
 	return v
 }
 

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -724,7 +724,7 @@ func (w *wrapper) View() tea.View {
 	v.AltScreen = true
 	v.ReportFocus = true
 	v.MouseMode = tea.MouseModeCellMotion
-	if config.Current.UI.NoMouse {
+	if !config.Current.UI.MouseSupport {
 		v.MouseMode = tea.MouseModeNone
 	}
 	return v


### PR DESCRIPTION
Add NoMouse bool `toml:"no_mouse"` to UIConfig to allow disabling mouse with `no_mouse = true` in config ui section. 

fixes #661