### PR TITLE
Show revset history before completions

### DIFF
--- a/internal/ui/revset/completion_provider.go
+++ b/internal/ui/revset/completion_provider.go
@@ -103,7 +103,8 @@ func (p *CompletionProvider) GetCompletionItems(input string, history []string) 
 	var items []CompletionItem
 
 	if input == "" {
-		// When input is empty, show history for quick access
+		// When input is empty, show history first for quick access,
+		// followed by all available completions.
 		for _, h := range history {
 			items = append(items, CompletionItem{
 				ReplaceStart: 0,
@@ -114,10 +115,6 @@ func (p *CompletionProvider) GetCompletionItems(input string, history []string) 
 				RestPart:     h,
 			})
 		}
-		if len(items) > 0 {
-			return items
-		}
-		// No history: fall through to show all available completions
 		for _, si := range p.items {
 			items = append(items, p.itemForSourceItem(si, 0, ""))
 		}

--- a/internal/ui/revset/completion_provider_test.go
+++ b/internal/ui/revset/completion_provider_test.go
@@ -75,6 +75,25 @@ func TestGetCompletions(t *testing.T) {
 	}
 }
 
+func TestGetCompletionItems_EmptyInputShowsHistoryThenAllCompletions(t *testing.T) {
+	provider := NewCompletionProvider(map[string]string{"myalias": "mine()"})
+
+	items := provider.GetCompletionItems("", []string{"mine()", "all()"})
+
+	assert.GreaterOrEqual(t, len(items), 4)
+	assert.Equal(t, CompletionItem{ReplaceStart: 0, Name: "mine()", InsertText: "mine()", Kind: KindHistory, RestPart: "mine()"}, items[0])
+	assert.Equal(t, CompletionItem{ReplaceStart: 0, Name: "all()", InsertText: "all()", Kind: KindHistory, RestPart: "all()"}, items[1])
+
+	functionIndex := slices.IndexFunc(items[2:], func(item CompletionItem) bool {
+		return item.InsertText == "all()" && item.Kind == KindFunction
+	})
+	aliasIndex := slices.IndexFunc(items[2:], func(item CompletionItem) bool {
+		return item.InsertText == "myalias" && item.Kind == KindAlias
+	})
+	assert.NotEqual(t, -1, functionIndex, "function completions should follow history")
+	assert.NotEqual(t, -1, aliasIndex, "alias completions should follow history")
+}
+
 func TestGetCompletionItems_FunctionArgumentCompletions(t *testing.T) {
 	provider := NewCompletionProvider(nil)
 	remoteListCalls := 0


### PR DESCRIPTION
right now when jjui is freshly launched, typing `L` to set revset shows functions and aliases. after resvet is set once, `L` only shows history. 

personally i think it makes sense to always show everything, with history, if exists, shown at the top of the list