### PR TITLE
fix: Use config preview commands for diff

### DIFF
--- a/internal/ui/operations/details/details.go
+++ b/internal/ui/operations/details/details.go
@@ -12,6 +12,7 @@ import (
 	"charm.land/bubbles/v2/key"
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
+	"github.com/idursun/jjui/internal/config"
 	"github.com/idursun/jjui/internal/jj"
 	"github.com/idursun/jjui/internal/ui/actions"
 	"github.com/idursun/jjui/internal/ui/common"
@@ -222,7 +223,16 @@ func (s *Operation) handleIntentInner(intent intents.Intent) (tea.Cmd, bool) {
 			return nil, true
 		}
 		return func() tea.Msg {
-			output, _ := s.context.RunCommandImmediate(jj.Diff(s.revision.GetChangeId(), selected.fileName))
+			args := jj.TemplatedArgs(
+				config.Current.Preview.FileCommand,
+				map[string]string{
+					jj.RevsetPlaceholder:   s.context.CurrentRevset,
+					jj.ChangeIdPlaceholder: s.revision.GetChangeId(),
+					jj.CommitIdPlaceholder: s.revision.CommitId,
+					jj.FilePlaceholder:     selected.fileName,
+				},
+			)
+			output, _ := s.context.RunCommandImmediate(args)
 			return intents.DiffShow{Content: string(output)}
 		}, true
 	case intents.DetailsSplit:

--- a/internal/ui/revisions/revisions.go
+++ b/internal/ui/revisions/revisions.go
@@ -985,9 +985,16 @@ func (m *Model) showDiff(intent intents.ShowDiff) tea.Cmd {
 	if commit == nil {
 		return nil
 	}
-	changeId := commit.GetChangeId()
 	return func() tea.Msg {
-		output, _ := m.context.RunCommandImmediate(jj.Diff(changeId, ""))
+		args := jj.TemplatedArgs(
+			config.Current.Preview.RevisionCommand,
+			map[string]string{
+				jj.RevsetPlaceholder:   m.context.CurrentRevset,
+				jj.ChangeIdPlaceholder: commit.GetChangeId(),
+				jj.CommitIdPlaceholder: commit.CommitId,
+			},
+		)
+		output, _ := m.context.RunCommandImmediate(args)
 		return intents.DiffShow{Content: string(output)}
 	}
 }


### PR DESCRIPTION
**Bug**: Pressing `d` to access the full-page diff doesn’t show the same content as the preview (i.e., the configured command)

**Steps to reproduce the issue (if applicable)**:
1. Set a custom preview command in the config
2. Notice the preview and the actual diff are different (this is especially noticeable if using Delta)

**How this fixes the problem**: Use the configured `RevisionCommand` and `FileCommand` for the `d` (diff) action.

> [!NOTE]
> I didn’t add tests because I’m not super familiar with Go. 