### PR TITLE
Allow pushing all bookmarks in selected changes

### DIFF
--- a/internal/ui/git/git.go
+++ b/internal/ui/git/git.go
@@ -680,22 +680,22 @@ func (m *Model) createMenuItems() []item {
 				command:  jj.GitPush(flags...),
 				key:      "c",
 			})
+	}
 
-		if len(selectedBookmarks) > 0 {
-			var bookmarkFlags []string
-			for _, name := range selectedBookmarks {
-				bookmarkFlags = append(bookmarkFlags, "--bookmark", name)
-			}
-			flags := append([]string{"--remote", selectedRemote}, bookmarkFlags...)
-			items = append(items,
-				item{
-					category: itemCategoryPush,
-					name:     fmt.Sprintf("git push %s --remote %s", strings.Join(bookmarkFlags, " "), selectedRemote),
-					desc:     fmt.Sprintf("Push only the selected bookmarks (%s)", strings.Join(selectedBookmarks, ", ")),
-					command:  jj.GitPush(flags...),
-					key:      "b",
-				})
+	if len(selectedBookmarks) > 0 {
+		var bookmarkFlags []string
+		for _, name := range selectedBookmarks {
+			bookmarkFlags = append(bookmarkFlags, "--bookmark", name)
 		}
+		flags := append([]string{"--remote", selectedRemote}, bookmarkFlags...)
+		items = append(items,
+			item{
+				category: itemCategoryPush,
+				name:     fmt.Sprintf("git push %s --remote %s", strings.Join(bookmarkFlags, " "), selectedRemote),
+				desc:     fmt.Sprintf("Push all bookmarks in selected changes (%s)", strings.Join(selectedBookmarks, ", ")),
+				command:  jj.GitPush(flags...),
+				key:      "b",
+			})
 	}
 
 	for _, commit := range revisions.Revisions {


### PR DESCRIPTION
### What is the current behavior?
The `b` shortcut aggregates the pushable bookmarks on the selected change(s) and pushes them in a single command. The block that builds it was nested inside the `if hasMultipleRevisions` check, so it was unreachable whenever a single change was selected, regardless of how many bookmarks that change had.

### What is the new behavior?
`b` is available whenever the selected change(s) have at least one pushable bookmark, independent of how many changes are selected.

### Changes
- Moved the `if len(selectedBookmarks) > 0` block out of the `hasMultipleRevisions` branch in `internal/ui/git/git.go`.
- Reworded the item label to `Push all bookmarks in selected changes (%s)`.

Closes #715
