### PR TITLE
fix: set filesearch list half viewport height

### DIFF
--- a/internal/ui/fuzzy_files/fuzzy_files.go
+++ b/internal/ui/fuzzy_files/fuzzy_files.go
@@ -182,10 +182,16 @@ func (fzf *fuzzyFiles) String(i int) string {
 func (fzf *fuzzyFiles) search(input string) {
 	src := &fuzzy_search.RefinedSource{Source: fzf}
 	fzf.cursor = 0
-	fzf.matches = src.Search(input, fzf.max)
+	// Generate all candidate matches; the display is capped to max in the view.
+	fzf.matches = src.Search(input, fzf.Len())
 }
 
 func (fzf *fuzzyFiles) ViewRect(dl *render.DisplayContext, box layout.Box) {
+	// Cap the list height to half of the available view height.
+	// Reserve one line for the title.
+	if desired := box.R.Dy()/2 - 1; desired > 0 {
+		fzf.max = desired
+	}
 	content := fzf.viewContent()
 	if content == "" {
 		return


### PR DESCRIPTION
As I was working on the refactoring for preview and bookmarkpane, I found out that file search is emitting a message to update preview

https://github.com/idursun/jjui/blob/281650c7e24389d97a68561b96d0b885e7279983/internal/ui/ui.go?plain=1#L590-L597


Didn't know this feature exists at all... right now it's useless because the file_search list expands to the whole screen and covers whatever's underneath. 

Therefore I'm opening this change to make file_search list half height of the viewport. 

| before | after |
| -- | -- | 
| <img width="1893" height="990" alt="image" src="https://github.com/user-attachments/assets/7bd3aa1d-62a7-4e2c-9a71-9b80ae8006c1" /> | <img width="1893" height="990" alt="image" src="https://github.com/user-attachments/assets/4ba99522-cd75-4d64-a5de-31ade5ff89ab" /> |
