### PR TITLE
toggle bookmarkpane with `b` when config flag is set

### DIFF
--- a/internal/config/default/bindings.toml
+++ b/internal/config/default/bindings.toml
@@ -84,7 +84,6 @@ bindings = [
     { key = "$", action = "ui.exec_shell", scope = "revisions", desc = "exec shell" },
     { key = "shift+w", action = "ui.open_command_history", scope = "revisions", desc = "command history" },
     { key = "shift+p", action = "ui.preview_toggle_bottom", scope = "revisions", desc = "move preview to bottom" },
-    { key = "shift+x", action = "ui.toggle_bookmark_pane", scope = "revisions", desc = "bookmark pane" },
     { key = "esc", action = "revisions.cancel", scope = "revisions", desc = "clear selection" },
 
     # revisions.quick_search
@@ -347,7 +346,6 @@ bindings = [
     { key = "enter", action = "bookmarks.apply", scope = "bookmarks.filter", desc = "apply" },
 
     # bookmark_pane
-    { key = "shift+x", action = "ui.toggle_bookmark_pane", scope = "bookmark_pane", desc = "bookmark pane" },
     { key = "tab", action = "ui.focus_next_pane", scope = "bookmark_pane", desc = "next pane" },
     { key = ["up", "k"], action = "bookmark_pane.move_up", scope = "bookmark_pane", desc = "up" },
     { key = ["down", "j"], action = "bookmark_pane.move_down", scope = "bookmark_pane", desc = "down" },

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -579,6 +579,10 @@ func (m *Model) HandleIntent(intent intents.Intent) (tea.Cmd, bool) {
 		m.stacked = model
 		return m.stacked.Init(), true
 	case intents.OpenBookmarks:
+		if config.Current.Bookmark.InteractiveBookmarkPane {
+			cmd, _ := m.handleSplitIntent(intents.ToggleBookmarkPane{})
+			return cmd, true
+		}
 		current := m.revisions.SelectedRevision()
 		if current == nil {
 			return nil, true


### PR DESCRIPTION
as #584 and #721 have been merged, jjui users can now try out the experimental bookmark pane feature behind a config flag

in previous PR, it was still `X` to trigger bookmark pane, which is fairly awkward. this PR updates it to intercept `b` so it replaces the current bookmark stack UI

tho this implies that these two features are mutually exclusive (in my own use case i think it's fine, since im mainly using bookmarkpane now, but of course, i am biased!), i understand this might not fit into the vision of jjui 

@idursun feel free to merge this PR as you see fit, or close it if it doesn't :") 