### PR TITLE
docs: require jj 0.37 or later

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,7 @@ go run ./cmd/genactions
 ## Requirements
 
 - Go 1.24.2+
-- `jj` v0.36+
+- `jj` v0.37+
 
 ## Verification Expectations
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ We welcome contributions from the community and appreciate your help in making t
 ### Prerequisites
 
 - Go 1.24.2 or later
-- [Jujutsu version control system](https://github.com/jj-vcs/jj) v0.36 or later
+- [Jujutsu version control system](https://github.com/jj-vcs/jj) v0.37 or later
 
 ### Setting up the Development Environment
 
@@ -58,7 +58,7 @@ This process helps ensure that:
 
 - Follow standard Go conventions and formatting
 - Use `go fmt` to format your code
-- Ensure compatibility with the minimum supported `jj` version (v0.36+)
+- Ensure compatibility with the minimum supported `jj` version (v0.37+)
 
 ### Code Generation
 

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ You can download pre-built binaries from the [releases](https://github.com/idurs
 
 ## Compatibility
 
-Minimum supported `jj` version is **v0.36**+.
+Minimum supported `jj` version is **v0.37**+.
 
 ## Contributing
 


### PR DESCRIPTION
Updated the minimum supported `jj` version from v0.36 to v0.37 across the documentation.

`jjui` uses the [`change_offset` keyword](https://github.com/idursun/jjui/blob/107dc4b1c4710c34650805941614cdeeb28a0508/internal/jj/commands.go?plain=1#L58), which was introduced in jj v0.37. A clean v0.36 installation fails to render the revision log.