### PR TITLE
fix(config): support jj extended revset-alias config

### DIFF
--- a/internal/config/jj_config.go
+++ b/internal/config/jj_config.go
@@ -1,12 +1,16 @@
 package config
 
 import (
+	"fmt"
+
 	"github.com/BurntSushi/toml"
 )
 
+type RevsetAliasMap map[string]string
+
 type JJConfig struct {
-	Colors        map[string]Color  `toml:"colors"`
-	RevsetAliases map[string]string `toml:"revset-aliases"`
+	Colors        map[string]Color `toml:"colors"`
+	RevsetAliases RevsetAliasMap   `toml:"revset-aliases"`
 	Revsets       struct {
 		Log string `toml:"log"`
 	} `toml:"revsets"`
@@ -50,4 +54,29 @@ func parseConfig(configContent string) (*JJConfig, error) {
 
 func DefaultConfig(output []byte) (*JJConfig, error) {
 	return parseConfig(string(output))
+}
+
+func (m *RevsetAliasMap) UnmarshalTOML(data any) error {
+	rawMap, ok := data.(map[string]any)
+	if !ok {
+		return fmt.Errorf("expected a table for revset-aliases, got %T", data)
+	}
+
+	*m = make(RevsetAliasMap)
+
+	for key, value := range rawMap {
+		switch v := value.(type) {
+		case string:
+			(*m)[key] = v
+		case map[string]any:
+			if def, ok := v["definition"].(string); ok {
+				(*m)[key] = def
+			} else {
+				return fmt.Errorf("missing or invalid 'definition' field in revset-alias object %q, %T", key, value)
+			}
+		default:
+			return fmt.Errorf("expected string or object for revset-alias %q, got %T", key, value)
+		}
+	}
+	return nil
 }

--- a/internal/config/jj_config_test.go
+++ b/internal/config/jj_config_test.go
@@ -1,0 +1,44 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseConfigRevsetAliases(t *testing.T) {
+	t.Run("valid config parsing", func(t *testing.T) {
+		tomlData := `
+[revsets]
+log = "all()"
+
+[templates]
+log = "builtin_log_comfortable"
+
+[revset-aliases]
+"@" = "HEAD"
+"my_alias" = { definition = "trunk()..", doc = "my_alias doc string" }
+
+[revset-aliases."another_alias"]
+definition = "mine()"
+doc = "another_alias doc"
+
+[revset-aliases."alias_func(to)"]
+definition = "heads(::to)"
+doc = "alias_func(to) doc"
+`
+		config, err := parseConfig(tomlData)
+		require.NoError(t, err)
+		require.NotNil(t, config)
+
+		assert.Equal(t, "all()", config.Revsets.Log)
+		assert.Equal(t, "builtin_log_comfortable", config.Templates.Log)
+
+		assert.Len(t, config.RevsetAliases, 4)
+		assert.Equal(t, "HEAD", config.RevsetAliases["@"])
+		assert.Equal(t, "trunk()..", config.RevsetAliases["my_alias"])
+		assert.Equal(t, "mine()", config.RevsetAliases["another_alias"])
+		assert.Equal(t, "heads(::to)", config.RevsetAliases["alias_func(to)"])
+	})
+}


### PR DESCRIPTION
[This jj PR](https://github.com/jj-vcs/jj/pull/9337) changed the schema for jj config to allow a "revset-aliases" key to contain an object with "doc" and "definition" keys instead of just a string. This PR adds support for that to jjui. For now we ignore the "doc" key and simply parse the "definition" key into a string.

Closes #724 