### PR TITLE
feat(git): add push option for selected bookmarks in multi-select

### DIFF
--- a/internal/jj/bookmark_parser.go
+++ b/internal/jj/bookmark_parser.go
@@ -32,6 +32,15 @@ func (b Bookmark) IsTrackable() bool {
 	return b.Local != nil && len(b.Remotes) == 0
 }
 
+func (b Bookmark) HasRemote(remote string) bool {
+	for _, r := range b.Remotes {
+		if r.Remote == remote {
+			return true
+		}
+	}
+	return false
+}
+
 func ParseBookmarkListOutput(output string) []Bookmark {
 	lines := strings.Split(output, "\n")
 	bookmarkMap := make(map[string]*Bookmark)

--- a/internal/ui/git/git.go
+++ b/internal/ui/git/git.go
@@ -639,7 +639,8 @@ func (m *Model) createMenuItems() []item {
 			if b.Conflict {
 				continue
 			}
-			if !seenBookmarks[b.Name] {
+			pushable := b.Local != nil && (len(b.Remotes) == 0 || b.HasRemote(selectedRemote))
+			if pushable && !seenBookmarks[b.Name] {
 				seenBookmarks[b.Name] = true
 				selectedBookmarks = append(selectedBookmarks, b.Name)
 			}

--- a/internal/ui/git/git.go
+++ b/internal/ui/git/git.go
@@ -631,11 +631,17 @@ func (m *Model) createMenuItems() []item {
 		selectedRemote = ""
 	}
 
+	var selectedBookmarks []string
+	seenBookmarks := make(map[string]bool)
 	for _, commit := range revisions.Revisions {
 		bookmarks := loadBookmarks(m.context, commit.GetChangeId())
 		for _, b := range bookmarks {
 			if b.Conflict {
 				continue
+			}
+			if !seenBookmarks[b.Name] {
+				seenBookmarks[b.Name] = true
+				selectedBookmarks = append(selectedBookmarks, b.Name)
 			}
 			for _, remote := range b.Remotes {
 				items = append(items, item{
@@ -677,6 +683,22 @@ func (m *Model) createMenuItems() []item {
 				command:  jj.GitPush(flags...),
 				key:      "c",
 			})
+
+		if len(selectedBookmarks) > 0 {
+			var bookmarkFlags []string
+			for _, name := range selectedBookmarks {
+				bookmarkFlags = append(bookmarkFlags, "--bookmark", name)
+			}
+			flags := append([]string{"--remote", selectedRemote}, bookmarkFlags...)
+			items = append(items,
+				item{
+					category: itemCategoryPush,
+					name:     fmt.Sprintf("git push %s --remote %s", strings.Join(bookmarkFlags, " "), selectedRemote),
+					desc:     fmt.Sprintf("Push only the selected bookmarks (%s)", strings.Join(selectedBookmarks, ", ")),
+					command:  jj.GitPush(flags...),
+					key:      "b",
+				})
+		}
 	}
 
 	for _, commit := range revisions.Revisions {

--- a/internal/ui/git/git_test.go
+++ b/internal/ui/git/git_test.go
@@ -91,6 +91,27 @@ func Test_PushChange(t *testing.T) {
 	test.SimulateModel(op, func() tea.Msg { return intents.Apply{} })
 }
 
+func Test_PushSelectedBookmarks(t *testing.T) {
+	const changeId1 = "abc123"
+	const changeId2 = "def456"
+	commandRunner := test.NewTestCommandRunner(t)
+	commandRunner.Expect(jj.BookmarkList(changeId1)).SetOutput([]byte("feature-a;.;false;false;false;83\n"))
+	commandRunner.Expect(jj.BookmarkList(changeId2)).SetOutput([]byte("feature-b;.;false;false;false;86\n"))
+	commandRunner.Expect(jj.GitRemoteList()).SetOutput([]byte(""))
+	commandRunner.Expect(jj.GitPush("--remote", "", "--bookmark", "feature-a", "--bookmark", "feature-b"))
+	defer commandRunner.Verify()
+
+	selected := jj.NewSelectedRevisions(&jj.Commit{ChangeId: changeId1}, &jj.Commit{ChangeId: changeId2})
+	op := NewModel(test.NewTestContext(commandRunner), selected)
+	test.SimulateModel(op, op.Init())
+	_ = test.RenderImmediate(op, 100, 40)
+
+	test.SimulateModel(op, func() tea.Msg { return intents.GitOpenFilter{} })
+	test.SimulateModel(op, test.Type("git push --bookmark feature-a --bookmark feature-b"))
+	test.SimulateModel(op, func() tea.Msg { return intents.Apply{} })
+	test.SimulateModel(op, func() tea.Msg { return intents.Apply{} })
+}
+
 func Test_NewModel_DoesNotPanicWithNilSelectedRevision(t *testing.T) {
 	commandRunner := test.NewTestCommandRunner(t)
 	commandRunner.Expect(jj.GitRemoteList()).SetOutput([]byte(""))

--- a/internal/ui/git/git_test.go
+++ b/internal/ui/git/git_test.go
@@ -106,10 +106,38 @@ func Test_PushSelectedBookmarks(t *testing.T) {
 	test.SimulateModel(op, op.Init())
 	_ = test.RenderImmediate(op, 100, 40)
 
-	test.SimulateModel(op, func() tea.Msg { return intents.GitOpenFilter{} })
-	test.SimulateModel(op, test.Type("git push --bookmark feature-a --bookmark feature-b"))
-	test.SimulateModel(op, func() tea.Msg { return intents.Apply{} })
-	test.SimulateModel(op, func() tea.Msg { return intents.Apply{} })
+	test.SimulateModel(op, intents.Invoke(intents.GitFilter{Kind: intents.GitFilterPush}))
+	test.SimulateModel(op, intents.Invoke(intents.GitApplyShortcut{Key: "b"}))
+}
+
+func Test_PushSelectedBookmarks_SkipsRemoteOnlyAndNonMatchingRemotes(t *testing.T) {
+	const (
+		localOnOrigin   = "abc123"
+		remoteOnly      = "def456"
+		localOnUpstream = "ghi789"
+		newLocal        = "jkl012"
+	)
+	commandRunner := test.NewTestCommandRunner(t)
+	commandRunner.Expect(jj.BookmarkList(localOnOrigin)).SetOutput([]byte("feature-a;.;true;false;false;83\nfeature-a;origin;true;false;false;83\n"))
+	commandRunner.Expect(jj.BookmarkList(remoteOnly)).SetOutput([]byte("feature-b;origin;false;false;false;86\n"))
+	commandRunner.Expect(jj.BookmarkList(localOnUpstream)).SetOutput([]byte("feature-c;.;true;false;false;90\nfeature-c;upstream;true;false;false;90\n"))
+	commandRunner.Expect(jj.BookmarkList(newLocal)).SetOutput([]byte("feature-d;.;false;false;false;92\n"))
+	commandRunner.Expect(jj.GitRemoteList()).SetOutput([]byte("origin\nupstream\n"))
+	commandRunner.Expect(jj.GitPush("--remote", "origin", "--bookmark", "feature-a", "--bookmark", "feature-d"))
+	defer commandRunner.Verify()
+
+	selected := jj.NewSelectedRevisions(
+		&jj.Commit{ChangeId: localOnOrigin},
+		&jj.Commit{ChangeId: remoteOnly},
+		&jj.Commit{ChangeId: localOnUpstream},
+		&jj.Commit{ChangeId: newLocal},
+	)
+	op := NewModel(test.NewTestContext(commandRunner), selected)
+	test.SimulateModel(op, op.Init())
+	_ = test.RenderImmediate(op, 100, 40)
+
+	test.SimulateModel(op, intents.Invoke(intents.GitFilter{Kind: intents.GitFilterPush}))
+	test.SimulateModel(op, intents.Invoke(intents.GitApplyShortcut{Key: "b"}))
 }
 
 func Test_NewModel_DoesNotPanicWithNilSelectedRevision(t *testing.T) {


### PR DESCRIPTION
## Summary

- When multiple revisions with bookmarks are selected and the git menu is opened (`g`), add a new push option that runs `jj git push --remote <remote> --bookmark <name> ...` for only the bookmarks on the selected revisions
- Deduplicate bookmark names across selected revisions and skip conflicted bookmarks
- Bind the new option to shortcut `b` in the push category

## Test plan

- [x] `go test ./internal/ui/git/`
- [x] Select multiple revisions with bookmarks, press `g`, filter push options, and confirm the aggregated bookmark push item appears
- [x] Run the new option and verify only the selected bookmarks are pushed to the chosen remote