### PR TITLE
refactor(ui): introduce split container for preview rendering

### DIFF
--- a/internal/ui/common/msgs.go
+++ b/internal/ui/common/msgs.go
@@ -59,12 +59,11 @@ type (
 		Msg ExecMsg
 	}
 	FileSearchMsg struct {
-		Revset       string
-		PreviewShown bool
-		Commit       *jj.Commit
-		RawFileOut   []byte // raw output from `jj file list`
+		Revset     string
+		Commit     *jj.Commit
+		RawFileOut []byte // raw output from `jj file list`
 	}
-	ShowPreview     bool
+	ShowPreview     struct{}
 	RunLuaScriptMsg struct {
 		Script       string
 		CompletionID string
@@ -160,13 +159,12 @@ func UpdateRevSet(revset string) tea.Cmd {
 	}
 }
 
-func FileSearch(revset string, preview bool, commit *jj.Commit, rawFileOut []byte) tea.Cmd {
+func FileSearch(revset string, commit *jj.Commit, rawFileOut []byte) tea.Cmd {
 	return func() tea.Msg {
 		return FileSearchMsg{
-			Commit:       commit,
-			RawFileOut:   rawFileOut,
-			Revset:       revset,
-			PreviewShown: preview,
+			Commit:     commit,
+			RawFileOut: rawFileOut,
+			Revset:     revset,
 		}
 	}
 }

--- a/internal/ui/fuzzy_files/fuzzy_files.go
+++ b/internal/ui/fuzzy_files/fuzzy_files.go
@@ -21,9 +21,8 @@ import (
 
 type fuzzyFiles struct {
 	// restore
-	revset          string
-	commit          *jj.Commit
-	wasPreviewShown bool
+	revset string
+	commit *jj.Commit
 
 	cursor int
 	// enabled with ctrl+t again
@@ -75,7 +74,7 @@ func (fzf *fuzzyFiles) Update(msg tea.Msg) tea.Cmd {
 		if fzf.revsetPreview {
 			return tea.Batch(
 				fzf.updateRevSet(),
-				newCmd(common.ShowPreview(true)),
+				newCmd(common.ShowPreview{}),
 			)
 		}
 	}
@@ -104,10 +103,7 @@ func (fzf *fuzzyFiles) handleIntent(intent intents.Intent) tea.Cmd {
 		fzf.moveCursor(intent.Delta)
 		return skipSearch
 	case intents.FileSearchCancel:
-		return tea.Batch(
-			common.UpdateRevSet(fzf.revset),
-			newCmd(common.ShowPreview(fzf.wasPreviewShown)),
-		)
+		return common.UpdateRevSet(fzf.revset)
 	case intents.FileSearchEdit:
 		path := fuzzy_search.SelectedMatch(fzf)
 		return newCmd(common.ExecMsg{
@@ -116,10 +112,13 @@ func (fzf *fuzzyFiles) handleIntent(intent intents.Intent) tea.Cmd {
 		})
 	case intents.FileSearchTogglePreview:
 		fzf.revsetPreview = !fzf.revsetPreview
-		return tea.Batch(
-			newCmd(common.ShowPreview(fzf.revsetPreview)),
-			fzf.updateRevSet(),
-		)
+		if fzf.revsetPreview {
+			return tea.Batch(
+				newCmd(common.ShowPreview{}),
+				fzf.updateRevSet(),
+			)
+		}
+		return fzf.updateRevSet()
 	case intents.FileSearchAccept:
 		return fzf.updateRevSet()
 	case intents.FileSearchPreviewScroll:
@@ -224,11 +223,10 @@ func (fzf *fuzzyFiles) viewContent() string {
 
 func NewModel(msg common.FileSearchMsg) fuzzy_search.Model {
 	model := &fuzzyFiles{
-		revset:          msg.Revset,
-		wasPreviewShown: msg.PreviewShown,
-		max:             30,
-		commit:          msg.Commit,
-		paths:           buildPathEntries(msg.RawFileOut),
+		revset: msg.Revset,
+		max:    30,
+		commit: msg.Commit,
+		paths:  buildPathEntries(msg.RawFileOut),
 	}
 	return model
 }

--- a/internal/ui/preview/preview.go
+++ b/internal/ui/preview/preview.go
@@ -1,7 +1,6 @@
 package preview
 
 import (
-	"log"
 	"strconv"
 	"strings"
 	"time"
@@ -21,13 +20,10 @@ import (
 var _ common.ImmediateModel = (*Model)(nil)
 
 type Model struct {
-	context             *context.MainContext
-	view                viewport.Model
-	previewVisible      bool
-	previewAutoPosition bool
-	previewAtBottom     bool
-	contentItem         common.SelectedItem // item which we are currently showing the preview for
-	content             string
+	view        viewport.Model
+	content     string
+	contentItem common.SelectedItem
+	context     *context.MainContext
 }
 
 const (
@@ -56,9 +52,6 @@ func (s ScrollMsg) SetDelta(delta int, horizontal bool) tea.Msg {
 }
 
 func (m *Model) Scopes() []common.Scope {
-	if !m.Visible() {
-		return nil
-	}
 	return []common.Scope{
 		{
 			Name:    actions.ScopeUiPreview,
@@ -95,35 +88,8 @@ func (m *Model) Init() tea.Cmd {
 	return nil
 }
 
-func (m *Model) Visible() bool {
-	return m.previewVisible
-}
-
-func (m *Model) SetVisible(visible bool) {
-	m.previewVisible = visible
-	if m.previewVisible {
-		m.reset()
-	}
-}
-
-func (m *Model) ToggleVisible() {
-	m.previewVisible = !m.previewVisible
-	if m.previewVisible {
-		m.reset()
-	}
-}
-
-func (m *Model) SetPosition(autoPos bool, atBottom bool) {
-	m.previewAutoPosition = autoPos
-	m.previewAtBottom = atBottom
-}
-
-func (m *Model) AutoPosition() bool {
-	return m.previewAutoPosition
-}
-
-func (m *Model) AtBottom() bool {
-	return m.previewAtBottom
+func (m *Model) OnShow() {
+	m.reset()
 }
 
 func (m *Model) YOffset() int {
@@ -279,23 +245,7 @@ func (m *Model) refreshPreviewForItem(item common.SelectedItem) tea.Cmd {
 }
 
 func New(context *context.MainContext) *Model {
-	previewAutoPosition := false
-	previewAtBottom := false
-	previewPositionCfg, err := config.GetPreviewPosition(config.Current)
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	if previewPositionCfg == config.PreviewPositionAuto {
-		previewAutoPosition = true
-	} else if previewPositionCfg == config.PreviewPositionBottom {
-		previewAtBottom = true
-	}
-
 	return &Model{
-		context:             context,
-		previewAutoPosition: previewAutoPosition,
-		previewAtBottom:     previewAtBottom,
-		previewVisible:      config.Current.Preview.ShowAtStart,
+		context: context,
 	}
 }

--- a/internal/ui/preview/preview_test.go
+++ b/internal/ui/preview/preview_test.go
@@ -122,7 +122,6 @@ func TestModel_View(t *testing.T) {
 
 			model := New(ctx)
 
-			model.previewAtBottom = tc.atBottom
 			model.SetContent(tc.content)
 			if tc.scrollBy.X > 0 {
 				model.ScrollHorizontal(tc.scrollBy.X)

--- a/internal/ui/split.go
+++ b/internal/ui/split.go
@@ -1,241 +1,144 @@
 package ui
 
 import (
-	"strings"
+	"log"
 
 	tea "charm.land/bubbletea/v2"
+	"github.com/idursun/jjui/internal/config"
 	"github.com/idursun/jjui/internal/ui/common"
+	"github.com/idursun/jjui/internal/ui/intents"
 	"github.com/idursun/jjui/internal/ui/layout"
-	"github.com/idursun/jjui/internal/ui/render"
+	"github.com/idursun/jjui/internal/ui/preview"
+	"github.com/idursun/jjui/internal/ui/split"
 )
 
-type splitState struct {
-	Percent    float64
-	MinPercent float64
-	MaxPercent float64
-}
+const previewContentID = "preview"
 
-func newSplitState(percent float64) *splitState {
-	s := &splitState{
-		Percent:    percent,
-		MinPercent: 10,
-		MaxPercent: 95,
+// initSplitContainer wires split layout state and the preview split content.
+func (m *Model) initSplitContainer() {
+	state := split.NewSplitState(config.Current.Preview.WidthPercentage)
+	previewPositionCfg, err := config.GetPreviewPosition(config.Current)
+	if err != nil {
+		log.Fatal(err)
 	}
-	s.clamp()
-	return s
-}
+	state.SetPlacement(splitPlacementFromPreviewConfig(previewPositionCfg))
 
-func (s *splitState) clamp() {
-	if s.Percent < s.MinPercent {
-		s.Percent = s.MinPercent
-	}
-	if s.Percent > s.MaxPercent {
-		s.Percent = s.MaxPercent
+	m.splitContainer = split.NewSplitContainer(state)
+	m.splitContainer.RegisterContent(previewContentID, preview.New(m.context))
+	if config.Current.Preview.ShowAtStart {
+		m.splitContainer.ShowContent(previewContentID)
 	}
 }
 
-func (s *splitState) DragTo(box layout.Box, vertical bool, x, y int) bool {
-	old := s.Percent
-	if vertical {
-		total := box.R.Dy()
-		if total <= 0 {
-			return false
+func splitPlacementFromPreviewConfig(position config.PreviewPosition) split.Placement {
+	switch position {
+	case config.PreviewPositionBottom:
+		return split.PlacementBottom
+	case config.PreviewPositionRight:
+		return split.PlacementRight
+	default:
+		return split.PlacementAuto
+	}
+}
+
+// selectionChanged emits a SelectionChangedMsg for the currently selected
+// item. It is fired whenever the preview becomes visible so the freshly shown
+// pane loads content for the current selection instead of staying empty until
+// the next cursor move.
+func (m *Model) selectionChanged() tea.Cmd {
+	if m.context == nil {
+		return nil
+	}
+	return common.SelectionChanged(m.context.SelectedItem)
+}
+
+func (m *Model) handleSplitMsg(msg tea.Msg) (tea.Cmd, bool) {
+	if m.splitContainer == nil {
+		return nil, false
+	}
+	switch msg := msg.(type) {
+	case common.ShowPreview:
+		if m.splitContainer.ShowContent(previewContentID) {
+			return m.selectionChanged(), true
 		}
-		distanceFromBottom := box.R.Max.Y - y
-		s.Percent = float64(distanceFromBottom*100) / float64(total)
-	} else {
-		total := box.R.Dx()
-		if total <= 0 {
-			return false
-		}
-		distanceFromRight := box.R.Max.X - x
-		s.Percent = float64(distanceFromRight*100) / float64(total)
+		return nil, true
+	case split.SplitDragMsg:
+		m.splitContainer.StartDrag(msg)
+		return nil, false
 	}
-	s.clamp()
-	return s.Percent != old
+	return nil, false
 }
 
-func (s *splitState) Expand(delta float64) {
-	s.Percent += delta
-	s.clamp()
-}
-
-func (s *splitState) Shrink(delta float64) {
-	s.Percent -= delta
-	s.clamp()
-}
-
-var (
-	_ common.ImmediateModel = (*split)(nil)
-)
-
-type split struct {
-	State              *splitState
-	Vertical           bool
-	Primary            common.ImmediateModel
-	Secondary          common.ImmediateModel
-	SeparatorVisible   bool
-	SeparatorThickness int
-	lastBox            layout.Box
-	hasLastBox         bool
-}
-
-func newSplit(state *splitState, primary, secondary common.ImmediateModel) *split {
-	return &split{
-		State:            state,
-		Primary:          primary,
-		Secondary:        secondary,
-		SeparatorVisible: true,
+func (m *Model) handleSplitIntent(intent intents.Intent) (tea.Cmd, bool) {
+	if m.splitContainer == nil {
+		return nil, false
 	}
+	switch msg := intent.(type) {
+	case intents.PreviewToggle:
+		m.splitContainer.ToggleContent(previewContentID)
+		return m.selectionChanged(), true
+	case intents.PreviewToggleBottom:
+		shown := m.splitContainer.ShowContent(previewContentID)
+		m.splitContainer.TogglePosition()
+		if shown {
+			return m.selectionChanged(), true
+		}
+		return nil, true
+	case intents.PreviewExpand:
+		m.splitContainer.Resize(config.Current.Preview.WidthIncrementPercentage)
+		return nil, true
+	case intents.PreviewShrink:
+		m.splitContainer.Resize(-config.Current.Preview.WidthIncrementPercentage)
+		return nil, true
+	case intents.PreviewShow:
+		m.splitContainer.ShowContent(previewContentID)
+		return m.splitContainer.Update(msg), true
+	}
+	return nil, false
 }
 
-func (s *split) Init() tea.Cmd {
-	return nil
+func (m *Model) updateSplit(msg tea.Msg) tea.Cmd {
+	if m.splitContainer == nil {
+		return nil
+	}
+	return m.splitContainer.Update(msg)
 }
 
-func (s *split) Update(msg tea.Msg) tea.Cmd {
-	return nil
+func (m *Model) splitScopes() []common.Scope {
+	if m.splitContainer == nil {
+		return nil
+	}
+	return m.splitContainer.Scopes()
 }
 
-func (s *split) ViewRect(dl *render.DisplayContext, box layout.Box) {
-	if s.State == nil {
-		s.State = newSplitState(50)
-	}
-	s.lastBox = box
-	s.hasLastBox = true
-
-	primaryVisible := isVisible(s.Primary)
-	secondaryVisible := isVisible(s.Secondary)
-
-	switch {
-	case primaryVisible && secondaryVisible:
-		s.renderBoth(dl, box)
-	case primaryVisible:
-		s.Primary.ViewRect(dl, box)
-	case secondaryVisible:
-		s.Secondary.ViewRect(dl, box)
-	}
-}
-
-func (s *split) renderBoth(dl *render.DisplayContext, box layout.Box) {
-	primaryPercent := 100 - s.State.Percent
-	thickness := s.SeparatorThickness
-	if thickness <= 0 {
-		thickness = 1
-	}
-	if !s.SeparatorVisible {
-		thickness = 0
-	}
-	if s.Vertical {
-		if box.R.Dy() <= 0 {
-			return
-		}
-		if thickness >= box.R.Dy() {
-			thickness = 0
-		}
-		usable := box.R.Dy() - thickness
-		splitBox := box
-		if thickness > 0 {
-			splitBox.R.Max.Y = splitBox.R.Min.Y + usable
-		}
-		boxes := splitBox.V(layout.Percent(primaryPercent), layout.Fill(1))
-		if len(boxes) < 2 {
-			return
-		}
-		if thickness > 0 {
-			sepRect := layout.Rect(box.R.Min.X, boxes[0].R.Max.Y, box.R.Dx(), thickness)
-			secondaryBox := boxes[1]
-			secondaryBox.R.Min.Y += thickness
-			secondaryBox.R.Max.Y += thickness
-			s.Primary.ViewRect(dl, boxes[0])
-			s.Secondary.ViewRect(dl, secondaryBox)
-			dl.AddInteraction(sepRect, SplitDragMsg{Split: s}, render.InteractionDrag, 0)
-			drawRect, content := separatorContent(sepRect, s.Vertical)
-			if drawRect.Dx() > 0 && drawRect.Dy() > 0 && content != "" {
-				dl.AddDraw(drawRect, content, render.ZPreview)
-			}
-			return
-		}
-		s.Primary.ViewRect(dl, boxes[0])
-		s.Secondary.ViewRect(dl, boxes[1])
+func (m *Model) renderSplit(primary common.ImmediateModel, box layout.Box) {
+	if m.splitContainer == nil {
+		primary.ViewRect(m.displayContext, box)
 		return
 	}
+	m.splitContainer.Render(m.displayContext, box, primary)
+}
 
-	if box.R.Dx() <= 0 {
+func (m *Model) updateSplitAutoPosition() {
+	if m.splitContainer == nil {
 		return
 	}
-	if thickness >= box.R.Dx() {
-		thickness = 0
+	m.splitContainer.SetAutoPosition(m.height >= m.width/2)
+}
+
+func (m *Model) handleSplitMouseMsg(msg tea.Msg) (tea.Cmd, bool) {
+	if m.splitContainer == nil {
+		return nil, false
 	}
-	usable := box.R.Dx() - thickness
-	splitBox := box
-	if thickness > 0 {
-		splitBox.R.Max.X = splitBox.R.Min.X + usable
-	}
-	boxes := splitBox.H(layout.Percent(primaryPercent), layout.Fill(1))
-	if len(boxes) < 2 {
-		return
-	}
-	if thickness > 0 {
-		sepRect := layout.Rect(boxes[0].R.Max.X, box.R.Min.Y, thickness, box.R.Dy())
-		secondaryBox := boxes[1]
-		secondaryBox.R.Min.X += thickness
-		secondaryBox.R.Max.X += thickness
-		s.Primary.ViewRect(dl, boxes[0])
-		s.Secondary.ViewRect(dl, secondaryBox)
-		dl.AddInteraction(sepRect, SplitDragMsg{Split: s}, render.InteractionDrag, 0)
-		drawRect, content := separatorContent(sepRect, s.Vertical)
-		if drawRect.Dx() > 0 && drawRect.Dy() > 0 && content != "" {
-			dl.AddDraw(drawRect, content, render.ZPreview)
+	switch msg := msg.(type) {
+	case tea.MouseReleaseMsg:
+		m.splitContainer.EndDrag()
+		return nil, false
+	case tea.MouseMotionMsg:
+		mouse := msg.Mouse()
+		if m.splitContainer.DragTo(mouse.X, mouse.Y) {
+			return nil, true
 		}
-		return
 	}
-	s.Primary.ViewRect(dl, boxes[0])
-	s.Secondary.ViewRect(dl, boxes[1])
-}
-
-func (s *split) DragTo(x, y int) bool {
-	if s == nil || s.State == nil || !s.hasLastBox {
-		return false
-	}
-	return s.State.DragTo(s.lastBox, s.Vertical, x, y)
-}
-
-type SplitDragMsg struct {
-	Split *split
-	X     int
-	Y     int
-}
-
-func (m SplitDragMsg) SetDragStart(x, y int) tea.Msg {
-	m.X = x
-	m.Y = y
-	return m
-}
-
-func isVisible(m common.ImmediateModel) bool {
-	if m == nil {
-		return false
-	}
-	if v, ok := m.(interface{ Visible() bool }); ok {
-		return v.Visible()
-	}
-	return true
-}
-
-func separatorContent(sepRect layout.Rectangle, vertical bool) (layout.Rectangle, string) {
-	if sepRect.Dx() <= 0 || sepRect.Dy() <= 0 {
-		return layout.Rectangle{}, ""
-	}
-	if vertical {
-		centerY := sepRect.Min.Y + sepRect.Dy()/2
-		drawRect := layout.Rect(sepRect.Min.X, centerY, sepRect.Dx(), 1)
-		return drawRect, strings.Repeat("─", drawRect.Dx())
-	}
-	centerX := sepRect.Min.X + sepRect.Dx()/2
-	drawRect := layout.Rect(centerX, sepRect.Min.Y, 1, sepRect.Dy())
-	if drawRect.Dy() == 1 {
-		return drawRect, "│"
-	}
-	return drawRect, strings.Repeat("│\n", drawRect.Dy()-1) + "│"
+	return nil, false
 }

--- a/internal/ui/split/container.go
+++ b/internal/ui/split/container.go
@@ -1,0 +1,137 @@
+package split
+
+import (
+	tea "charm.land/bubbletea/v2"
+	"github.com/idursun/jjui/internal/ui/common"
+	"github.com/idursun/jjui/internal/ui/layout"
+	"github.com/idursun/jjui/internal/ui/render"
+)
+
+// SplitContent is a renderable model that can be shown inside a SplitContainer.
+type SplitContent interface {
+	common.ImmediateModel
+	OnShow()
+}
+
+// SplitContainer manages one optional split-content pane next to a primary view.
+type SplitContainer struct {
+	renderer *SplitRenderer
+	state    *SplitState
+	dragging bool
+	contents map[string]SplitContent
+	activeID string
+}
+
+func NewSplitContainer(state *SplitState) *SplitContainer {
+	return &SplitContainer{
+		renderer: NewRenderer(state, nil, nil),
+		state:    state,
+		contents: make(map[string]SplitContent),
+	}
+}
+
+func (sc *SplitContainer) RegisterContent(id string, content SplitContent) {
+	sc.contents[id] = content
+}
+
+func (sc *SplitContainer) ShowContent(id string) bool {
+	if sc.activeID == id {
+		return false
+	}
+	sc.activeID = id
+	sc.contents[id].OnShow()
+	return true
+}
+
+func (sc *SplitContainer) ToggleContent(id string) bool {
+	if sc.activeID != "" && sc.activeID == id {
+		sc.Close()
+		return true
+	}
+	return sc.ShowContent(id)
+}
+
+func (sc *SplitContainer) Close() bool {
+	if sc.activeID == "" {
+		return false
+	}
+	sc.activeID = ""
+	return true
+}
+
+func (sc *SplitContainer) Resize(delta float64) bool {
+	old := sc.state.Percent
+	if delta > 0 {
+		sc.state.Expand(delta)
+	} else if delta < 0 {
+		sc.state.Shrink(-delta)
+	}
+	return sc.state.Percent != old
+}
+
+func (sc *SplitContainer) TogglePosition() {
+	sc.state.TogglePosition()
+}
+
+func (sc *SplitContainer) SetAutoPosition(atBottom bool) {
+	if sc.state.AutoPosition {
+		sc.state.AtBottom = atBottom
+	}
+}
+
+func (sc *SplitContainer) Update(msg tea.Msg) tea.Cmd {
+	content := sc.activeContent()
+	if content == nil {
+		return nil
+	}
+	return content.Update(msg)
+}
+
+func (sc *SplitContainer) Scopes() []common.Scope {
+	content := sc.activeContent()
+	if content == nil {
+		return nil
+	}
+	provider, ok := content.(common.ScopeProvider)
+	if !ok {
+		return nil
+	}
+	return provider.Scopes()
+}
+
+func (sc *SplitContainer) StartDrag(msg SplitDragMsg) {
+	if msg.Renderer != sc.renderer {
+		return
+	}
+	sc.dragging = true
+	sc.renderer.DragTo(msg.X, msg.Y)
+}
+
+func (sc *SplitContainer) DragTo(x, y int) bool {
+	if !sc.dragging {
+		return false
+	}
+	sc.renderer.DragTo(x, y)
+	return true
+}
+
+func (sc *SplitContainer) EndDrag() {
+	sc.dragging = false
+}
+
+func (sc *SplitContainer) Render(dl *render.DisplayContext, box layout.Box, primary common.ImmediateModel) {
+	content := sc.activeContent()
+	if content == nil {
+		primary.ViewRect(dl, box)
+		return
+	}
+	sc.renderer.State = sc.state
+	sc.renderer.ViewModels(dl, box, primary, content, sc.state.AtBottom)
+}
+
+func (sc *SplitContainer) activeContent() SplitContent {
+	if sc.activeID == "" {
+		return nil
+	}
+	return sc.contents[sc.activeID]
+}

--- a/internal/ui/split/container_test.go
+++ b/internal/ui/split/container_test.go
@@ -1,0 +1,79 @@
+package split
+
+import (
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/idursun/jjui/internal/ui/layout"
+	"github.com/idursun/jjui/internal/ui/render"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeContent struct {
+	shows   int
+	updates int
+}
+
+func (f *fakeContent) Init() tea.Cmd { return nil }
+
+func (f *fakeContent) Update(tea.Msg) tea.Cmd {
+	f.updates++
+	return nil
+}
+
+func (f *fakeContent) ViewRect(*render.DisplayContext, layout.Box) {}
+
+func (f *fakeContent) OnShow() { f.shows++ }
+
+func TestSplitContainerShowToggleAndClose(t *testing.T) {
+	sc := NewSplitContainer(NewSplitState(50))
+	a := &fakeContent{}
+	b := &fakeContent{}
+	sc.RegisterContent("a", a)
+	sc.RegisterContent("b", b)
+
+	require.True(t, sc.ShowContent("a"))
+	assert.Equal(t, 1, a.shows)
+	require.False(t, sc.ShowContent("a"))
+	assert.Equal(t, 1, a.shows)
+	sc.Update(struct{}{})
+	assert.Equal(t, 1, a.updates)
+	assert.Equal(t, 0, b.updates)
+
+	require.True(t, sc.ToggleContent("a"))
+	sc.Update(struct{}{})
+	assert.Equal(t, 1, a.updates, "closed content should not receive updates")
+
+	require.True(t, sc.ToggleContent("b"))
+	assert.Equal(t, 1, b.shows)
+	sc.Update(struct{}{})
+	assert.Equal(t, 1, b.updates)
+
+	require.True(t, sc.ToggleContent("a"))
+	assert.Equal(t, 2, a.shows)
+	sc.Update(struct{}{})
+	assert.Equal(t, 2, a.updates)
+
+	require.True(t, sc.Close())
+	require.False(t, sc.Close())
+}
+
+func TestSplitContainerResizeAndPositionAreContainerState(t *testing.T) {
+	state := NewSplitState(50)
+	state.SetPlacement(PlacementAuto)
+	sc := NewSplitContainer(state)
+
+	require.True(t, sc.Resize(10))
+	assert.Equal(t, 60.0, state.Percent)
+	require.True(t, sc.Resize(-20))
+	assert.Equal(t, 40.0, state.Percent)
+
+	sc.SetAutoPosition(true)
+	assert.True(t, state.AtBottom)
+	sc.TogglePosition()
+	assert.False(t, state.AutoPosition)
+	assert.False(t, state.AtBottom)
+	sc.SetAutoPosition(true)
+	assert.False(t, state.AtBottom, "manual placement should ignore auto-position updates")
+}

--- a/internal/ui/split/renderer.go
+++ b/internal/ui/split/renderer.go
@@ -1,0 +1,199 @@
+package split
+
+import (
+	"strings"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/idursun/jjui/internal/ui/common"
+	"github.com/idursun/jjui/internal/ui/layout"
+	"github.com/idursun/jjui/internal/ui/render"
+)
+
+var _ common.ImmediateModel = (*SplitRenderer)(nil)
+
+// SplitRenderer lays out two immediate-mode models with a draggable separator.
+// It handles the low-level rectangle splitting, separator drawing, and drag hitbox.
+type SplitRenderer struct {
+	State    *SplitState
+	Vertical bool
+	// Primary could be revision, oplog
+	Primary common.ImmediateModel
+	// Secondary could be preview, bookmark pane
+	Secondary          common.ImmediateModel
+	SeparatorVisible   bool
+	SeparatorThickness int
+	lastBox            layout.Box
+	hasLastBox         bool
+}
+
+func NewRenderer(state *SplitState, primary, secondary common.ImmediateModel) *SplitRenderer {
+	return &SplitRenderer{
+		State:            state,
+		Primary:          primary,
+		Secondary:        secondary,
+		SeparatorVisible: true,
+	}
+}
+
+func (s *SplitRenderer) Init() tea.Cmd {
+	return nil
+}
+
+func (s *SplitRenderer) Update(msg tea.Msg) tea.Cmd {
+	return nil
+}
+
+func (s *SplitRenderer) ViewModels(dl *render.DisplayContext, box layout.Box, primary, secondary common.ImmediateModel, vertical bool) {
+	if s == nil {
+		primary.ViewRect(dl, box)
+		return
+	}
+	s.Primary = primary
+	s.Secondary = secondary
+	s.SeparatorVisible = true
+	s.Vertical = vertical
+	s.ViewRect(dl, box)
+}
+
+func (s *SplitRenderer) ViewRect(dl *render.DisplayContext, box layout.Box) {
+	if s.State == nil {
+		s.State = NewSplitState(50)
+	}
+	s.lastBox = box
+	s.hasLastBox = true
+
+	primaryVisible := isVisible(s.Primary)
+	secondaryVisible := isVisible(s.Secondary)
+
+	switch {
+	case primaryVisible && secondaryVisible:
+		s.renderBoth(dl, box)
+	case primaryVisible:
+		s.Primary.ViewRect(dl, box)
+	case secondaryVisible:
+		s.Secondary.ViewRect(dl, box)
+	}
+}
+
+func (s *SplitRenderer) renderBoth(dl *render.DisplayContext, box layout.Box) {
+	primaryPercent := 100 - s.State.Percent
+	thickness := s.SeparatorThickness
+	if thickness <= 0 {
+		thickness = 1
+	}
+	if !s.SeparatorVisible {
+		thickness = 0
+	}
+	if s.Vertical {
+		if box.R.Dy() <= 0 {
+			return
+		}
+		if thickness >= box.R.Dy() {
+			thickness = 0
+		}
+		usable := box.R.Dy() - thickness
+		splitBox := box
+		if thickness > 0 {
+			splitBox.R.Max.Y = splitBox.R.Min.Y + usable
+		}
+		boxes := splitBox.V(layout.Percent(primaryPercent), layout.Fill(1))
+		if len(boxes) < 2 {
+			return
+		}
+		if thickness > 0 {
+			sepRect := layout.Rect(box.R.Min.X, boxes[0].R.Max.Y, box.R.Dx(), thickness)
+			secondaryBox := boxes[1]
+			secondaryBox.R.Min.Y += thickness
+			secondaryBox.R.Max.Y += thickness
+			s.Primary.ViewRect(dl, boxes[0])
+			s.Secondary.ViewRect(dl, secondaryBox)
+			dl.AddInteraction(sepRect, SplitDragMsg{Renderer: s}, render.InteractionDrag, 0)
+			drawRect, content := separatorContent(sepRect, s.Vertical)
+			if drawRect.Dx() > 0 && drawRect.Dy() > 0 && content != "" {
+				dl.AddDraw(drawRect, content, render.ZPreview)
+			}
+			return
+		}
+		s.Primary.ViewRect(dl, boxes[0])
+		s.Secondary.ViewRect(dl, boxes[1])
+		return
+	}
+
+	if box.R.Dx() <= 0 {
+		return
+	}
+	if thickness >= box.R.Dx() {
+		thickness = 0
+	}
+	usable := box.R.Dx() - thickness
+	splitBox := box
+	if thickness > 0 {
+		splitBox.R.Max.X = splitBox.R.Min.X + usable
+	}
+	boxes := splitBox.H(layout.Percent(primaryPercent), layout.Fill(1))
+	if len(boxes) < 2 {
+		return
+	}
+	if thickness > 0 {
+		sepRect := layout.Rect(boxes[0].R.Max.X, box.R.Min.Y, thickness, box.R.Dy())
+		secondaryBox := boxes[1]
+		secondaryBox.R.Min.X += thickness
+		secondaryBox.R.Max.X += thickness
+		s.Primary.ViewRect(dl, boxes[0])
+		s.Secondary.ViewRect(dl, secondaryBox)
+		dl.AddInteraction(sepRect, SplitDragMsg{Renderer: s}, render.InteractionDrag, 0)
+		drawRect, content := separatorContent(sepRect, s.Vertical)
+		if drawRect.Dx() > 0 && drawRect.Dy() > 0 && content != "" {
+			dl.AddDraw(drawRect, content, render.ZPreview)
+		}
+		return
+	}
+	s.Primary.ViewRect(dl, boxes[0])
+	s.Secondary.ViewRect(dl, boxes[1])
+}
+
+func (s *SplitRenderer) DragTo(x, y int) bool {
+	if s == nil || s.State == nil || !s.hasLastBox {
+		return false
+	}
+	return s.State.DragTo(s.lastBox, s.Vertical, x, y)
+}
+
+type SplitDragMsg struct {
+	Renderer *SplitRenderer
+	X        int
+	Y        int
+}
+
+func (m SplitDragMsg) SetDragStart(x, y int) tea.Msg {
+	m.X = x
+	m.Y = y
+	return m
+}
+
+func isVisible(m common.ImmediateModel) bool {
+	if m == nil {
+		return false
+	}
+	if v, ok := m.(interface{ Visible() bool }); ok {
+		return v.Visible()
+	}
+	return true
+}
+
+func separatorContent(sepRect layout.Rectangle, vertical bool) (layout.Rectangle, string) {
+	if sepRect.Dx() <= 0 || sepRect.Dy() <= 0 {
+		return layout.Rectangle{}, ""
+	}
+	if vertical {
+		centerY := sepRect.Min.Y + sepRect.Dy()/2
+		drawRect := layout.Rect(sepRect.Min.X, centerY, sepRect.Dx(), 1)
+		return drawRect, strings.Repeat("─", drawRect.Dx())
+	}
+	centerX := sepRect.Min.X + sepRect.Dx()/2
+	drawRect := layout.Rect(centerX, sepRect.Min.Y, 1, sepRect.Dy())
+	if drawRect.Dy() == 1 {
+		return drawRect, "│"
+	}
+	return drawRect, strings.Repeat("│\n", drawRect.Dy()-1) + "│"
+}

--- a/internal/ui/split/state.go
+++ b/internal/ui/split/state.go
@@ -1,0 +1,79 @@
+package split
+
+import "github.com/idursun/jjui/internal/ui/layout"
+
+type Placement int
+
+const (
+	PlacementAuto Placement = iota
+	PlacementBottom
+	PlacementRight
+)
+
+type SplitState struct {
+	Percent      float64
+	MinPercent   float64
+	MaxPercent   float64
+	AtBottom     bool
+	AutoPosition bool
+}
+
+func NewSplitState(percent float64) *SplitState {
+	s := &SplitState{
+		Percent:    percent,
+		MinPercent: 10,
+		MaxPercent: 95,
+	}
+	s.clamp()
+	return s
+}
+
+func (s *SplitState) SetPlacement(placement Placement) {
+	s.AutoPosition = placement == PlacementAuto
+	s.AtBottom = placement == PlacementBottom
+}
+
+func (s *SplitState) TogglePosition() {
+	s.AutoPosition = false
+	s.AtBottom = !s.AtBottom
+}
+
+func (s *SplitState) clamp() {
+	if s.Percent < s.MinPercent {
+		s.Percent = s.MinPercent
+	}
+	if s.Percent > s.MaxPercent {
+		s.Percent = s.MaxPercent
+	}
+}
+
+func (s *SplitState) DragTo(box layout.Box, vertical bool, x, y int) bool {
+	old := s.Percent
+	if vertical {
+		total := box.R.Dy()
+		if total <= 0 {
+			return false
+		}
+		distanceFromBottom := box.R.Max.Y - y
+		s.Percent = float64(distanceFromBottom*100) / float64(total)
+	} else {
+		total := box.R.Dx()
+		if total <= 0 {
+			return false
+		}
+		distanceFromRight := box.R.Max.X - x
+		s.Percent = float64(distanceFromRight*100) / float64(total)
+	}
+	s.clamp()
+	return s.Percent != old
+}
+
+func (s *SplitState) Expand(delta float64) {
+	s.Percent += delta
+	s.clamp()
+}
+
+func (s *SplitState) Shrink(delta float64) {
+	s.Percent -= delta
+	s.clamp()
+}

--- a/internal/ui/status/status_test.go
+++ b/internal/ui/status/status_test.go
@@ -91,10 +91,9 @@ func TestStatus_Update_FileSearchFocusesAndTypingUpdatesInput(t *testing.T) {
 	m := New(ctx)
 
 	cmd := m.Update(common.FileSearchMsg{
-		Revset:       "@",
-		PreviewShown: false,
-		Commit:       &jj.Commit{ChangeId: "abc123", CommitId: "def456"},
-		RawFileOut:   []byte("a.txt\nb.txt"),
+		Revset:     "@",
+		Commit:     &jj.Commit{ChangeId: "abc123", CommitId: "def456"},
+		RawFileOut: []byte("a.txt\nb.txt"),
 	})
 	assert.NotNil(t, cmd)
 	assert.Equal(t, FocusFileSearch, m.FocusKind())

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -34,10 +34,10 @@ import (
 
 	"github.com/idursun/jjui/internal/ui/input"
 	"github.com/idursun/jjui/internal/ui/oplog"
-	"github.com/idursun/jjui/internal/ui/preview"
 	"github.com/idursun/jjui/internal/ui/redo"
 	"github.com/idursun/jjui/internal/ui/revisions"
 	"github.com/idursun/jjui/internal/ui/revset"
+	"github.com/idursun/jjui/internal/ui/split"
 	"github.com/idursun/jjui/internal/ui/status"
 	"github.com/idursun/jjui/internal/ui/undo"
 )
@@ -46,7 +46,6 @@ type Model struct {
 	revisions        *revisions.Model
 	oplog            *oplog.Model
 	revsetModel      *revset.Model
-	previewModel     *preview.Model
 	diff             *diff.Model
 	flash            *flash.Model
 	state            common.State
@@ -62,8 +61,7 @@ type Model struct {
 	frameCursor      *tea.Cursor
 	width            int
 	height           int
-	revisionsSplit   *split
-	activeSplit      *split
+	splitContainer   *split.SplitContainer
 
 	// mode2031Supported is set when the terminal confirms it supports
 	// mode 2031 push. Once true, the OSC 11 polling loop stops.
@@ -148,13 +146,9 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 			return nil
 		}
 		return tea.Batch(tea.RequestBackgroundColor, scheduleColorSchemePoll())
-	case tea.MouseReleaseMsg:
-		m.activeSplit = nil
-	case tea.MouseMotionMsg:
-		if m.activeSplit != nil {
-			mouse := msg.Mouse()
-			m.activeSplit.DragTo(mouse.X, mouse.Y)
-			return nil
+	case tea.MouseReleaseMsg, tea.MouseMotionMsg:
+		if cmd, handled := m.handleSplitMouseMsg(msg); handled {
+			return cmd
 		}
 	case tea.MouseClickMsg, tea.MouseWheelMsg:
 		if m.displayContext != nil {
@@ -286,8 +280,9 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 	case input.SelectedMsg, input.CancelledMsg:
 		m.stacked = nil
 	case common.ShowPreview:
-		m.previewModel.SetVisible(bool(msg))
-		cmds = append(cmds, common.SelectionChanged(m.context.SelectedItem))
+		if cmd, handled := m.handleSplitMsg(msg); handled {
+			cmds = append(cmds, cmd)
+		}
 		return tea.Batch(cmds...)
 	case common.TogglePasswordMsg:
 		if m.password != nil {
@@ -302,10 +297,9 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 			//   - if the user denies the request on the device, a new prompt automatically happen "Enter PIN for ...
 			m.password = password.New(msg)
 		}
-	case SplitDragMsg:
-		m.activeSplit = msg.Split
-		if m.activeSplit != nil {
-			m.activeSplit.DragTo(msg.X, msg.Y)
+	case split.SplitDragMsg:
+		if cmd, handled := m.handleSplitMsg(msg); handled {
+			return cmd
 		}
 
 	case tea.WindowSizeMsg:
@@ -347,9 +341,7 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 		cmds = append(cmds, m.revisions.Update(msg))
 	}
 
-	if m.previewModel.Visible() {
-		cmds = append(cmds, m.previewModel.Update(msg))
-	}
+	cmds = append(cmds, m.updateSplit(msg))
 
 	return tea.Batch(cmds...)
 }
@@ -373,13 +365,7 @@ func (m *Model) View() string {
 	if m.diff != nil {
 		m.renderDiffLayout(box)
 	} else {
-		if m.previewModel.Visible() {
-			if m.previewModel.AutoPosition() {
-				atBottom := m.height >= m.width/2
-				m.previewModel.SetPosition(true, atBottom)
-			}
-		}
-		m.syncPreviewSplitOrientation()
+		m.updateSplitAutoPosition()
 		if m.oplog != nil {
 			m.renderOpLogLayout(box)
 		} else {
@@ -437,33 +423,6 @@ func (m *Model) renderWithStatus(box layout.Box, renderContent func(layout.Box))
 	m.status.ViewRect(m.displayContext, rows[1])
 }
 
-func (m *Model) renderSplit(primary common.ImmediateModel, box layout.Box) {
-	if m.revisionsSplit == nil {
-		return
-	}
-	m.revisionsSplit.Primary = primary
-	m.revisionsSplit.Secondary = m.previewModel
-	m.revisionsSplit.ViewRect(m.displayContext, box)
-}
-
-func (m *Model) syncPreviewSplitOrientation() {
-	if m.revisionsSplit == nil {
-		return
-	}
-	vertical := m.previewModel.AtBottom()
-	m.revisionsSplit.Vertical = vertical
-}
-
-func (m *Model) initSplit() {
-	splitState := newSplitState(config.Current.Preview.WidthPercentage)
-
-	m.revisionsSplit = newSplit(
-		splitState,
-		m.revisions,
-		m.previewModel,
-	)
-}
-
 func (m *Model) scheduleAutoRefresh() tea.Cmd {
 	interval := config.Current.UI.AutoRefreshInterval
 	if interval > 0 {
@@ -498,7 +457,7 @@ func (m *Model) dispatchScopes() []common.Scope {
 		scopes = append(scopes, m.revisions.Scopes()...)
 	}
 
-	scopes = append(scopes, m.previewModel.Scopes()...)
+	scopes = append(scopes, m.splitScopes()...)
 	if !m.revsetModel.IsEditing() {
 		scopes = append(scopes, m.revsetModel.Scopes()...)
 	}
@@ -593,36 +552,11 @@ func (m *Model) HandleIntent(intent intents.Intent) (tea.Cmd, bool) {
 			return nil, true
 		}
 		out, _ := m.context.RunCommandImmediate(jj.FilesInRevision(rev))
-		return common.FileSearch(m.context.CurrentRevset, m.previewModel.Visible(), rev, out), true
+		return common.FileSearch(m.context.CurrentRevset, m.previewContentVisible(), rev, out), true
 
-	// --- Preview controls ---
-	case intents.PreviewToggle:
-		m.previewModel.ToggleVisible()
-		return common.SelectionChanged(m.context.SelectedItem), true
-	case intents.PreviewToggleBottom:
-		previewPos := m.previewModel.AtBottom()
-		m.previewModel.SetPosition(false, !previewPos)
-		if m.previewModel.Visible() {
-			return nil, true
-		}
-		m.previewModel.ToggleVisible()
-		return common.SelectionChanged(m.context.SelectedItem), true
-	case intents.PreviewExpand:
-		if !m.previewModel.Visible() {
-			return nil, true
-		}
-		if m.revisionsSplit != nil && m.revisionsSplit.State != nil {
-			m.revisionsSplit.State.Expand(config.Current.Preview.WidthIncrementPercentage)
-		}
-		return nil, true
-	case intents.PreviewShrink:
-		if !m.previewModel.Visible() {
-			return nil, true
-		}
-		if m.revisionsSplit != nil && m.revisionsSplit.State != nil {
-			m.revisionsSplit.State.Shrink(config.Current.Preview.WidthIncrementPercentage)
-		}
-		return nil, true
+	// --- Split controls ---
+	case intents.PreviewToggle, intents.PreviewToggleBottom, intents.PreviewExpand, intents.PreviewShrink, intents.PreviewShow:
+		return m.handleSplitIntent(intent)
 
 	// --- Delegated intents ---
 	case intents.DiffShow:
@@ -630,12 +564,6 @@ func (m *Model) HandleIntent(intent intents.Intent) (tea.Cmd, bool) {
 			m.diff = diff.New("")
 		}
 		return m.diff.Update(intent), true
-	case intents.PreviewShow:
-		if !m.previewModel.Visible() {
-			m.previewModel.ToggleVisible()
-		}
-		return m.previewModel.Update(intent), true
-
 	// --- Status ---
 	case intents.ExpandStatusToggle:
 		m.status.ToggleStatusExpand()
@@ -820,20 +748,18 @@ func NewUI(c *context.MainContext) *Model {
 	revisionsModel := revisions.New(c)
 	statusModel := status.New(c)
 	flashView := flash.New()
-	previewModel := preview.New(c)
 	revsetModel := revset.New(c)
 
 	ui := &Model{
-		context:      c,
-		state:        common.Loading,
-		revisions:    revisionsModel,
-		previewModel: previewModel,
-		status:       statusModel,
-		revsetModel:  revsetModel,
-		flash:        flashView,
+		context:     c,
+		state:       common.Loading,
+		revisions:   revisionsModel,
+		status:      statusModel,
+		revsetModel: revsetModel,
+		flash:       flashView,
 	}
+	ui.initSplitContainer()
 	ui.initResolver()
-	ui.initSplit()
 	return ui
 }
 

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -552,7 +552,7 @@ func (m *Model) HandleIntent(intent intents.Intent) (tea.Cmd, bool) {
 			return nil, true
 		}
 		out, _ := m.context.RunCommandImmediate(jj.FilesInRevision(rev))
-		return common.FileSearch(m.context.CurrentRevset, m.previewContentVisible(), rev, out), true
+		return common.FileSearch(m.context.CurrentRevset, rev, out), true
 
 	// --- Split controls ---
 	case intents.PreviewToggle, intents.PreviewToggleBottom, intents.PreviewExpand, intents.PreviewShrink, intents.PreviewShow:

--- a/internal/ui/ui_test.go
+++ b/internal/ui/ui_test.go
@@ -29,12 +29,56 @@ import (
 	"github.com/idursun/jjui/internal/ui/operations/details"
 	"github.com/idursun/jjui/internal/ui/operations/rebase"
 	"github.com/idursun/jjui/internal/ui/operations/set_parents"
+	"github.com/idursun/jjui/internal/ui/preview"
 	"github.com/idursun/jjui/internal/ui/render"
 	"github.com/idursun/jjui/internal/ui/revset"
 	"github.com/idursun/jjui/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func activePreview(t *testing.T, model *Model) *preview.Model {
+	t.Helper()
+	scopes := model.splitContainer.Scopes()
+	require.NotEmpty(t, scopes, "expected active split content")
+	previewModel, ok := scopes[0].Handler.(*preview.Model)
+	require.True(t, ok, "expected active split content to be Preview")
+	return previewModel
+}
+
+func showPreview(t *testing.T, model *Model) *preview.Model {
+	t.Helper()
+	model.splitContainer.ShowContent(previewContentID)
+	return activePreview(t, model)
+}
+
+type blankImmediateModel struct{}
+
+func (blankImmediateModel) Init() tea.Cmd { return nil }
+
+func (blankImmediateModel) Update(tea.Msg) tea.Cmd { return nil }
+
+func (blankImmediateModel) ViewRect(*render.DisplayContext, layout.Box) {}
+
+func splitSeparatorX(t *testing.T, model *Model) int {
+	t.Helper()
+	dl := render.NewDisplayContext()
+	model.displayContext = dl
+	box := layout.NewBox(layout.Rect(0, 0, 100, 20))
+	model.renderSplit(blankImmediateModel{}, box)
+	buf := render.NewScreenBuffer(100, 20)
+	dl.Render(buf)
+	view := strings.ReplaceAll(ansi.Strip(buf.Render()), "\r", "")
+	for _, line := range strings.Split(view, "\n") {
+		for x, r := range []rune(line) {
+			if r == '│' && x > 0 && x < 99 {
+				return x
+			}
+		}
+	}
+	t.Fatalf("split separator not rendered:\n%s", view)
+	return -1
+}
 
 func dispatchAction(model *Model, action keybindings.Action, args map[string]any) (tea.Cmd, bool) {
 	result := model.resolver.ResolveAction(action, args)
@@ -184,31 +228,31 @@ func Test_Update_PreviewScrollKeysWorkWhenVisible(t *testing.T) {
 			ctx := test.NewTestContext(commandRunner)
 
 			model := NewUI(ctx)
-			model.previewModel.SetVisible(true)
+			previewModel := showPreview(t, model)
 
 			var content strings.Builder
 			for range 100 {
 				content.WriteString("line content here\n")
 			}
-			model.previewModel.SetContent(content.String())
+			previewModel.SetContent(content.String())
 
 			// Force internal view port to have a size
-			model.previewModel.ViewRect(render.NewDisplayContext(), layout.NewBox(layout.Rect(0, 0, 100, 50)))
+			previewModel.ViewRect(render.NewDisplayContext(), layout.NewBox(layout.Rect(0, 0, 100, 50)))
 
-			initialYOffset := model.previewModel.YOffset()
+			initialYOffset := previewModel.YOffset()
 
 			// Send the key message
 			model.Update(tc.key)
 
-			newYOffset := model.previewModel.YOffset()
+			newYOffset := previewModel.YOffset()
 			if tc.expectedScroll > 0 {
 				assert.Greater(t, newYOffset, initialYOffset, "expected scroll down for key %s", tc.name)
 			} else {
 				// For scroll up, we need content scrolled down first
-				model.previewModel.Scroll(50) // scroll down first
-				scrolledYOffset := model.previewModel.YOffset()
+				previewModel.Scroll(50) // scroll down first
+				scrolledYOffset := previewModel.YOffset()
 				model.Update(tc.key)
-				newYOffset = model.previewModel.YOffset()
+				newYOffset = previewModel.YOffset()
 				assert.Less(t, newYOffset, scrolledYOffset, "expected scroll up for key %s", tc.name)
 			}
 		})
@@ -216,6 +260,15 @@ func Test_Update_PreviewScrollKeysWorkWhenVisible(t *testing.T) {
 }
 
 func Test_Update_PreviewResizeKeysWorkWhenVisible(t *testing.T) {
+	origPosition := config.Current.Preview.Position
+	origWidth := config.Current.Preview.WidthPercentage
+	config.Current.Preview.Position = "right"
+	config.Current.Preview.WidthPercentage = 50
+	t.Cleanup(func() {
+		config.Current.Preview.Position = origPosition
+		config.Current.Preview.WidthPercentage = origWidth
+	})
+
 	tests := []struct {
 		name           string
 		key            tea.KeyPressMsg
@@ -239,16 +292,16 @@ func Test_Update_PreviewResizeKeysWorkWhenVisible(t *testing.T) {
 			ctx := test.NewTestContext(commandRunner)
 
 			model := NewUI(ctx)
-			model.previewModel.SetVisible(true)
+			showPreview(t, model)
 
-			initialWidth := model.revisionsSplit.State.Percent
+			initialX := splitSeparatorX(t, model)
 			model.Update(tc.key)
-			newWidth := model.revisionsSplit.State.Percent
+			newX := splitSeparatorX(t, model)
 
 			if tc.expectedResize > 0 {
-				assert.Greater(t, newWidth, initialWidth, "expected preview to expand for key %s", tc.name)
+				assert.Less(t, newX, initialX, "expected preview to expand for key %s", tc.name)
 			} else {
-				assert.Less(t, newWidth, initialWidth, "expected preview to shrink for key %s", tc.name)
+				assert.Greater(t, newX, initialX, "expected preview to shrink for key %s", tc.name)
 			}
 		})
 	}
@@ -1114,8 +1167,8 @@ func Test_Update_DispatchedPreviewShowUpdatesVisiblePreview(t *testing.T) {
 
 	ctx := test.NewTestContext(commandRunner)
 	model := NewUI(ctx)
-	model.previewModel.SetVisible(true)
-	model.previewModel.SetContent("old")
+	previewModel := showPreview(t, model)
+	previewModel.SetContent("old")
 
 	cmd := model.Update(common.DispatchActionMsg{
 		Action:  "ui.preview.show",
@@ -1123,7 +1176,7 @@ func Test_Update_DispatchedPreviewShowUpdatesVisiblePreview(t *testing.T) {
 		BuiltIn: true,
 	})
 	require.Nil(t, cmd)
-	assert.Equal(t, "new", test.Stripped(test.RenderImmediate(model.previewModel, 20, 3)))
+	assert.Equal(t, "new", test.Stripped(test.RenderImmediate(previewModel, 20, 3)))
 }
 
 func Test_Update_DispatchedPreviewShowOpensHiddenPreview(t *testing.T) {
@@ -1132,8 +1185,6 @@ func Test_Update_DispatchedPreviewShowOpensHiddenPreview(t *testing.T) {
 
 	ctx := test.NewTestContext(commandRunner)
 	model := NewUI(ctx)
-	model.previewModel.SetContent("old")
-	model.previewModel.SetVisible(false)
 
 	cmd := model.Update(common.DispatchActionMsg{
 		Action:  "ui.preview.show",
@@ -1141,8 +1192,8 @@ func Test_Update_DispatchedPreviewShowOpensHiddenPreview(t *testing.T) {
 		BuiltIn: true,
 	})
 	require.Nil(t, cmd)
-	assert.True(t, model.previewModel.Visible())
-	assert.Equal(t, "new", test.Stripped(test.RenderImmediate(model.previewModel, 20, 3)))
+	assert.NotEmpty(t, model.splitContainer.Scopes())
+	assert.Equal(t, "new", test.Stripped(test.RenderImmediate(activePreview(t, model), 20, 3)))
 }
 
 func Test_Update_LuaInputEscCancelsAndFinishesScript(t *testing.T) {
@@ -1564,7 +1615,7 @@ func Test_Update_SetBookmarkTypingDoesNotTogglePreview(t *testing.T) {
 
 	ctx := test.NewTestContext(commandRunner)
 	model := NewUI(ctx)
-	model.previewModel.SetVisible(true)
+	showPreview(t, model)
 
 	op := bookmark.NewSetBookmarkOperation(ctx, "abc123", "")
 	test.SimulateModel(op, op.Init())
@@ -1573,7 +1624,7 @@ func Test_Update_SetBookmarkTypingDoesNotTogglePreview(t *testing.T) {
 	require.True(t, model.revisions.IsEditing(), "set bookmark should be editing")
 
 	test.SimulateModel(model, test.Type("p"))
-	assert.True(t, model.previewModel.Visible(), "typing in set_bookmark should not toggle preview")
+	assert.NotEmpty(t, model.splitContainer.Scopes(), "typing in set_bookmark should not toggle preview")
 }
 
 // withShortColorSchemePoll temporarily shortens the polling interval so


### PR DESCRIPTION
part of #584 , mentioned [here](https://github.com/idursun/jjui/pull/584#discussion_r3358181160), this PR extracts the refactoring of split and preview into a separate PR for review

- Move preview split layout ownership out of the preview model and into a reusable split package. 
- Add SplitContainer/SplitContent for managing the primary view plus optional split content, 
- SplitRenderer for low-level layout/separator rendering, and SplitState for size/position state.

This keeps preview focused on content, scrolling, and refresh behavior while preparing the UI wiring for additional split content beyond preview.

----

stacked on top of #690