### PR TITLE
fix(flash): prevent command output from corrupting card borders

### DIFF
--- a/internal/ui/flash/render.go
+++ b/internal/ui/flash/render.go
@@ -10,8 +10,7 @@ import (
 
 const commandMarkWidth = 3
 
-type CardRenderer struct {
-}
+type CardRenderer struct{}
 
 func NewCardRenderer() CardRenderer {
 	return CardRenderer{}
@@ -54,6 +53,7 @@ func (r CardRenderer) renderCard(command, text string, commandErr error, maxWidt
 			bodyText = commandErr.Error()
 		}
 		if bodyText != "" {
+			bodyText = render.ReplayTerminalOutput(bodyText)
 			bodyStyle := lipgloss.NewStyle()
 			if highlight {
 				bodyStyle = statusStyle
@@ -89,6 +89,7 @@ func (r CardRenderer) renderCardOnSurface(command, text string, commandErr error
 			bodyText = commandErr.Error()
 		}
 		if bodyText != "" {
+			bodyText = render.ReplayTerminalOutput(bodyText)
 			parts = append(parts, withoutBackground(statusStyle).Render(bodyText))
 		}
 	}

--- a/internal/ui/flash/render_test.go
+++ b/internal/ui/flash/render_test.go
@@ -1,0 +1,62 @@
+package flash
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/x/ansi"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCardRenderer_InterpretsCarriageReturnsInCommandError(t *testing.T) {
+	rendered := NewCardRenderer().RenderMessage(
+		"jj git push",
+		"",
+		errors.New("git: first\rgit: second\r\nfatal: failed"),
+		80,
+	)
+	plain := ansi.Strip(rendered)
+
+	assert.NotContains(t, plain, "\r")
+	assert.NotContains(t, plain, "git: first")
+	assert.Contains(t, plain, "git: second")
+	assert.Contains(t, plain, "fatal: failed")
+
+	for _, line := range strings.Split(plain, "\n") {
+		assert.True(t, strings.HasPrefix(line, "│") || strings.HasPrefix(line, "┌") || strings.HasPrefix(line, "└"))
+		assert.True(t, strings.HasSuffix(line, "│") || strings.HasSuffix(line, "┐") || strings.HasSuffix(line, "┘"))
+	}
+}
+
+func TestCardRenderer_InterpretsCarriageReturnsInHistoryOutput(t *testing.T) {
+	rendered := NewCardRenderer().RenderHistoryEntry(commandHistoryEntry{
+		Command: "jj git push",
+		Text:    "first\rsecond\r\nthird",
+	}, 80, true)
+	plain := ansi.Strip(rendered)
+
+	assert.NotContains(t, plain, "\r")
+	assert.NotContains(t, plain, "first")
+	assert.Regexp(t, `(?m)^│ second +│$`, plain)
+	assert.Regexp(t, `(?m)^│ third +│$`, plain)
+}
+
+func TestCardRenderer_RendersGitSidebandOutputLikeTerminal(t *testing.T) {
+	output := "git: bad configuration option        \rgit: \n" +
+		"git: terminating        \rgit: \n" +
+		"remote: failed        \rremote: \n"
+
+	rendered := NewCardRenderer().RenderMessage(
+		"jj git push",
+		"",
+		errors.New(output),
+		80,
+	)
+	plain := ansi.Strip(rendered)
+
+	assert.Equal(t, 2, strings.Count(plain, "git:"))
+	assert.Equal(t, 1, strings.Count(plain, "remote:"))
+	assert.NotRegexp(t, `(?m)^│ git: +│$`, plain)
+	assert.NotRegexp(t, `(?m)^│ remote: +│$`, plain)
+}

--- a/internal/ui/render/display_context_test.go
+++ b/internal/ui/render/display_context_test.go
@@ -6,9 +6,23 @@ import (
 
 	"charm.land/lipgloss/v2"
 	uv "github.com/charmbracelet/ultraviolet"
+	"github.com/charmbracelet/x/ansi"
 	"github.com/idursun/jjui/internal/ui/layout"
 	"github.com/stretchr/testify/assert"
 )
+
+func TestReplayTerminalOutput(t *testing.T) {
+	output := "git: bad configuration option        \rgit: \n" +
+		"git: terminating        \rgit: \n" +
+		"remote: failed        \rremote: \n"
+
+	assert.Equal(t,
+		"git: bad configuration option\n"+
+			"git: terminating\n"+
+			"remote: failed\n",
+		ansi.Strip(ReplayTerminalOutput(output)),
+	)
+}
 
 func TestDisplayContext_AddDraw(t *testing.T) {
 	dl := NewDisplayContext()

--- a/internal/ui/render/draw.go
+++ b/internal/ui/render/draw.go
@@ -1,6 +1,9 @@
 package render
 
 import (
+	"strings"
+
+	uv "github.com/charmbracelet/ultraviolet"
 	"github.com/idursun/jjui/internal/ui/layout"
 )
 
@@ -23,4 +26,23 @@ func PreserveBackground() DrawOption {
 	return func(opts *DrawOptions) {
 		opts.PreserveBackground = true
 	}
+}
+
+// ReplayTerminalOutput replays captured command output through an offscreen
+// terminal buffer. Applied to the rendering of flash message and command
+// history
+func ReplayTerminalOutput(content string) string {
+	width := 1
+	for field := range strings.FieldsFuncSeq(content, func(r rune) bool {
+		return r == '\r' || r == '\n'
+	}) {
+		// finds the max width of the content
+		width = max(width, StringWidth(field))
+	}
+
+	height := strings.Count(content, "\n") + 1
+	// builds an offscreen terminal and draws the content
+	buf := NewScreenBuffer(width, height)
+	uv.NewStyledString(content).Draw(buf, layout.Rect(0, 0, width, height))
+	return buf.Render()
 }


### PR DESCRIPTION
certain commands like Git and SSH errors can contain carriage returns
(`\r`). When rendered directly inside a flash card, these characters
move the terminal cursor to the start of the line, causing subsequent
output to overwrite the card's left border.

Normalize CRLF and standalone carriage returns to newlines before
rendering flash messages and command history entries. Add regression
tests covering both error and history output.

## before 
<img width="500" alt="file-5dd330798229614dbbf387723eb7f1b8" src="https://github.com/user-attachments/assets/962b9bd7-cb01-4ff8-9102-98361b45d087" />

## after 
<img width="500" alt="file-29e6190fdb1ba70724ab35998ca4ccee" src="https://github.com/user-attachments/assets/f26378ee-8fce-4373-8a90-068cd59f199d" />
