### PR TITLE
feat(ui): add ctrl-n/p list navigation aliases

### DIFF
--- a/internal/config/default/bindings.toml
+++ b/internal/config/default/bindings.toml
@@ -23,8 +23,8 @@ bindings = [
     { key = "enter", action = "revset.apply", scope = "revset", desc = "apply" },
     { key = "tab", action = "revset.autocomplete", scope = "revset", desc = "autocomplete" },
     { key = "shift+tab", action = "revset.autocomplete_back", scope = "revset", desc = "autocomplete back" },
-    { key = "up", action = "revset.move_up", scope = "revset", desc = "up" },
-    { key = "down", action = "revset.move_down", scope = "revset", desc = "down" },
+    { key = ["up", "ctrl+p"], action = "revset.move_up", scope = "revset", desc = "up" },
+    { key = ["down", "ctrl+n"], action = "revset.move_down", scope = "revset", desc = "down" },
 
     # preview
     { key = "ctrl+h", action = "ui.preview_expand", scope = "ui.preview", desc = "expand preview" },
@@ -239,8 +239,8 @@ bindings = [
     { key = "esc", action = "revisions.target_picker.cancel", scope = "revisions.target_picker", desc = "cancel" },
     { key = "enter", action = "revisions.target_picker.apply", scope = "revisions.target_picker", desc = "apply" },
     { key = "alt+enter", action = "revisions.target_picker.apply", scope = "revisions.target_picker", desc = "force apply", args = { force = true } },
-    { key = "up", action = "revisions.target_picker.move_up", scope = "revisions.target_picker", desc = "up" },
-    { key = "down", action = "revisions.target_picker.move_down", scope = "revisions.target_picker", desc = "down" },
+    { key = ["up", "ctrl+p"], action = "revisions.target_picker.move_up", scope = "revisions.target_picker", desc = "up" },
+    { key = ["down", "ctrl+n"], action = "revisions.target_picker.move_down", scope = "revisions.target_picker", desc = "down" },
     { key = "tab", action = "revisions.target_picker.autocomplete", scope = "revisions.target_picker", desc = "autocomplete" },
     { key = "shift+tab", action = "revisions.target_picker.autocomplete_back", scope = "revisions.target_picker", desc = "autocomplete back" },
 
@@ -264,8 +264,8 @@ bindings = [
     { key = "enter", action = "file_search.apply", scope = "file_search", desc = "apply" },
     { key = "ctrl+t", action = "file_search.toggle", scope = "file_search", desc = "toggle" },
     { key = "alt+e", action = "file_search.edit", scope = "file_search", desc = "edit" },
-    { key = "up", action = "file_search.move_up", scope = "file_search", desc = "up" },
-    { key = "down", action = "file_search.move_down", scope = "file_search", desc = "down" },
+    { key = ["up", "ctrl+p"], action = "file_search.move_up", scope = "file_search", desc = "up" },
+    { key = ["down", "ctrl+n"], action = "file_search.move_down", scope = "file_search", desc = "down" },
     { key = ["ctrl+u", "pgup"], action = "file_search.page_up", scope = "file_search", desc = "pgup" },
     { key = ["ctrl+d", "pgdown"], action = "file_search.page_down", scope = "file_search", desc = "pgdown" },
     { key = "ctrl+b", action = "file_search.preview_half_page_up", scope = "file_search", desc = "preview half up" },

--- a/internal/ui/dispatch/resolver_test.go
+++ b/internal/ui/dispatch/resolver_test.go
@@ -92,6 +92,88 @@ func TestResolveKey_BuiltInCatalogResolution(t *testing.T) {
 	assert.Equal(t, 1, nav.Delta)
 }
 
+func TestResolveKey_DefaultEmacsListNavigationAliases(t *testing.T) {
+	runtimeBindings := config.BindingsToRuntime(config.Current.Bindings)
+	r := makeResolver(runtimeBindings, nil)
+
+	tests := []struct {
+		name       string
+		scope      keybindings.ScopeName
+		key        tea.KeyPressMsg
+		assertions func(t *testing.T, intent intents.Intent)
+	}{
+		{
+			name:  "ctrl+p moves revset completions up",
+			scope: "revset",
+			key:   tea.KeyPressMsg{Code: 'p', Mod: tea.ModCtrl},
+			assertions: func(t *testing.T, intent intents.Intent) {
+				nav, ok := intent.(intents.CompletionMove)
+				assert.True(t, ok)
+				assert.Equal(t, -1, nav.Delta)
+			},
+		},
+		{
+			name:  "ctrl+n moves revset completions down",
+			scope: "revset",
+			key:   tea.KeyPressMsg{Code: 'n', Mod: tea.ModCtrl},
+			assertions: func(t *testing.T, intent intents.Intent) {
+				nav, ok := intent.(intents.CompletionMove)
+				assert.True(t, ok)
+				assert.Equal(t, 1, nav.Delta)
+			},
+		},
+		{
+			name:  "ctrl+p moves file search up",
+			scope: "file_search",
+			key:   tea.KeyPressMsg{Code: 'p', Mod: tea.ModCtrl},
+			assertions: func(t *testing.T, intent intents.Intent) {
+				nav, ok := intent.(intents.FileSearchNavigate)
+				assert.True(t, ok)
+				assert.Equal(t, 1, nav.Delta)
+			},
+		},
+		{
+			name:  "ctrl+n moves file search down",
+			scope: "file_search",
+			key:   tea.KeyPressMsg{Code: 'n', Mod: tea.ModCtrl},
+			assertions: func(t *testing.T, intent intents.Intent) {
+				nav, ok := intent.(intents.FileSearchNavigate)
+				assert.True(t, ok)
+				assert.Equal(t, -1, nav.Delta)
+			},
+		},
+		{
+			name:  "ctrl+p moves target picker up",
+			scope: "revisions.target_picker",
+			key:   tea.KeyPressMsg{Code: 'p', Mod: tea.ModCtrl},
+			assertions: func(t *testing.T, intent intents.Intent) {
+				nav, ok := intent.(intents.TargetPickerNavigate)
+				assert.True(t, ok)
+				assert.Equal(t, -1, nav.Delta)
+			},
+		},
+		{
+			name:  "ctrl+n moves target picker down",
+			scope: "revisions.target_picker",
+			key:   tea.KeyPressMsg{Code: 'n', Mod: tea.ModCtrl},
+			assertions: func(t *testing.T, intent intents.Intent) {
+				nav, ok := intent.(intents.TargetPickerNavigate)
+				assert.True(t, ok)
+				assert.Equal(t, 1, nav.Delta)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := r.ResolveKey(tt.key, createScopes(tt.scope))
+			assert.True(t, result.Consumed)
+			assert.Equal(t, string(tt.scope), result.Scope)
+			tt.assertions(t, result.Intent)
+		})
+	}
+}
+
 func TestResolveKey_UsesMatchedBindingScopeForRouting(t *testing.T) {
 	r := makeResolver([]keybindings.Binding{
 		{Action: "revset.edit", Scope: "revisions", Key: []string{"L"}},

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -496,10 +496,10 @@ func (m *Model) dispatchScopes() []common.Scope {
 		scopes = append(scopes, m.revisions.Scopes()...)
 	}
 
+	scopes = append(scopes, m.previewModel.Scopes()...)
 	if !m.revsetModel.IsEditing() {
 		scopes = append(scopes, m.revsetModel.Scopes()...)
 	}
-	scopes = append(scopes, m.previewModel.Scopes()...)
 	scopes = append(scopes, common.Scope{
 		Name:    scopeUi,
 		Leak:    common.LeakNone,


### PR DESCRIPTION
## What changed

This PR adds `ctrl+n` / `ctrl+p` as cosy home-row aliases for moving down and up in input-driven lists.

This matches the behaviour many folks already expect from readline, Vim-ish and Emacs-ish interfaces, and makes these little lists nicer to use without reaching for the arrow keys.

Closes #666.

## Why

`j` and `k` are already lovely in the main revision list, but they are not a good fit inside text inputs because they should remain normal typed characters there.

`ctrl+n` and `ctrl+p` give those input lists a familiar navigation path without stealing regular typing.

## Notes

While adding the revset aliases, I also adjusted the inactive revset scope ordering so preview scrolling keeps its existing `ctrl+n` / `ctrl+p` behaviour when the revset input is not being edited.

## Verification

- `go build ./cmd/jjui`
- `go test ./...`
