### PR TITLE
fix(dispatch): treat Ctrl-[ as Escape

### DIFF
--- a/internal/ui/dispatch/dispatcher.go
+++ b/internal/ui/dispatch/dispatcher.go
@@ -221,5 +221,9 @@ func isPrefix(full []string, prefix []tea.Key) bool {
 }
 
 func keyMatches(candidate string, key tea.Key) bool {
-	return candidate == key.String() || candidate == key.Keystroke()
+	keystroke := key.Keystroke()
+	if candidate == key.String() || candidate == keystroke {
+		return true
+	}
+	return candidate == "esc" && keystroke == "ctrl+["
 }

--- a/internal/ui/dispatch/dispatcher_test.go
+++ b/internal/ui/dispatch/dispatcher_test.go
@@ -80,17 +80,44 @@ func TestDispatcher_SwallowsMismatchedContinuationAndResets(t *testing.T) {
 	require.True(t, again.Pending)
 }
 
-func TestDispatcher_CancelSequenceWithEsc(t *testing.T) {
-	d, err := NewDispatcher([]bindings.Binding{{Action: "git_push", Scope: "revisions", Seq: []string{"g", "p"}}})
+func TestDispatcher_CancelSequenceWithEscapeAliases(t *testing.T) {
+	tests := []struct {
+		name         string
+		key          tea.KeyPressMsg
+		continuation string
+	}{
+		{name: "escape", key: tea.KeyPressMsg{Code: tea.KeyEsc}, continuation: "esc"},
+		{name: "ctrl left bracket", key: tea.KeyPressMsg{Code: '[', Mod: tea.ModCtrl}, continuation: "ctrl+["},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Make the cancellation key a valid continuation so this test exercises
+			// the reserved Escape path instead of the mismatched-key reset path.
+			d, err := NewDispatcher([]bindings.Binding{{Action: "git_push", Scope: "revisions", Seq: []string{"g", tt.continuation}}})
+			require.NoError(t, err)
+
+			first := d.Resolve(runeKey('g'), createScopes("revisions"))
+			require.True(t, first.Pending)
+
+			cancel := d.Resolve(tt.key, createScopes("revisions"))
+			require.True(t, cancel.Consumed)
+			require.False(t, cancel.Pending)
+			require.Empty(t, cancel.Action)
+
+			again := d.Resolve(runeKey('g'), createScopes("revisions"))
+			require.True(t, again.Pending)
+		})
+	}
+}
+
+func TestDispatcher_ResolvesCtrlLeftBracketAsEsc(t *testing.T) {
+	d, err := NewDispatcher([]bindings.Binding{{Action: "cancel", Scope: "ui", Key: []string{"esc"}}})
 	require.NoError(t, err)
 
-	first := d.Resolve(runeKey('g'), createScopes("revisions"))
-	require.True(t, first.Pending)
-
-	cancel := d.Resolve(tea.KeyPressMsg{Code: tea.KeyEsc}, createScopes("revisions"))
-	require.True(t, cancel.Consumed)
-	require.False(t, cancel.Pending)
-	require.Empty(t, cancel.Action)
+	result := d.Resolve(tea.KeyPressMsg{Code: '[', Mod: tea.ModCtrl}, createScopes("ui"))
+	require.True(t, result.Consumed)
+	require.Equal(t, bindings.Action("cancel"), result.Action)
 }
 
 func TestDispatcher_ResolvesSpaceAliasForSingleKey(t *testing.T) {

--- a/internal/ui/dispatch/resolver_test.go
+++ b/internal/ui/dispatch/resolver_test.go
@@ -46,6 +46,17 @@ func TestResolveKey_BuiltInAction(t *testing.T) {
 	assert.Equal(t, "ui", result.Scope)
 }
 
+func TestResolveKey_CtrlLeftBracketUsesEscBinding(t *testing.T) {
+	r := makeResolver([]keybindings.Binding{
+		{Action: "ui.cancel", Scope: "ui", Key: []string{"esc"}},
+	}, nil)
+
+	result := r.ResolveKey(tea.KeyPressMsg{Code: '[', Mod: tea.ModCtrl}, createScopes("ui"))
+	assert.True(t, result.Consumed)
+	assert.IsType(t, intents.Cancel{}, result.Intent)
+	assert.Equal(t, "ui", result.Scope)
+}
+
 func TestResolveKey_Pending(t *testing.T) {
 	r := makeResolver([]keybindings.Binding{
 		{Action: "ui.quit", Scope: "ui", Seq: []string{"g", "q"}},


### PR DESCRIPTION
## summary

- treat `Ctrl-[` as an alias for `Escape` in the central key matcher
- reuse existing `esc` bindings without duplicating keys across scopes
- make `Ctrl-[` cancel pending key sequences like physical Escape

Closes #710

## testing

- `go test ./internal/ui/dispatch`
- `go test ./...`
- `go build ./cmd/jjui`
- manually verified help rebase andd quick search cancelation using an
  enhanced-terminal `Ctrl-[` key event