### PR TITLE
fix(parser): keep gutter one segment per rune when padding blank graph lines

### DIFF
--- a/internal/parser/row_line.go
+++ b/internal/parser/row_line.go
@@ -99,8 +99,13 @@ func (gr *GraphRowLine) chop(indent int) {
 
 	// Pad with spaces if indent is not fully consumed
 	if indent > 0 && len(gr.Gutter.Segments) > 0 {
-		lastSegment := gr.Gutter.Segments[len(gr.Gutter.Segments)-1]
-		lastSegment.Text += strings.Repeat(" ", indent)
+		style := gr.Gutter.Segments[len(gr.Gutter.Segments)-1].Style
+		for range indent {
+			gr.Gutter.Segments = append(gr.Gutter.Segments, &screen.Segment{
+				Text:  " ",
+				Style: style,
+			})
+		}
 	}
 }
 

--- a/test/log_parser_test.go
+++ b/test/log_parser_test.go
@@ -104,6 +104,19 @@ func TestParser_Parse_Extend(t *testing.T) {
 	assert.Len(t, extended.Segments, 2)
 }
 
+func TestParser_Parse_ExtendBlankGraphLine(t *testing.T) {
+	file, err := os.Open("testdata/single-line-with-description.log")
+	assert.NoError(t, err)
+	defer file.Close()
+	rows := parser.ParseRows(file)
+	assert.Len(t, rows, 1)
+	var sb strings.Builder
+	for _, segment := range rows[0].Extend().Segments {
+		sb.WriteString(segment.Text)
+	}
+	assert.Equal(t, "│  ", sb.String())
+}
+
 func TestParser_Parse_WorkingCopy_1(t *testing.T) {
 	var lb LogBuilder
 	lb.Write("*   _PREFIX:abcde_PREFIX:xyrq id=abcde author=some@author id=xyrq")


### PR DESCRIPTION
Parsing the shipped fixture `test/testdata/single-line-with-description.log` (a commit followed by a blank `│` graph line, as `builtin_log_comfortable` emits) and extending the row drops two gutter columns:

```
rows[0].Extend()  actual "│"   (1 segment)
                  expected "│  " (3 segments, row.Indent == 3)
```

Downstream, that shifts every embedded operation panel (details file list, inline describe, evolog, rebase preview) two columns to the left of the row's own text under a comfortable template.

### Cause

`GraphRowLine.chop` first splits the gutter into one segment per rune, then pads short lines up to the row indent. The padding step re-fattened the **last** segment's `.Text` with `strings.Repeat(" ", indent)`, undoing the per-rune split. `Row.Extend()` derives its mask from the gutter's segment count, so a blank line reporting 1 segment instead of 3 loses the trailing columns.

### Fix

Pad by appending one single-space `screen.Segment` per remaining indent column, each carrying the last gutter segment's `Style`, so the one-rune-per-segment invariant holds.

### Test

`TestParser_Parse_ExtendBlankGraphLine` in `test/log_parser_test.go` extends the fixture row and asserts the gutter is `"│  "`. I verified it fails without the source change (`actual "│"` vs `expected "│  "`) and passes with it.

`go test ./...` is green.
