### PR TITLE
feat(config): add [bookmark] config for bookmark pane

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -28,6 +28,7 @@ type Config struct {
 	Limit           int             `toml:"limit"`
 	Git             GitConfig       `toml:"git"`
 	Ssh             SshConfig       `toml:"ssh"`
+	Bookmark        BookmarkConfig  `toml:"bookmark"`
 }
 
 type Color struct {
@@ -337,4 +338,8 @@ func GetGitDefaultRemote(c *Config) string {
 
 type SshConfig struct {
 	HijackAskpass bool `toml:"hijack_askpass"`
+}
+
+type BookmarkConfig struct {
+	InteractiveBookmarkPane bool `toml:"interactive_bookmark_pane"`
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestLoad_Theme_Simple(t *testing.T) {
@@ -121,4 +122,15 @@ explicit_false = { fg = "blue", underline = false }
 	if assert.NotNil(t, config.UI.Colors["explicit_false"].Underline) {
 		assert.False(t, *config.UI.Colors["explicit_false"].Underline)
 	}
+}
+
+func TestLoad_BookmarkConfig(t *testing.T) {
+	content := `
+[bookmark]
+interactive_bookmark_pane = true
+`
+	config := &Config{}
+	err := config.Load(content, "")
+	require.NoError(t, err)
+	assert.True(t, config.Bookmark.InteractiveBookmarkPane)
 }

--- a/internal/config/default/config.toml
+++ b/internal/config/default/config.toml
@@ -41,6 +41,9 @@ bindings_profile = ":builtin"
 [ssh]
   hijack_askpass = false
 
+[bookmark]
+  interactive_bookmark_pane = false
+
 # Backwards compatibility
 [[actions]]
 name = "revisions.toggle_select"


### PR DESCRIPTION
Add a BookmarkConfig struct and [bookmark] TOML section to prepare for gating the experimental interactive bookmark pane behind a config flag.

The interactive_bookmark_pane option defaults to false so existing users keep the classic bookmark menu. This is a no-op config addition.

