### PR TITLE
feat: add Home/End key support for navigating to top/bottom of revs

### DIFF
--- a/internal/config/default/bindings.toml
+++ b/internal/config/default/bindings.toml
@@ -75,6 +75,8 @@ bindings = [
     { key = "/", action = "ui.quick_search", scope = "revisions", desc = "search" },
     { key = "pgup", action = "revisions.page_up", scope = "revisions", desc = "pgup" },
     { key = "pgdown", action = "revisions.page_down", scope = "revisions", desc = "pgdown" },
+    { key = "home", action = "revisions.go_to_top", scope = "revisions", desc = "top" },
+    { key = "end", action = "revisions.go_to_bottom", scope = "revisions", desc = "bottom" },
     { key = "ctrl+t", action = "ui.file_search_toggle", scope = "revisions", desc = "file search" },
     { key = ":", action = "ui.exec_jj", scope = "revisions", desc = "exec jj" },
     { key = "$", action = "ui.exec_shell", scope = "revisions", desc = "exec shell" },
@@ -106,6 +108,8 @@ bindings = [
     { key = ["down", "j"], action = "revisions.move_down", scope = "revisions.rebase", desc = "down" },
     { key = "pgup", action = "revisions.page_up", scope = "revisions.rebase", desc = "pgup" },
     { key = "pgdown", action = "revisions.page_down", scope = "revisions.rebase", desc = "pgdown" },
+    { key = "home", action = "revisions.go_to_top", scope = "revisions.rebase", desc = "top" },
+    { key = "end", action = "revisions.go_to_bottom", scope = "revisions.rebase", desc = "bottom" },
 
     # revisions.squash
     { key = "enter", action = "revisions.squash.apply", scope = "revisions.squash", desc = "apply" },
@@ -121,6 +125,8 @@ bindings = [
     { key = ["down", "j"], action = "revisions.move_down", scope = "revisions.squash", desc = "down" },
     { key = "pgup", action = "revisions.page_up", scope = "revisions.squash", desc = "pgup" },
     { key = "pgdown", action = "revisions.page_down", scope = "revisions.squash", desc = "pgdown" },
+    { key = "home", action = "revisions.go_to_top", scope = "revisions.squash", desc = "top" },
+    { key = "end", action = "revisions.go_to_bottom", scope = "revisions.squash", desc = "bottom" },
 
     # revisions.revert
     { key = "enter", action = "revisions.revert.apply", scope = "revisions.revert", desc = "apply" },
@@ -137,6 +143,8 @@ bindings = [
     { key = ["down", "j"], action = "revisions.move_down", scope = "revisions.revert", desc = "down" },
     { key = "pgup", action = "revisions.page_up", scope = "revisions.revert", desc = "pgup" },
     { key = "pgdown", action = "revisions.page_down", scope = "revisions.revert", desc = "pgdown" },
+    { key = "home", action = "revisions.go_to_top", scope = "revisions.revert", desc = "top" },
+    { key = "end", action = "revisions.go_to_bottom", scope = "revisions.revert", desc = "bottom" },
 
     # revisions.duplicate
     { key = "enter", action = "revisions.duplicate.apply", scope = "revisions.duplicate", desc = "apply" },
@@ -153,6 +161,8 @@ bindings = [
     { key = ["down", "j"], action = "revisions.move_down", scope = "revisions.duplicate", desc = "down" },
     { key = "pgup", action = "revisions.page_up", scope = "revisions.duplicate", desc = "pgup" },
     { key = "pgdown", action = "revisions.page_down", scope = "revisions.duplicate", desc = "pgdown" },
+    { key = "home", action = "revisions.go_to_top", scope = "revisions.duplicate", desc = "top" },
+    { key = "end", action = "revisions.go_to_bottom", scope = "revisions.duplicate", desc = "bottom" },
 
     # revisions.details
     { key = ["up", "k"], action = "revisions.details.move_up", scope = "revisions.details", desc = "up" },
@@ -200,6 +210,8 @@ bindings = [
     { key = ["down", "j"], action = "revisions.move_down", scope = "revisions.abandon", desc = "down" },
     { key = "pgup", action = "revisions.page_up", scope = "revisions.abandon", desc = "pgup" },
     { key = "pgdown", action = "revisions.page_down", scope = "revisions.abandon", desc = "pgdown" },
+    { key = "home", action = "revisions.go_to_top", scope = "revisions.abandon", desc = "top" },
+    { key = "end", action = "revisions.go_to_bottom", scope = "revisions.abandon", desc = "bottom" },
     { key = "@", action = "revisions.jump_to_working_copy", scope = "revisions.abandon", desc = "jump to working copy" },
 
     # revisions.absorb
@@ -212,6 +224,8 @@ bindings = [
     { key = ["down", "j"], action = "revisions.move_down", scope = "revisions.absorb", desc = "down" },
     { key = "pgup", action = "revisions.page_up", scope = "revisions.absorb", desc = "pgup" },
     { key = "pgdown", action = "revisions.page_down", scope = "revisions.absorb", desc = "pgdown" },
+    { key = "home", action = "revisions.go_to_top", scope = "revisions.absorb", desc = "top" },
+    { key = "end", action = "revisions.go_to_bottom", scope = "revisions.absorb", desc = "bottom" },
     { key = "@", action = "revisions.jump_to_working_copy", scope = "revisions.absorb", desc = "jump to working copy" },
 
     # revisions.set_parents
@@ -224,6 +238,8 @@ bindings = [
     { key = ["down", "j"], action = "revisions.move_down", scope = "revisions.set_parents", desc = "down" },
     { key = "pgup", action = "revisions.page_up", scope = "revisions.set_parents", desc = "pgup" },
     { key = "pgdown", action = "revisions.page_down", scope = "revisions.set_parents", desc = "pgdown" },
+    { key = "home", action = "revisions.go_to_top", scope = "revisions.set_parents", desc = "top" },
+    { key = "end", action = "revisions.go_to_bottom", scope = "revisions.set_parents", desc = "bottom" },
 
     # revisions.inline_describe
     { key = "esc", action = "revisions.inline_describe.cancel", scope = "revisions.inline_describe", desc = "cancel" },

--- a/internal/config/default/types.lua
+++ b/internal/config/default/types.lua
@@ -226,6 +226,8 @@ function wait_refresh() end
 ---@field edit fun()
 ---@field force_apply fun()
 ---@field force_edit fun()
+---@field go_to_bottom fun()
+---@field go_to_top fun()
 ---@field jump_to_children fun()
 ---@field jump_to_parent fun()
 ---@field jump_to_working_copy fun()

--- a/internal/ui/actionmeta/builtins_gen.go
+++ b/internal/ui/actionmeta/builtins_gen.go
@@ -164,6 +164,8 @@ var builtInActionScopes = map[string][]string{
 	"revisions.evolog.restore":                   {"revisions.evolog"},
 	"revisions.force_apply":                      {"revisions"},
 	"revisions.force_edit":                       {"revisions"},
+	"revisions.go_to_bottom":                     {"revisions"},
+	"revisions.go_to_top":                        {"revisions"},
 	"revisions.inline_describe.accept":           {"revisions.inline_describe"},
 	"revisions.inline_describe.cancel":           {"revisions.inline_describe"},
 	"revisions.inline_describe.editor":           {"revisions.inline_describe"},

--- a/internal/ui/actions/catalog_gen.go
+++ b/internal/ui/actions/catalog_gen.go
@@ -286,6 +286,10 @@ func ResolveIntent(scope string, action keybindings.Action, args map[string]any)
 			return intents.Apply{Force: true}, true
 		case keybindings.Action("revisions.force_edit"):
 			return intents.StartEdit{IgnoreImmutable: true}, true
+		case keybindings.Action("revisions.go_to_bottom"):
+			return intents.GoToBottom{}, true
+		case keybindings.Action("revisions.go_to_top"):
+			return intents.GoToTop{}, true
 		case keybindings.Action("revisions.jump_to_children"):
 			return intents.Navigate{Target: intents.TargetChild}, true
 		case keybindings.Action("revisions.jump_to_parent"):

--- a/internal/ui/intents/revisions_intents.go
+++ b/internal/ui/intents/revisions_intents.go
@@ -90,6 +90,16 @@ const (
 	TargetWorkingCopy
 )
 
+//jjui:bind scope=revisions action=go_to_top
+type GoToTop struct{}
+
+func (GoToTop) isIntent() {}
+
+//jjui:bind scope=revisions action=go_to_bottom
+type GoToBottom struct{}
+
+func (GoToBottom) isIntent() {}
+
 //jjui:bind scope=revisions action=move_up set=Delta:-1
 //jjui:bind scope=revisions action=move_down set=Delta:1
 //jjui:bind scope=revisions action=page_up set=Delta:-1,IsPage:true

--- a/internal/ui/revisions/revisions.go
+++ b/internal/ui/revisions/revisions.go
@@ -757,6 +757,10 @@ func (m *Model) HandleIntent(intent intents.Intent) (tea.Cmd, bool) {
 		return nil, true
 	case intents.Navigate:
 		return m.navigate(intent), true
+	case intents.GoToTop:
+		return m.goToTop(), true
+	case intents.GoToBottom:
+		return m.goToBottom(), true
 	case intents.Describe:
 		return m.startDescribe(intent), true
 	case intents.OpenEvolog:
@@ -953,6 +957,24 @@ func (m *Model) startAbandon(intent intents.OpenAbandon) tea.Cmd {
 		return nil
 	}
 	return m.setBaseOperation(abandon.NewOperation(m.context, selected, m.SelectedRevision()))
+}
+
+func (m *Model) goToTop() tea.Cmd {
+	if len(m.rows) == 0 {
+		return nil
+	}
+	m.SetCursor(0)
+	m.ensureCursorView = true
+	return nil
+}
+
+func (m *Model) goToBottom() tea.Cmd {
+	if len(m.rows) == 0 {
+		return nil
+	}
+	m.SetCursor(len(m.rows) - 1)
+	m.ensureCursorView = true
+	return m.requestMoreRows(m.tag.Load())
 }
 
 func (m *Model) navigate(intent intents.Navigate) tea.Cmd {

--- a/internal/ui/revisions/revisions_test.go
+++ b/internal/ui/revisions/revisions_test.go
@@ -158,6 +158,18 @@ func TestModel_Navigate(t *testing.T) {
 	assert.Equal(t, "a", model.SelectedRevision().ChangeId)
 }
 
+func TestModel_GoToTopAndBottom(t *testing.T) {
+	ctx := test.NewTestContext(test.NewTestCommandRunner(t))
+	model := New(ctx)
+	model.updateGraphRows(rows, "a", true)
+
+	test.SimulateModel(model, model.Update(intents.GoToBottom{}))
+	assert.Equal(t, len(model.rows)-1, model.Cursor())
+
+	test.SimulateModel(model, model.Update(intents.GoToTop{}))
+	assert.Equal(t, 0, model.Cursor())
+}
+
 func TestModel_UpdateGraphRows_DoesNotPrefixMatchImplicitCurrentSelection(t *testing.T) {
 	ctx := test.NewTestContext(test.NewTestCommandRunner(t))
 	model := New(ctx)


### PR DESCRIPTION
Simply adds Home and End key support for navigating to top and bottom of revs, respectively.