### PR TITLE
feat(files): render file paths relative to startup directory

### DIFF
--- a/internal/jj/commands.go
+++ b/internal/jj/commands.go
@@ -91,7 +91,7 @@ func DiffEdit(changeId string) CommandArgs {
 	return []string{"diffedit", "-r", changeId}
 }
 
-func Split(revision string, files []string, parallel bool, interactive bool) CommandArgs {
+func Split(revision string, files []FileName, parallel bool, interactive bool) CommandArgs {
 	args := []string{"split", "-r", revision}
 	if parallel {
 		args = append(args, "--parallel")
@@ -101,7 +101,7 @@ func Split(revision string, files []string, parallel bool, interactive bool) Com
 	}
 	var escapedFiles []string
 	for _, file := range files {
-		escapedFiles = append(escapedFiles, EscapeFileName(file))
+		escapedFiles = append(escapedFiles, file.Escaped())
 	}
 	args = append(args, escapedFiles...)
 	return args
@@ -137,10 +137,10 @@ func Abandon(revision SelectedRevisions, ignoreImmutable bool) CommandArgs {
 	return args
 }
 
-func Diff(revision string, fileName string, extraArgs ...string) CommandArgs {
+func Diff(revision string, fileName FileName, extraArgs ...string) CommandArgs {
 	args := []string{"diff", "-r", revision, "--color", "always", "--ignore-working-copy"}
-	if fileName != "" {
-		args = append(args, EscapeFileName(fileName))
+	if !fileName.IsEmpty() {
+		args = append(args, fileName.Escaped())
 	}
 	if extraArgs != nil {
 		args = append(args, extraArgs...)
@@ -152,14 +152,14 @@ func DiffRange(from string, to string) CommandArgs {
 	return []string{"diff", "--from", from, "--to", to, "--color", "always", "--ignore-working-copy"}
 }
 
-func Restore(revision string, files []string, interactive bool) CommandArgs {
+func Restore(revision string, files []FileName, interactive bool) CommandArgs {
 	args := []string{"restore", "-c", revision}
 	if interactive {
 		args = append(args, "--interactive")
 	}
 	var escapedFiles []string
 	for _, file := range files {
-		escapedFiles = append(escapedFiles, EscapeFileName(file))
+		escapedFiles = append(escapedFiles, file.Escaped())
 	}
 	args = append(args, escapedFiles...)
 	return args
@@ -231,7 +231,7 @@ func BookmarkUntrack(name string, remote string) CommandArgs {
 	return args
 }
 
-func Squash(from SelectedRevisions, destination string, files []string, keepEmptied bool, useDestinationMessage bool, interactive bool, ignoreImmutable bool) CommandArgs {
+func Squash(from SelectedRevisions, destination string, files []FileName, keepEmptied bool, useDestinationMessage bool, interactive bool, ignoreImmutable bool) CommandArgs {
 	args := []string{"squash"}
 	args = append(args, from.AsPrefixedArgs("--from")...)
 	args = append(args, "--into", destination)
@@ -250,7 +250,7 @@ func Squash(from SelectedRevisions, destination string, files []string, keepEmpt
 	if len(files) > 0 {
 		var escapedFiles []string
 		for _, file := range files {
-			escapedFiles = append(escapedFiles, EscapeFileName(file))
+			escapedFiles = append(escapedFiles, file.Escaped())
 		}
 		args = append(args, escapedFiles...)
 	}
@@ -387,7 +387,7 @@ func TemplatedArgs(templatedArgs []string, replacements map[string]string) Comma
 	var args []string
 	if fileReplacement, exists := replacements[FilePlaceholder]; exists {
 		// Ensure that the file replacement is quoted
-		replacements[FilePlaceholder] = EscapeFileName(fileReplacement)
+		replacements[FilePlaceholder] = NewFileName(fileReplacement).Escaped()
 	}
 	for _, arg := range templatedArgs {
 		for k, v := range replacements {
@@ -398,14 +398,14 @@ func TemplatedArgs(templatedArgs []string, replacements map[string]string) Comma
 	return args
 }
 
-func Absorb(changeId string, into []string, files ...string) CommandArgs {
+func Absorb(changeId string, into []string, files ...FileName) CommandArgs {
 	args := []string{"absorb", "--from", changeId, "--color", "never"}
 	for _, target := range into {
 		args = append(args, "--into", target)
 	}
 	var escapedFiles []string
 	for _, file := range files {
-		escapedFiles = append(escapedFiles, EscapeFileName(file))
+		escapedFiles = append(escapedFiles, file.Escaped())
 	}
 	args = append(args, escapedFiles...)
 	return args
@@ -486,15 +486,4 @@ func ResolveRevisionID(revision string) CommandArgs {
 
 func RevsetValidate(revset string) CommandArgs {
 	return []string{"log", "-r", revset, "-n", "1", "--ignore-working-copy"}
-}
-
-func EscapeFileName(fileName string) string {
-	// Escape backslashes and quotes in the file name for shell compatibility
-	if strings.Contains(fileName, "\\") {
-		fileName = strings.ReplaceAll(fileName, "\\", "\\\\")
-	}
-	if strings.Contains(fileName, "\"") {
-		fileName = strings.ReplaceAll(fileName, "\"", "\\\"")
-	}
-	return fmt.Sprintf("file:\"%s\"", fileName)
 }

--- a/internal/jj/commands_test.go
+++ b/internal/jj/commands_test.go
@@ -16,3 +16,15 @@ func TestBookmarkPatternCommandsUseExactStringPatterns(t *testing.T) {
 	assert.Equal(t, CommandArgs{"bookmark", "track", `exact:"1.3.63-+-json-length-\"fix\"\\branch"`, "--remote", `exact:"origin+backup"`}, BookmarkTrack(name, remote))
 	assert.Equal(t, CommandArgs{"bookmark", "untrack", `exact:"1.3.63-+-json-length-\"fix\"\\branch"`, "--remote", `exact:"origin+backup"`}, BookmarkUntrack(name, remote))
 }
+
+func TestFileCommandsUseTypedRepositoryPaths(t *testing.T) {
+	file := NewFileName(`dir/a "quoted"\file.go`)
+	escaped := `file:"dir/a \"quoted\"\\file.go"`
+	revisions := NewSelectedRevisions(&Commit{ChangeId: "source"})
+
+	assert.Equal(t, CommandArgs{"diff", "-r", "source", "--color", "always", "--ignore-working-copy", escaped}, Diff("source", file))
+	assert.Equal(t, CommandArgs{"split", "-r", "source", escaped}, Split("source", []FileName{file}, false, false))
+	assert.Equal(t, CommandArgs{"restore", "-c", "source", escaped}, Restore("source", []FileName{file}, false))
+	assert.Equal(t, CommandArgs{"squash", "--from", "source", "--into", "target", escaped}, Squash(revisions, "target", []FileName{file}, false, false, false, false))
+	assert.Equal(t, CommandArgs{"absorb", "--from", "source", "--color", "never", escaped}, Absorb("source", nil, file))
+}

--- a/internal/jj/file_name.go
+++ b/internal/jj/file_name.go
@@ -1,0 +1,54 @@
+package jj
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+// FileName is a canonical repository-relative path returned to and accepted by jj.
+type FileName struct {
+	path string
+}
+
+func NewFileName(path string) FileName {
+	return FileName{path: path}
+}
+
+func (f FileName) Path() string {
+	return f.path
+}
+
+func (f FileName) IsEmpty() bool {
+	return f.path == ""
+}
+
+// Display returns the path relative to the directory where jjui was started.
+func (f FileName) Display(repoRoot, workingDirectory string) string {
+	if f.path == "" || repoRoot == "" || workingDirectory == "" {
+		return f.path
+	}
+	directory := strings.HasSuffix(f.path, "/")
+	absPath := filepath.Join(repoRoot, filepath.FromSlash(f.path))
+	rel, err := filepath.Rel(workingDirectory, absPath)
+	if err != nil {
+		return f.path
+	}
+	rel = filepath.ToSlash(rel)
+	if directory {
+		if rel == "." {
+			return "./"
+		}
+		if !strings.HasSuffix(rel, "/") {
+			rel += "/"
+		}
+	}
+	return rel
+}
+
+// Escaped returns a jj fileset expression for this path.
+func (f FileName) Escaped() string {
+	path := strings.ReplaceAll(f.path, `\`, `\\`)
+	path = strings.ReplaceAll(path, `"`, `\"`)
+	return fmt.Sprintf(`file:"%s"`, path)
+}

--- a/internal/jj/file_name.go
+++ b/internal/jj/file_name.go
@@ -52,3 +52,8 @@ func (f FileName) Escaped() string {
 	path = strings.ReplaceAll(path, `"`, `\"`)
 	return fmt.Sprintf(`file:"%s"`, path)
 }
+
+// ShellEscaped returns this path as a single shell argument.
+func (f FileName) ShellEscaped() string {
+	return "'" + strings.ReplaceAll(f.path, "'", "'\\''") + "'"
+}

--- a/internal/jj/file_name_test.go
+++ b/internal/jj/file_name_test.go
@@ -1,0 +1,54 @@
+package jj
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFileNameDisplay(t *testing.T) {
+	repo := filepath.Join(string(filepath.Separator), "work", "repo")
+	tests := []struct {
+		name string
+		path string
+		cwd  string
+		want string
+	}{
+		{name: "repository root", path: "src/main.go", cwd: repo, want: "src/main.go"},
+		{name: "nested descendant", path: "src/pkg/main.go", cwd: filepath.Join(repo, "src"), want: "pkg/main.go"},
+		{name: "nested sibling", path: "docs/readme.md", cwd: filepath.Join(repo, "src"), want: "../docs/readme.md"},
+		{name: "nested ancestor directory", path: "src/", cwd: filepath.Join(repo, "src", "pkg"), want: "../"},
+		{name: "startup directory", path: "src/", cwd: filepath.Join(repo, "src"), want: "./"},
+		{name: "outside repository", path: "../shared/file.go", cwd: repo, want: "../shared/file.go"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, NewFileName(tt.path).Display(repo, tt.cwd))
+		})
+	}
+}
+
+func TestFileNameDisplayFallbacks(t *testing.T) {
+	assert.Equal(t, "", NewFileName("").Display("/repo", "/repo"))
+	assert.Equal(t, "src/main.go", NewFileName("src/main.go").Display("", "/repo"))
+	assert.Equal(t, "src/main.go", NewFileName("src/main.go").Display("/repo", ""))
+}
+
+func TestFileNameEscaped(t *testing.T) {
+	tests := map[string]string{
+		"a b.go":      `file:"a b.go"`,
+		`a"quote.go`:  `file:"a\"quote.go"`,
+		`dir\file.go`: `file:"dir\\file.go"`,
+		`both\".go`:   `file:"both\\\".go"`,
+	}
+	for path, want := range tests {
+		assert.Equal(t, want, NewFileName(path).Escaped())
+	}
+}
+
+func TestFileNameAccessors(t *testing.T) {
+	assert.True(t, NewFileName("").IsEmpty())
+	assert.False(t, NewFileName("a.go").IsEmpty())
+	assert.Equal(t, "a.go", NewFileName("a.go").Path())
+}

--- a/internal/jj/file_name_test.go
+++ b/internal/jj/file_name_test.go
@@ -38,12 +38,27 @@ func TestFileNameDisplayFallbacks(t *testing.T) {
 func TestFileNameEscaped(t *testing.T) {
 	tests := map[string]string{
 		"a b.go":      `file:"a b.go"`,
+		"a'b.go":      `file:"a'b.go"`,
 		`a"quote.go`:  `file:"a\"quote.go"`,
 		`dir\file.go`: `file:"dir\\file.go"`,
 		`both\".go`:   `file:"both\\\".go"`,
 	}
 	for path, want := range tests {
 		assert.Equal(t, want, NewFileName(path).Escaped())
+	}
+}
+
+func TestFileNameShellEscaped(t *testing.T) {
+	tests := map[string]string{
+		"a b.go":  `'a b.go'`,
+		"a'b.go":  `'a'\''b.go'`,
+		`a"b.go`:  `'a"b.go'`,
+		`a$b.go`:  `'a$b.go'`,
+		`a; b.go`: `'a; b.go'`,
+		`a\b.go`:  `'a\b.go'`,
+	}
+	for path, want := range tests {
+		assert.Equal(t, want, NewFileName(path).ShellEscaped())
 	}
 }
 

--- a/internal/jj/source/source.go
+++ b/internal/jj/source/source.go
@@ -23,6 +23,7 @@ const (
 // Item represents a completion/picker item from any source.
 type Item struct {
 	Name          string
+	File          jj.FileName
 	Kind          Kind
 	SignatureHelp string
 	HasParameters bool
@@ -37,18 +38,26 @@ type Source interface {
 }
 
 type FileSource struct {
-	Files []string
+	Files []jj.FileName
 }
 
 func (s FileSource) Fetch(_ Runner) ([]Item, error) {
 	items := make([]Item, 0, len(s.Files))
 	for _, file := range s.Files {
-		if strings.TrimSpace(file) == "" {
+		if strings.TrimSpace(file.Path()) == "" {
 			continue
 		}
-		items = append(items, Item{Name: file, Kind: KindFile})
+		items = append(items, Item{Name: file.Path(), File: file, Kind: KindFile})
 	}
 	return items, nil
+}
+
+type StaticSource struct {
+	Items []Item
+}
+
+func (s StaticSource) Fetch(_ Runner) ([]Item, error) {
+	return s.Items, nil
 }
 
 // FetchAll collects items from multiple sources, skipping failures.

--- a/internal/jj/source/source_test.go
+++ b/internal/jj/source/source_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/idursun/jjui/internal/jj"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -98,12 +99,12 @@ func TestHistorySource(t *testing.T) {
 }
 
 func TestFileSource(t *testing.T) {
-	s := FileSource{Files: []string{"a.go", "", "dir/b.go"}}
+	s := FileSource{Files: []jj.FileName{jj.NewFileName("a.go"), jj.NewFileName(""), jj.NewFileName("dir/b.go")}}
 	items, err := s.Fetch(nil)
 	assert.NoError(t, err)
 	assert.Equal(t, []Item{
-		{Name: "a.go", Kind: KindFile},
-		{Name: "dir/b.go", Kind: KindFile},
+		{Name: "a.go", File: jj.NewFileName("a.go"), Kind: KindFile},
+		{Name: "dir/b.go", File: jj.NewFileName("dir/b.go"), Kind: KindFile},
 	}, items)
 }
 

--- a/internal/jj/summary.go
+++ b/internal/jj/summary.go
@@ -9,12 +9,13 @@ import (
 )
 
 type SummaryFile struct {
-	Status   rune
-	Name     string
-	FileName string
+	Status      rune
+	FileName    FileName
+	RenameFrom  FileName
+	braceRename bool
 }
 
-var braceRenameRe = regexp.MustCompile(`\{[^}]*? => \s*([^}]*?)\s*\}`)
+var braceRenameRe = regexp.MustCompile(`^(.*)\{([^{}]*?) =>\s*([^{}]*?)\}(.*)$`)
 
 func ParseSummaryFile(line string) (SummaryFile, bool) {
 	line = strings.TrimSpace(ansi.Strip(line))
@@ -28,26 +29,44 @@ func ParseSummaryFile(line string) (SummaryFile, bool) {
 		line = strings.TrimSpace(strings.TrimPrefix(line, fields[0]))
 	}
 
-	return SummaryFile{
-		Status:   status,
-		Name:     line,
-		FileName: NormalizeSummaryFileName(line),
-	}, true
+	result := SummaryFile{Status: status, FileName: NewFileName(line)}
+	if matches := braceRenameRe.FindStringSubmatch(line); matches != nil {
+		result.RenameFrom = NewFileName(path.Clean(matches[1] + strings.TrimSpace(matches[2]) + matches[4]))
+		result.FileName = NewFileName(path.Clean(matches[1] + strings.TrimSpace(matches[3]) + matches[4]))
+		result.braceRename = true
+		return result, true
+	}
+	if before, after, ok := strings.Cut(line, " => "); ok {
+		result.RenameFrom = NewFileName(strings.TrimSpace(before))
+		result.FileName = NewFileName(strings.TrimSpace(after))
+	}
+	return result, true
 }
 
-func NormalizeSummaryFileName(fileName string) string {
-	fileName = strings.TrimSpace(fileName)
-	if fileName == "" {
-		return ""
+func (s SummaryFile) Display(repoRoot, workingDirectory string) string {
+	to := s.FileName.Display(repoRoot, workingDirectory)
+	if s.RenameFrom.IsEmpty() {
+		return to
 	}
+	from := s.RenameFrom.Display(repoRoot, workingDirectory)
+	if !s.braceRename {
+		return from + " => " + to
+	}
+	return compactRename(from, to)
+}
 
-	if strings.Contains(fileName, "{") {
-		return path.Clean(braceRenameRe.ReplaceAllString(fileName, "$1"))
+func compactRename(from, to string) string {
+	a, b := []rune(from), []rune(to)
+	prefix := 0
+	for prefix < len(a) && prefix < len(b) && a[prefix] == b[prefix] {
+		prefix++
 	}
-	if _, after, ok := strings.Cut(fileName, " => "); ok {
-		return strings.TrimSpace(after)
+	suffix := 0
+	for suffix < len(a)-prefix && suffix < len(b)-prefix && a[len(a)-1-suffix] == b[len(b)-1-suffix] {
+		suffix++
 	}
-	return fileName
+	aEnd, bEnd := len(a)-suffix, len(b)-suffix
+	return string(a[:prefix]) + "{" + string(a[prefix:aEnd]) + " => " + string(b[prefix:bEnd]) + "}" + string(a[aEnd:])
 }
 
 func isSummaryStatus(token string) bool {

--- a/internal/jj/summary_test.go
+++ b/internal/jj/summary_test.go
@@ -33,14 +33,14 @@ func TestParseSummaryFile(t *testing.T) {
 			name:     "brace rename",
 			line:     "R internal/ui/{revisions => }/file.go",
 			status:   'R',
-			display:  "internal/ui/{revisions => }/file.go",
+			display:  "internal/ui/{revisions/ => }file.go",
 			fileName: "internal/ui/file.go",
 		},
 		{
 			name:     "deep brace rename",
 			line:     "R {src1/to_be_renamed.md => src2/renamed.md}",
 			status:   'R',
-			display:  "{src1/to_be_renamed.md => src2/renamed.md}",
+			display:  "src{1/to_be_ => 2/}renamed.md",
 			fileName: "src2/renamed.md",
 		},
 		{
@@ -63,8 +63,26 @@ func TestParseSummaryFile(t *testing.T) {
 			got, ok := ParseSummaryFile(tt.line)
 			require.True(t, ok)
 			assert.Equal(t, tt.status, got.Status)
-			assert.Equal(t, tt.display, got.Name)
-			assert.Equal(t, tt.fileName, got.FileName)
+			assert.Equal(t, tt.display, got.Display("", ""))
+			assert.Equal(t, tt.fileName, got.FileName.Path())
 		})
+	}
+}
+
+func TestSummaryFileDisplayRelativeToWorkingDirectory(t *testing.T) {
+	repo := "/work/repo"
+	cwd := "/work/repo/src"
+	tests := map[string]string{
+		"M src/main.go":                   "main.go",
+		"R src/old.go => docs/new.go":     "old.go => ../docs/new.go",
+		"R src/{before => after}/name.go": "{before => after}/name.go",
+		"R old/alpha.go => new/beta.go":   "../old/alpha.go => ../new/beta.go",
+		"R src/{日本語 => 日本海}/file.go":      "日本{語 => 海}/file.go",
+		"M src/file{with}braces.go":       "file{with}braces.go",
+	}
+	for line, want := range tests {
+		summary, ok := ParseSummaryFile(line)
+		require.True(t, ok)
+		assert.Equal(t, want, summary.Display(repo, cwd), line)
 	}
 }

--- a/internal/scripting/lua.go
+++ b/internal/scripting/lua.go
@@ -228,7 +228,7 @@ func registerAPI(L *lua.LState, ctx *uicontext.MainContext) {
 	}))
 	contextTable.RawSetString("file", L.NewFunction(func(L *lua.LState) int {
 		if item, ok := ctx.SelectedItem.(uicontext.SelectedFile); ok {
-			L.Push(lua.LString(item.File))
+			L.Push(lua.LString(item.File.Path()))
 			return 1
 		}
 		return 0
@@ -244,7 +244,7 @@ func registerAPI(L *lua.LState, ctx *uicontext.MainContext) {
 		tbl := L.NewTable()
 		for _, item := range ctx.CheckedItems {
 			if f, ok := item.(uicontext.SelectedFile); ok {
-				tbl.Append(lua.LString(f.File))
+				tbl.Append(lua.LString(f.File.Path()))
 			}
 		}
 		L.Push(tbl)

--- a/internal/scripting/lua_test.go
+++ b/internal/scripting/lua_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/idursun/jjui/internal/jj"
 	"github.com/idursun/jjui/internal/ui/common"
 	uicontext "github.com/idursun/jjui/internal/ui/context"
 	"github.com/idursun/jjui/internal/ui/intents"
@@ -78,7 +79,7 @@ func TestContext_ChangeId(t *testing.T) {
 			ctx: &uicontext.MainContext{SelectedItem: uicontext.SelectedFile{
 				ChangeId: "file123",
 				CommitId: "commit456",
-				File:     "test.go",
+				File:     jj.NewFileName("test.go"),
 			}},
 			want: strPtr("file123"),
 		},
@@ -116,7 +117,7 @@ func TestContext_CommitId(t *testing.T) {
 			ctx: &uicontext.MainContext{SelectedItem: uicontext.SelectedFile{
 				ChangeId: "file123",
 				CommitId: "commit456",
-				File:     "test.go",
+				File:     jj.NewFileName("test.go"),
 			}},
 			want: strPtr("commit456"),
 		},
@@ -148,7 +149,7 @@ func TestContext_File(t *testing.T) {
 			ctx: &uicontext.MainContext{SelectedItem: uicontext.SelectedFile{
 				ChangeId: "file123",
 				CommitId: "commit456",
-				File:     "path/to/file.go",
+				File:     jj.NewFileName("path/to/file.go"),
 			}},
 			want: strPtr("path/to/file.go"),
 		},
@@ -204,10 +205,10 @@ func TestContext_OperationId(t *testing.T) {
 func TestContext_CheckedFiles(t *testing.T) {
 	ctx := &uicontext.MainContext{
 		CheckedItems: []uicontext.SelectedItem{
-			uicontext.SelectedFile{ChangeId: "c1", CommitId: "co1", File: "file1.go"},
-			uicontext.SelectedFile{ChangeId: "c2", CommitId: "co2", File: "file2.go"},
+			uicontext.SelectedFile{ChangeId: "c1", CommitId: "co1", File: jj.NewFileName("file1.go")},
+			uicontext.SelectedFile{ChangeId: "c2", CommitId: "co2", File: jj.NewFileName("file2.go")},
 			uicontext.SelectedRevision{ChangeId: "rev1", CommitId: "com1"}, // should be ignored
-			uicontext.SelectedFile{ChangeId: "c3", CommitId: "co3", File: "file3.go"},
+			uicontext.SelectedFile{ChangeId: "c3", CommitId: "co3", File: jj.NewFileName("file3.go")},
 		},
 	}
 
@@ -242,7 +243,7 @@ func TestContext_CheckedChangeIds(t *testing.T) {
 	ctx := &uicontext.MainContext{
 		CheckedItems: []uicontext.SelectedItem{
 			uicontext.SelectedRevision{ChangeId: "change1", CommitId: "com1"},
-			uicontext.SelectedFile{ChangeId: "change2", CommitId: "com2", File: "f.go"},
+			uicontext.SelectedFile{ChangeId: "change2", CommitId: "com2", File: jj.NewFileName("f.go")},
 			uicontext.SelectedOperation{OperationId: "op1"}, // should be ignored
 			uicontext.SelectedRevision{ChangeId: "change3", CommitId: "com3"},
 		},
@@ -266,7 +267,7 @@ func TestContext_CheckedCommitIds(t *testing.T) {
 	ctx := &uicontext.MainContext{
 		CheckedItems: []uicontext.SelectedItem{
 			uicontext.SelectedRevision{ChangeId: "c1", CommitId: "commit1"},
-			uicontext.SelectedFile{ChangeId: "c2", CommitId: "commit2", File: "f.go"},
+			uicontext.SelectedFile{ChangeId: "c2", CommitId: "commit2", File: jj.NewFileName("f.go")},
 			uicontext.SelectedCommit{CommitId: "commit3"},
 			uicontext.SelectedOperation{OperationId: "op1"}, // should be ignored
 		},

--- a/internal/ui/common/msgs.go
+++ b/internal/ui/common/msgs.go
@@ -59,9 +59,11 @@ type (
 		Msg ExecMsg
 	}
 	FileSearchMsg struct {
-		Revset     string
-		Commit     *jj.Commit
-		RawFileOut []byte // raw output from `jj file list`
+		Revset           string
+		Commit           *jj.Commit
+		RawFileOut       []byte // raw output from `jj file list`
+		RepoRoot         string
+		WorkingDirectory string
 	}
 	ShowPreview     struct{}
 	RunLuaScriptMsg struct {
@@ -168,12 +170,14 @@ func UpdateRevSet(revset string) tea.Cmd {
 	}
 }
 
-func FileSearch(revset string, commit *jj.Commit, rawFileOut []byte) tea.Cmd {
+func FileSearch(revset string, commit *jj.Commit, rawFileOut []byte, repoRoot, workingDirectory string) tea.Cmd {
 	return func() tea.Msg {
 		return FileSearchMsg{
-			Commit:     commit,
-			RawFileOut: rawFileOut,
-			Revset:     revset,
+			Commit:           commit,
+			RawFileOut:       rawFileOut,
+			Revset:           revset,
+			RepoRoot:         repoRoot,
+			WorkingDirectory: workingDirectory,
 		}
 	}
 }

--- a/internal/ui/common/selection.go
+++ b/internal/ui/common/selection.go
@@ -1,5 +1,7 @@
 package common
 
+import "github.com/idursun/jjui/internal/jj"
+
 type SelectedItem interface {
 	Equal(other SelectedItem) bool
 }
@@ -28,7 +30,7 @@ func (s SelectedRevision) Equal(other SelectedItem) bool {
 type SelectedFile struct {
 	ChangeId string
 	CommitId string
-	File     string
+	File     jj.FileName
 }
 
 func (s SelectedFile) Equal(other SelectedItem) bool {

--- a/internal/ui/context/main_context.go
+++ b/internal/ui/context/main_context.go
@@ -1,6 +1,7 @@
 package context
 
 import (
+	"os"
 	"reflect"
 	"slices"
 	"strings"
@@ -28,6 +29,7 @@ type MainContext struct {
 	SelectedItem              SelectedItem   // Single item where cursor is hover.
 	CheckedItems              []SelectedItem // Items checked ✓ by the user.
 	Location                  string
+	WorkingDirectory          string
 	JJConfig                  *config.JJConfig
 	DefaultRevset             string
 	CurrentRevset             string
@@ -41,13 +43,15 @@ type MainContext struct {
 }
 
 func NewAppContext(location string, aps *askpass.Server) *MainContext {
+	workingDirectory, _ := os.Getwd()
 	m := &MainContext{
 		CommandRunner: &MainCommandRunner{
 			Location: location,
 			Askpass:  aps,
 		},
-		Location:  location,
-		Histories: config.NewHistories(),
+		Location:         location,
+		WorkingDirectory: workingDirectory,
+		Histories:        config.NewHistories(),
 	}
 
 	m.JJConfig = &config.JJConfig{}
@@ -119,7 +123,7 @@ func (ctx *MainContext) CreateReplacements() map[string]string {
 	case SelectedFile:
 		replacements[jj.ChangeIdPlaceholder] = selectedItem.ChangeId
 		replacements[jj.CommitIdPlaceholder] = selectedItem.CommitId
-		replacements[jj.FilePlaceholder] = selectedItem.File
+		replacements[jj.FilePlaceholder] = selectedItem.File.Path()
 	case SelectedOperation:
 		replacements[jj.OperationIdPlaceholder] = selectedItem.OperationId
 	}
@@ -131,7 +135,7 @@ func (ctx *MainContext) CreateReplacements() map[string]string {
 		case SelectedRevision:
 			checkedRevisions = append(checkedRevisions, c.CommitId)
 		case SelectedFile:
-			checkedFiles = append(checkedFiles, c.File)
+			checkedFiles = append(checkedFiles, c.File.Path())
 		}
 	}
 

--- a/internal/ui/context/main_context_test.go
+++ b/internal/ui/context/main_context_test.go
@@ -1,11 +1,23 @@
 package context
 
 import (
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestNewAppContextCapturesWorkingDirectoryAndWorkspaceChangePreservesIt(t *testing.T) {
+	workingDirectory, err := os.Getwd()
+	require.NoError(t, err)
+	ctx := NewAppContext("/repo", nil)
+	assert.Equal(t, workingDirectory, ctx.WorkingDirectory)
+
+	ctx.ChangeWorkspace("/other/repo")
+	assert.Equal(t, "/other/repo", ctx.Location)
+	assert.Equal(t, workingDirectory, ctx.WorkingDirectory)
+}
 
 func TestChangeWorkspace(t *testing.T) {
 	runner := &MainCommandRunner{Location: "/old/path"}

--- a/internal/ui/diff/diff.go
+++ b/internal/ui/diff/diff.go
@@ -159,10 +159,10 @@ var _ common.ImmediateModel = (*Model)(nil)
 type Model struct {
 	context      *appContext.MainContext
 	originalArgs []string
-	targetFiles  []string
+	targetFiles  []jj.FileName
 	targetLoaded bool
 	targetErr    error
-	currentFile  string
+	currentFile  jj.FileName
 
 	lines        []string
 	maxLineWidth int
@@ -178,13 +178,13 @@ type targetPickerPayload struct{}
 
 type summaryLoadedMsg struct {
 	args  []string
-	files []string
+	files []jj.FileName
 	err   error
 }
 
 type fileLoadedMsg struct {
 	content string
-	file    string
+	file    jj.FileName
 	err     error
 }
 
@@ -238,7 +238,7 @@ func (m *Model) HandleIntent(intent intents.Intent) (tea.Cmd, bool) {
 		m.targetFiles = nil
 		m.targetLoaded = false
 		m.targetErr = nil
-		m.currentFile = ""
+		m.currentFile = jj.FileName{}
 		return m.Init(), true
 
 	case intents.DiffOpenTargetPicker:
@@ -295,11 +295,11 @@ func (m *Model) Init() tea.Cmd {
 		if err != nil {
 			return summaryLoadedMsg{args: originalArgs, err: err}
 		}
-		seen := map[string]bool{}
-		var files []string
+		seen := map[jj.FileName]bool{}
+		var files []jj.FileName
 		for _, line := range strings.Split(string(output), "\n") {
 			summary, ok := jj.ParseSummaryFile(line)
-			if !ok || summary.FileName == "" || seen[summary.FileName] {
+			if !ok || summary.FileName.IsEmpty() || seen[summary.FileName] {
 				continue
 			}
 			seen[summary.FileName] = true
@@ -375,7 +375,7 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 		if !slices.Equal(msg.args, m.originalArgs) {
 			return nil
 		}
-		m.targetFiles = append([]string(nil), msg.files...)
+		m.targetFiles = append([]jj.FileName(nil), msg.files...)
 		m.targetLoaded = msg.err == nil
 		m.targetErr = msg.err
 		return nil
@@ -391,9 +391,11 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 			return nil
 		}
 		if msg.Target == allFilesTargetLabel {
-			msg.Target = ""
+			msg.File = jj.FileName{}
+		} else if msg.File.IsEmpty() {
+			return nil
 		}
-		return m.loadFile(msg.Target)
+		return m.loadFile(msg.File)
 	}
 	return nil
 }
@@ -434,17 +436,19 @@ func (m *Model) openTargetPicker() tea.Cmd {
 	if len(m.targetFiles) == 0 {
 		return intents.Invoke(intents.AddMessage{Text: "No files found in diff summary"})
 	}
-	files := append([]string{allFilesTargetLabel}, m.targetFiles...)
-	return common.OpenTargetPickerWithPayload(targetPickerPayload{}, source.FileSource{Files: files})
+	return common.OpenTargetPickerWithPayload(targetPickerPayload{},
+		source.StaticSource{Items: []source.Item{{Name: allFilesTargetLabel}}},
+		source.FileSource{Files: m.targetFiles},
+	)
 }
 
-func (m *Model) loadFile(file string) tea.Cmd {
+func (m *Model) loadFile(file jj.FileName) tea.Cmd {
 	if len(m.originalArgs) == 0 || m.context == nil {
 		return intents.Invoke(intents.AddMessage{Text: "File picker is unavailable for this diff"})
 	}
 	args := append([]string(nil), m.originalArgs...)
-	if file != "" {
-		args = append(args, jj.EscapeFileName(file))
+	if !file.IsEmpty() {
+		args = append(args, file.Escaped())
 	}
 	return func() tea.Msg {
 		output, err := m.context.RunCommandImmediate(args)

--- a/internal/ui/diff/diff_test.go
+++ b/internal/ui/diff/diff_test.go
@@ -184,8 +184,8 @@ func TestTargetPickerUnavailableWithoutArgs(t *testing.T) {
 func TestTargetPickerLoadsSummaryFiles(t *testing.T) {
 	commandRunner := test.NewTestCommandRunner(t)
 	defer commandRunner.Verify()
-	args := jj.Diff("abc", "")
-	commandRunner.Expect(append(jj.Diff("abc", ""), "--summary")).SetOutput([]byte("M a.go\nA b.go\nR {old => new}/path.txt\nM a.go"))
+	args := jj.Diff("abc", jj.FileName{})
+	commandRunner.Expect(append(jj.Diff("abc", jj.FileName{}), "--summary")).SetOutput([]byte("M a.go\nA b.go\nR {old => new}/path.txt\nM a.go"))
 
 	model := NewWithContext(test.NewTestContext(commandRunner), "diff", args)
 	cmd := model.Init()
@@ -198,23 +198,25 @@ func TestTargetPickerLoadsSummaryFiles(t *testing.T) {
 	require.NotNil(t, openCmd)
 	openMsg, ok := openCmd().(common.OpenTargetPickerMsg)
 	require.True(t, ok)
-	require.Len(t, openMsg.Sources, 1)
-	items, err := openMsg.Sources[0].Fetch(nil)
+	require.Len(t, openMsg.Sources, 2)
+	staticItems, err := openMsg.Sources[0].Fetch(nil)
+	require.NoError(t, err)
+	assert.Equal(t, []source.Item{{Name: allFilesTargetLabel}}, staticItems)
+	items, err := openMsg.Sources[1].Fetch(nil)
 	require.NoError(t, err)
 	assert.Equal(t, []source.Item{
-		{Name: allFilesTargetLabel, Kind: source.KindFile},
-		{Name: "a.go", Kind: source.KindFile},
-		{Name: "b.go", Kind: source.KindFile},
-		{Name: "new/path.txt", Kind: source.KindFile},
+		{Name: "a.go", File: jj.NewFileName("a.go"), Kind: source.KindFile},
+		{Name: "b.go", File: jj.NewFileName("b.go"), Kind: source.KindFile},
+		{Name: "new/path.txt", File: jj.NewFileName("new/path.txt"), Kind: source.KindFile},
 	}, items)
 }
 
 func TestTargetPickerSelectedAllFilesLoadsOriginalDiff(t *testing.T) {
 	commandRunner := test.NewTestCommandRunner(t)
 	defer commandRunner.Verify()
-	args := jj.Diff("abc", "")
+	args := jj.Diff("abc", jj.FileName{})
 	commandRunner.Expect(args).SetOutput([]byte("all files diff"))
-	commandRunner.Expect(append(jj.Diff("abc", ""), "--summary")).SetOutput([]byte("M dir/a.go"))
+	commandRunner.Expect(append(jj.Diff("abc", jj.FileName{}), "--summary")).SetOutput([]byte("M dir/a.go"))
 
 	model := NewWithContext(test.NewTestContext(commandRunner), "file diff", args)
 	initCmd := model.Init()
@@ -235,15 +237,15 @@ func TestTargetPickerSelectedAllFilesLoadsOriginalDiff(t *testing.T) {
 	require.Nil(t, updateCmd)
 	assert.Equal(t, "all files diff", test.Stripped(test.RenderImmediate(model, 20, 3)))
 	assert.Equal(t, []string(args), model.originalArgs)
-	assert.Equal(t, "", model.currentFile)
+	assert.True(t, model.currentFile.IsEmpty())
 }
 
 func TestTargetPickerSelectedFileLoadsDiffAndKeepsOriginalArgs(t *testing.T) {
 	commandRunner := test.NewTestCommandRunner(t)
 	defer commandRunner.Verify()
-	args := jj.Diff("abc", "")
-	commandRunner.Expect(append(jj.Diff("abc", ""), jj.EscapeFileName("dir/a b.go"))).SetOutput([]byte("file diff"))
-	commandRunner.Expect(append(jj.Diff("abc", ""), "--summary")).SetOutput([]byte("M dir/a b.go"))
+	args := jj.Diff("abc", jj.FileName{})
+	commandRunner.Expect(append(jj.Diff("abc", jj.FileName{}), jj.NewFileName("dir/a b.go").Escaped())).SetOutput([]byte("file diff"))
+	commandRunner.Expect(append(jj.Diff("abc", jj.FileName{}), "--summary")).SetOutput([]byte("M dir/a b.go"))
 
 	model := NewWithContext(test.NewTestContext(commandRunner), "initial diff", args)
 	initCmd := model.Init()
@@ -253,7 +255,7 @@ func TestTargetPickerSelectedFileLoadsDiffAndKeepsOriginalArgs(t *testing.T) {
 	require.Nil(t, model.Update(loadedTargets))
 
 	cmd := model.Update(target_picker.TargetSelectedMsg{
-		Target:  "dir/a b.go",
+		File:    jj.NewFileName("dir/a b.go"),
 		Payload: targetPickerPayload{},
 	})
 	require.NotNil(t, cmd)
@@ -264,7 +266,7 @@ func TestTargetPickerSelectedFileLoadsDiffAndKeepsOriginalArgs(t *testing.T) {
 	require.Nil(t, updateCmd)
 	assert.Equal(t, "file diff", test.Stripped(test.RenderImmediate(model, 20, 3)))
 	assert.Equal(t, []string(args), model.originalArgs)
-	assert.Equal(t, "dir/a b.go", model.currentFile)
+	assert.Equal(t, "dir/a b.go", model.currentFile.Path())
 
 	summaryCmd := model.Update(intents.DiffOpenTargetPicker{})
 	require.NotNil(t, summaryCmd)
@@ -275,11 +277,11 @@ func TestTargetPickerSelectedFileLoadsDiffAndKeepsOriginalArgs(t *testing.T) {
 func TestFileNavigateLoadsAdjacentFilesAndWraps(t *testing.T) {
 	commandRunner := test.NewTestCommandRunner(t)
 	defer commandRunner.Verify()
-	args := jj.Diff("abc", "")
-	commandRunner.Expect(append(jj.Diff("abc", ""), "--summary")).SetOutput([]byte("M a.go\nM b.go\nM c.go"))
-	commandRunner.Expect(append(jj.Diff("abc", ""), jj.EscapeFileName("c.go"))).SetOutput([]byte("c diff"))
-	commandRunner.Expect(append(jj.Diff("abc", ""), jj.EscapeFileName("a.go"))).SetOutput([]byte("a diff"))
-	commandRunner.Expect(append(jj.Diff("abc", ""), jj.EscapeFileName("b.go"))).SetOutput([]byte("b diff"))
+	args := jj.Diff("abc", jj.FileName{})
+	commandRunner.Expect(append(jj.Diff("abc", jj.FileName{}), jj.NewFileName("c.go").Escaped())).SetOutput([]byte("c diff"))
+	commandRunner.Expect(append(jj.Diff("abc", jj.FileName{}), jj.NewFileName("a.go").Escaped())).SetOutput([]byte("a diff"))
+	commandRunner.Expect(append(jj.Diff("abc", jj.FileName{}), jj.NewFileName("b.go").Escaped())).SetOutput([]byte("b diff"))
+	commandRunner.Expect(append(jj.Diff("abc", jj.FileName{}), "--summary")).SetOutput([]byte("M a.go\nM b.go\nM c.go"))
 
 	model := NewWithContext(test.NewTestContext(commandRunner), "initial diff", args)
 	initCmd := model.Init()
@@ -294,7 +296,7 @@ func TestFileNavigateLoadsAdjacentFilesAndWraps(t *testing.T) {
 	require.True(t, ok)
 	require.Nil(t, model.Update(loaded))
 	assert.Equal(t, "c diff", test.Stripped(test.RenderImmediate(model, 20, 3)))
-	assert.Equal(t, "c.go", model.currentFile)
+	assert.Equal(t, "c.go", model.currentFile.Path())
 
 	cmd = model.Update(intents.DiffFileNavigate{Delta: 1})
 	require.NotNil(t, cmd)
@@ -302,7 +304,7 @@ func TestFileNavigateLoadsAdjacentFilesAndWraps(t *testing.T) {
 	require.True(t, ok)
 	require.Nil(t, model.Update(loaded))
 	assert.Equal(t, "a diff", test.Stripped(test.RenderImmediate(model, 20, 3)))
-	assert.Equal(t, "a.go", model.currentFile)
+	assert.Equal(t, "a.go", model.currentFile.Path())
 
 	cmd = model.Update(intents.DiffFileNavigate{Delta: 1})
 	require.NotNil(t, cmd)
@@ -310,7 +312,7 @@ func TestFileNavigateLoadsAdjacentFilesAndWraps(t *testing.T) {
 	require.True(t, ok)
 	require.Nil(t, model.Update(loaded))
 	assert.Equal(t, "b diff", test.Stripped(test.RenderImmediate(model, 20, 3)))
-	assert.Equal(t, "b.go", model.currentFile)
+	assert.Equal(t, "b.go", model.currentFile.Path())
 }
 
 func TestFileNavigateUnavailableWithoutArgs(t *testing.T) {

--- a/internal/ui/fuzzy_files/fuzzy_files.go
+++ b/internal/ui/fuzzy_files/fuzzy_files.go
@@ -87,7 +87,7 @@ func (fzf *fuzzyFiles) updateRevSet() tea.Cmd {
 	path := fzf.selectedPath()
 	revset := fzf.revset
 	if !path.IsEmpty() {
-		revset = fmt.Sprintf("files('%s')", path.Path())
+		revset = fmt.Sprintf("files(%s)", path.Escaped())
 	}
 	return common.UpdateRevSet(revset)
 }
@@ -109,7 +109,7 @@ func (fzf *fuzzyFiles) handleIntent(intent intents.Intent) tea.Cmd {
 	case intents.FileSearchEdit:
 		path := fzf.selectedPath()
 		return newCmd(common.ExecMsg{
-			Line: config.GetDefaultEditor() + " '" + path.Path() + "'",
+			Line: config.GetDefaultEditor() + " " + path.ShellEscaped(),
 			Mode: common.ExecShell,
 		})
 	case intents.FileSearchTogglePreview:

--- a/internal/ui/fuzzy_files/fuzzy_files.go
+++ b/internal/ui/fuzzy_files/fuzzy_files.go
@@ -31,9 +31,11 @@ type fuzzyFiles struct {
 	debounceTag   int
 
 	// search state
-	paths   []string
-	max     int
-	matches fuzzy.Matches
+	paths            []jj.FileName
+	repoRoot         string
+	workingDirectory string
+	max              int
+	matches          fuzzy.Matches
 }
 
 var debounceDuration = 250 * time.Millisecond
@@ -82,10 +84,10 @@ func (fzf *fuzzyFiles) Update(msg tea.Msg) tea.Cmd {
 }
 
 func (fzf *fuzzyFiles) updateRevSet() tea.Cmd {
-	path := fuzzy_search.SelectedMatch(fzf)
+	path := fzf.selectedPath()
 	revset := fzf.revset
-	if len(path) > 0 {
-		revset = fmt.Sprintf("files(%s)", path)
+	if !path.IsEmpty() {
+		revset = fmt.Sprintf("files('%s')", path.Path())
 	}
 	return common.UpdateRevSet(revset)
 }
@@ -105,9 +107,9 @@ func (fzf *fuzzyFiles) handleIntent(intent intents.Intent) tea.Cmd {
 	case intents.FileSearchCancel:
 		return common.UpdateRevSet(fzf.revset)
 	case intents.FileSearchEdit:
-		path := fuzzy_search.SelectedMatch(fzf)
+		path := fzf.selectedPath()
 		return newCmd(common.ExecMsg{
-			Line: config.GetDefaultEditor() + " " + path,
+			Line: config.GetDefaultEditor() + " '" + path.Path() + "'",
 			Mode: common.ExecShell,
 		})
 	case intents.FileSearchTogglePreview:
@@ -175,7 +177,18 @@ func (fzf *fuzzyFiles) String(i int) string {
 	if i < 0 || i >= n {
 		return ""
 	}
-	return fzf.paths[i]
+	return fzf.paths[i].Display(fzf.repoRoot, fzf.workingDirectory)
+}
+
+func (fzf *fuzzyFiles) selectedPath() jj.FileName {
+	if fzf.cursor < 0 || fzf.cursor >= len(fzf.matches) {
+		return jj.FileName{}
+	}
+	index := fzf.matches[fzf.cursor].Index
+	if index < 0 || index >= len(fzf.paths) {
+		return jj.FileName{}
+	}
+	return fzf.paths[index]
 }
 
 func (fzf *fuzzyFiles) search(input string) {
@@ -223,17 +236,19 @@ func (fzf *fuzzyFiles) viewContent() string {
 
 func NewModel(msg common.FileSearchMsg) fuzzy_search.Model {
 	model := &fuzzyFiles{
-		revset: msg.Revset,
-		max:    30,
-		commit: msg.Commit,
-		paths:  buildPathEntries(msg.RawFileOut),
+		revset:           msg.Revset,
+		max:              30,
+		commit:           msg.Commit,
+		paths:            buildPathEntries(msg.RawFileOut),
+		repoRoot:         msg.RepoRoot,
+		workingDirectory: msg.WorkingDirectory,
 	}
 	return model
 }
 
-func buildPathEntries(rawFileOut []byte) []string {
+func buildPathEntries(rawFileOut []byte) []jj.FileName {
 	lines := strings.Split(string(rawFileOut), "\n")
-	entries := make([]string, 0, len(lines))
+	entries := make([]jj.FileName, 0, len(lines))
 	seen := make(map[string]struct{}, len(lines))
 
 	add := func(entry string) {
@@ -244,7 +259,7 @@ func buildPathEntries(rawFileOut []byte) []string {
 			return
 		}
 		seen[entry] = struct{}{}
-		entries = append(entries, entry)
+		entries = append(entries, jj.NewFileName(entry))
 	}
 
 	for _, file := range lines {

--- a/internal/ui/fuzzy_files/fuzzy_files_test.go
+++ b/internal/ui/fuzzy_files/fuzzy_files_test.go
@@ -29,8 +29,7 @@ func TestUpdateRevSet_WithPath(t *testing.T) {
 	updateMsg, ok := msg.(common.UpdateRevSetMsg)
 	assert.True(t, ok)
 
-	// wrapped in single quotes by SelectedMatch in fuzzy_search
-	assert.Equal(t, "files('path/to/file2.go')", string(updateMsg))
+	assert.Equal(t, `files(file:"path/to/file2.go")`, string(updateMsg))
 }
 
 func TestUpdateRevSet_WithPathContainingSpaces(t *testing.T) {
@@ -49,8 +48,7 @@ func TestUpdateRevSet_WithPathContainingSpaces(t *testing.T) {
 	updateMsg, ok := msg.(common.UpdateRevSetMsg)
 	assert.True(t, ok)
 
-	// the whole path wrapped in single quotes
-	assert.Equal(t, "files('file with spaces.txt')", string(updateMsg))
+	assert.Equal(t, `files(file:"file with spaces.txt")`, string(updateMsg))
 }
 
 func TestUpdateRevSet_WithPathContainingBraces(t *testing.T) {
@@ -69,8 +67,7 @@ func TestUpdateRevSet_WithPathContainingBraces(t *testing.T) {
 	updateMsg, ok := msg.(common.UpdateRevSetMsg)
 	assert.True(t, ok)
 
-	// braces should be preserved and the whole path wrapped in single quotes
-	assert.Equal(t, "files('file{with}braces.txt')", string(updateMsg))
+	assert.Equal(t, `files(file:"file{with}braces.txt")`, string(updateMsg))
 }
 
 func TestUpdateRevSet_WithDirectory(t *testing.T) {
@@ -86,7 +83,7 @@ func TestUpdateRevSet_WithDirectory(t *testing.T) {
 	msg := cmd()
 	updateMsg, ok := msg.(common.UpdateRevSetMsg)
 	assert.True(t, ok)
-	assert.Equal(t, "files('path/to/')", string(updateMsg))
+	assert.Equal(t, `files(file:"path/to/")`, string(updateMsg))
 }
 
 func TestUpdateRevSet_NoPath(t *testing.T) {
@@ -145,10 +142,24 @@ func TestFileSearchDisplaysRelativePathsButUsesRepositoryPath(t *testing.T) {
 
 	assert.Equal(t, "ui/ui.go", model.String(0))
 	msg := model.updateRevSet()()
-	assert.Equal(t, "files('internal/ui/ui.go')", string(msg.(common.UpdateRevSetMsg)))
+	assert.Equal(t, `files(file:"internal/ui/ui.go")`, string(msg.(common.UpdateRevSetMsg)))
 
 	edit := model.handleIntent(intents.FileSearchEdit{})().(common.ExecMsg)
 	assert.Contains(t, edit.Line, " 'internal/ui/ui.go'")
+}
+
+func TestFileSearchSafelyEscapesApostrophes(t *testing.T) {
+	model := &fuzzyFiles{
+		revset:  "all()",
+		paths:   fileNames("it's complicated.go"),
+		matches: fuzzy.Matches{{Index: 0, Str: "it's complicated.go"}},
+	}
+
+	msg := model.updateRevSet()()
+	assert.Equal(t, `files(file:"it's complicated.go")`, string(msg.(common.UpdateRevSetMsg)))
+
+	edit := model.handleIntent(intents.FileSearchEdit{})().(common.ExecMsg)
+	assert.Contains(t, edit.Line, ` 'it'\''s complicated.go'`)
 }
 
 func fileNames(paths ...string) []jj.FileName {

--- a/internal/ui/fuzzy_files/fuzzy_files_test.go
+++ b/internal/ui/fuzzy_files/fuzzy_files_test.go
@@ -3,7 +3,9 @@ package fuzzy_files
 import (
 	"testing"
 
+	"github.com/idursun/jjui/internal/jj"
 	"github.com/idursun/jjui/internal/ui/common"
+	"github.com/idursun/jjui/internal/ui/intents"
 	"github.com/sahilm/fuzzy"
 	"github.com/stretchr/testify/assert"
 )
@@ -11,7 +13,7 @@ import (
 func TestUpdateRevSet_WithPath(t *testing.T) {
 	model := &fuzzyFiles{
 		revset: "all()",
-		paths:  []string{"file1.txt", "path/to/file2.go", "special file.txt"},
+		paths:  fileNames("file1.txt", "path/to/file2.go", "special file.txt"),
 	}
 
 	// a match being selected
@@ -34,7 +36,7 @@ func TestUpdateRevSet_WithPath(t *testing.T) {
 func TestUpdateRevSet_WithPathContainingSpaces(t *testing.T) {
 	model := &fuzzyFiles{
 		revset: "all()",
-		paths:  []string{"file with spaces.txt"},
+		paths:  fileNames("file with spaces.txt"),
 	}
 
 	model.matches = fuzzy.Matches{
@@ -54,7 +56,7 @@ func TestUpdateRevSet_WithPathContainingSpaces(t *testing.T) {
 func TestUpdateRevSet_WithPathContainingBraces(t *testing.T) {
 	model := &fuzzyFiles{
 		revset: "all()",
-		paths:  []string{"file{with}braces.txt"},
+		paths:  fileNames("file{with}braces.txt"),
 	}
 
 	model.matches = fuzzy.Matches{
@@ -74,7 +76,7 @@ func TestUpdateRevSet_WithPathContainingBraces(t *testing.T) {
 func TestUpdateRevSet_WithDirectory(t *testing.T) {
 	model := &fuzzyFiles{
 		revset: "all()",
-		paths:  []string{"path/to/"},
+		paths:  fileNames("path/to/"),
 	}
 
 	model.matches = fuzzy.Matches{{Index: 0, Str: "path/to/"}}
@@ -90,7 +92,7 @@ func TestUpdateRevSet_WithDirectory(t *testing.T) {
 func TestUpdateRevSet_NoPath(t *testing.T) {
 	model := &fuzzyFiles{
 		revset:  "all()",
-		paths:   []string{},
+		paths:   []jj.FileName{},
 		matches: fuzzy.Matches{},
 	}
 
@@ -106,7 +108,7 @@ func TestUpdateRevSet_NoPath(t *testing.T) {
 func TestUpdateRevSet_EmptyMatches(t *testing.T) {
 	model := &fuzzyFiles{
 		revset:  "@",
-		paths:   []string{"file1.txt"},
+		paths:   fileNames("file1.txt"),
 		matches: fuzzy.Matches{},
 		cursor:  0,
 	}
@@ -123,13 +125,38 @@ func TestUpdateRevSet_EmptyMatches(t *testing.T) {
 func TestBuildPathEntries_IncludesDirectories(t *testing.T) {
 	entries := buildPathEntries([]byte("src/pkg/main.go\nsrc/other.go\nREADME.md\n"))
 
-	assert.Equal(t, []string{
+	assert.Equal(t, fileNames(
 		"src/",
 		"src/pkg/",
 		"src/pkg/main.go",
 		"src/other.go",
 		"README.md",
-	}, entries)
+	), entries)
+}
+
+func TestFileSearchDisplaysRelativePathsButUsesRepositoryPath(t *testing.T) {
+	model := &fuzzyFiles{
+		revset:           "all()",
+		paths:            fileNames("internal/ui/ui.go"),
+		repoRoot:         "/work/repo",
+		workingDirectory: "/work/repo/internal",
+		matches:          fuzzy.Matches{{Index: 0, Str: "ui/ui.go"}},
+	}
+
+	assert.Equal(t, "ui/ui.go", model.String(0))
+	msg := model.updateRevSet()()
+	assert.Equal(t, "files('internal/ui/ui.go')", string(msg.(common.UpdateRevSetMsg)))
+
+	edit := model.handleIntent(intents.FileSearchEdit{})().(common.ExecMsg)
+	assert.Contains(t, edit.Line, " 'internal/ui/ui.go'")
+}
+
+func fileNames(paths ...string) []jj.FileName {
+	result := make([]jj.FileName, len(paths))
+	for i, path := range paths {
+		result[i] = jj.NewFileName(path)
+	}
+	return result
 }
 
 func TestBuildPathEntries_EmptyOutput(t *testing.T) {

--- a/internal/ui/intents/revisions_intents.go
+++ b/internal/ui/intents/revisions_intents.go
@@ -10,7 +10,7 @@ func (OpenDetails) isIntent() {}
 //jjui:bind scope=revisions action=open_squash
 type OpenSquash struct {
 	Selected jj.SelectedRevisions
-	Files    []string
+	Files    []jj.FileName
 }
 
 func (OpenSquash) isIntent() {}
@@ -66,7 +66,7 @@ type StartSplit struct {
 	Selected      *jj.Commit
 	IsParallel    bool
 	IsInteractive bool
-	Files         []string
+	Files         []jj.FileName
 }
 
 func (StartSplit) isIntent() {}

--- a/internal/ui/operations/details/details.go
+++ b/internal/ui/operations/details/details.go
@@ -23,7 +23,7 @@ import (
 
 type updateCommitStatusMsg struct {
 	summary       string
-	selectedFiles []string
+	selectedFiles []jj.FileName
 }
 
 type filterState uint8
@@ -220,7 +220,7 @@ func (s *Operation) HandleIntent(intent intents.Intent) (tea.Cmd, bool) {
 			return nil, true
 		}
 		return func() tea.Msg {
-			args := jj.Diff(s.revision.GetChangeId(), "")
+			args := jj.Diff(s.revision.GetChangeId(), jj.FileName{})
 			output, _ := s.context.RunCommandImmediate(jj.Diff(s.revision.GetChangeId(), selected.fileName))
 			return intents.DiffShow{Content: string(output), Args: args}
 		}, true
@@ -306,12 +306,12 @@ func (s *Operation) HandleIntent(intent intents.Intent) (tea.Cmd, bool) {
 		return nil, true
 	case intents.DetailsRevisionsChangingFile:
 		if current := s.current(); current != nil {
-			return tea.Batch(common.Close, common.UpdateRevSet(fmt.Sprintf("files(%s)", jj.EscapeFileName(current.fileName)))), true
+			return tea.Batch(common.Close, common.UpdateRevSet(fmt.Sprintf("files(%s)", current.fileName.Escaped()))), true
 		}
 		return nil, true
 	case intents.DetailsSelectFile:
 		for i := range s.files {
-			if s.files[i].fileName == intent.File {
+			if s.files[i].fileName.Path() == intent.File {
 				s.files[i].selected = true
 				break
 			}
@@ -335,7 +335,7 @@ func (s *Operation) Selection() common.SelectionSnapshot {
 	return snapshot
 }
 
-func (s *Operation) selectedFile(file string) context.SelectedFile {
+func (s *Operation) selectedFile(file jj.FileName) context.SelectedFile {
 	return context.SelectedFile{
 		ChangeId: s.revision.GetChangeId(),
 		CommitId: s.revision.CommitId,
@@ -479,8 +479,8 @@ func (s *Operation) Name() string {
 	return "details"
 }
 
-func (s *Operation) getSelectedFiles(allowVirtualSelection bool) []string {
-	selectedFiles := make([]string, 0)
+func (s *Operation) getSelectedFiles(allowVirtualSelection bool) []jj.FileName {
+	selectedFiles := make([]jj.FileName, 0)
 	if len(s.files) == 0 {
 		return selectedFiles
 	}
@@ -498,7 +498,7 @@ func (s *Operation) getSelectedFiles(allowVirtualSelection bool) []string {
 	return selectedFiles
 }
 
-func (s *Operation) createListItems(content string, selectedFiles []string) []*item {
+func (s *Operation) createListItems(content string, selectedFiles []jj.FileName) []*item {
 	var items []*item
 	scanner := bufio.NewScanner(strings.NewReader(content))
 	scanner.Split(bufio.ScanWords)
@@ -538,9 +538,9 @@ func (s *Operation) createListItems(content string, selectedFiles []string) []*i
 		}
 		items = append(items, &item{
 			status:   status,
-			name:     summary.Name,
+			name:     summary.Display(s.context.Location, s.context.WorkingDirectory),
 			fileName: summary.FileName,
-			selected: slices.ContainsFunc(selectedFiles, func(s string) bool { return s == summary.FileName }),
+			selected: slices.Contains(selectedFiles, summary.FileName),
 			conflict: conflicts[index],
 		})
 		index++

--- a/internal/ui/operations/details/details_list.go
+++ b/internal/ui/operations/details/details_list.go
@@ -6,6 +6,7 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
+	"github.com/idursun/jjui/internal/jj"
 	"github.com/idursun/jjui/internal/ui/common"
 	"github.com/idursun/jjui/internal/ui/layout"
 	"github.com/idursun/jjui/internal/ui/render"
@@ -56,7 +57,7 @@ func NewDetailsList() *DetailsList {
 }
 
 func (d *DetailsList) setItems(files []*item) {
-	currentFile := ""
+	currentFile := jj.FileName{}
 	if current := d.current(); current != nil {
 		currentFile = current.fileName
 	}
@@ -67,7 +68,7 @@ func (d *DetailsList) setItems(files []*item) {
 }
 
 func (d *DetailsList) setFilter(query string, enabled bool) {
-	currentFile := ""
+	currentFile := jj.FileName{}
 	if current := d.current(); current != nil {
 		currentFile = current.fileName
 	}
@@ -78,7 +79,7 @@ func (d *DetailsList) setFilter(query string, enabled bool) {
 	d.ensureCursorView = true
 }
 
-func (d *DetailsList) rebuildMatches(preferredFile string) {
+func (d *DetailsList) rebuildMatches(preferredFile jj.FileName) {
 	if d.filtering {
 		d.matches = nil
 		query := strings.TrimSpace(d.filterQuery)
@@ -97,7 +98,7 @@ func (d *DetailsList) rebuildMatches(preferredFile string) {
 		d.cursor = -1
 		return
 	}
-	if preferredFile != "" {
+	if !preferredFile.IsEmpty() {
 		for index := range visibleLen {
 			if candidate := d.itemAt(index); candidate != nil && candidate.fileName == preferredFile {
 				d.cursor = index

--- a/internal/ui/operations/details/details_list_test.go
+++ b/internal/ui/operations/details/details_list_test.go
@@ -6,6 +6,7 @@ import (
 
 	"charm.land/lipgloss/v2"
 	"github.com/idursun/jjui/internal/config"
+	"github.com/idursun/jjui/internal/jj"
 	"github.com/idursun/jjui/internal/ui/common"
 	"github.com/idursun/jjui/internal/ui/layout"
 	"github.com/idursun/jjui/internal/ui/render"
@@ -16,8 +17,8 @@ import (
 func TestDetailsList_RenderFileListShowsCheckedAndUncheckedHints(t *testing.T) {
 	list := NewDetailsList()
 	list.files = []*item{
-		{status: Modified, name: "checked.txt", fileName: "checked.txt", selected: true},
-		{status: Added, name: "unchecked.txt", fileName: "unchecked.txt"},
+		{status: Modified, name: "checked.txt", fileName: jj.NewFileName("checked.txt"), selected: true},
+		{status: Added, name: "unchecked.txt", fileName: jj.NewFileName("unchecked.txt")},
 	}
 	list.cursor = 1
 	list.selectedHint = "stays as is"
@@ -52,9 +53,9 @@ func TestDetailsList_SelectedDeletedKeepsStatusForeground(t *testing.T) {
 func TestDetailsList_FilterUsesMatchesAsVisibleRows(t *testing.T) {
 	list := NewDetailsList()
 	list.setItems([]*item{
-		{status: Modified, name: "cmd/jjui/main.go", fileName: "cmd/jjui/main.go"},
-		{status: Modified, name: "internal/ui/details.go", fileName: "internal/ui/details.go", selected: true},
-		{status: Modified, name: "docs/configuration.md", fileName: "docs/configuration.md"},
+		{status: Modified, name: "cmd/jjui/main.go", fileName: jj.NewFileName("cmd/jjui/main.go")},
+		{status: Modified, name: "internal/ui/details.go", fileName: jj.NewFileName("internal/ui/details.go"), selected: true},
+		{status: Modified, name: "docs/configuration.md", fileName: jj.NewFileName("docs/configuration.md")},
 	})
 	list.setCursor(1)
 
@@ -62,33 +63,33 @@ func TestDetailsList_FilterUsesMatchesAsVisibleRows(t *testing.T) {
 
 	assert.Equal(t, 1, list.VisibleLen())
 	require.NotNil(t, list.current())
-	assert.Equal(t, "internal/ui/details.go", list.current().fileName)
+	assert.Equal(t, "internal/ui/details.go", list.current().fileName.Path())
 	assert.True(t, list.files[1].selected, "filtering must preserve checked state on source items")
 }
 
 func TestDetailsList_FilterRequiresContiguousSubstringAndPreservesOrder(t *testing.T) {
 	list := NewDetailsList()
 	list.setItems([]*item{
-		{status: Modified, name: "internal/ui/ui_test.go", fileName: "internal/ui/ui_test.go"},
-		{status: Modified, name: "internal/ui/intents/details_intents.go", fileName: "internal/ui/intents/details_intents.go"},
-		{status: Modified, name: "internal/ui/intents/other.go", fileName: "internal/ui/intents/other.go"},
+		{status: Modified, name: "internal/ui/ui_test.go", fileName: jj.NewFileName("internal/ui/ui_test.go")},
+		{status: Modified, name: "internal/ui/intents/details_intents.go", fileName: jj.NewFileName("internal/ui/intents/details_intents.go")},
+		{status: Modified, name: "internal/ui/intents/other.go", fileName: jj.NewFileName("internal/ui/intents/other.go")},
 	})
 	list.setCursor(2)
 
 	list.setFilter("intents", true)
 
 	assert.Equal(t, 2, list.VisibleLen())
-	assert.Equal(t, "internal/ui/intents/details_intents.go", list.itemAt(0).fileName)
-	assert.Equal(t, "internal/ui/intents/other.go", list.itemAt(1).fileName)
+	assert.Equal(t, "internal/ui/intents/details_intents.go", list.itemAt(0).fileName.Path())
+	assert.Equal(t, "internal/ui/intents/other.go", list.itemAt(1).fileName.Path())
 	require.NotNil(t, list.current())
-	assert.Equal(t, "internal/ui/intents/other.go", list.current().fileName)
+	assert.Equal(t, "internal/ui/intents/other.go", list.current().fileName.Path())
 }
 
 func TestDetailsList_FilterMapsSelectionToSourceItem(t *testing.T) {
 	list := NewDetailsList()
 	list.setItems([]*item{
-		{status: Modified, name: "one.txt", fileName: "one.txt"},
-		{status: Modified, name: "two.txt", fileName: "two.txt"},
+		{status: Modified, name: "one.txt", fileName: jj.NewFileName("one.txt")},
+		{status: Modified, name: "two.txt", fileName: jj.NewFileName("two.txt")},
 	})
 	list.setFilter("two", true)
 
@@ -100,7 +101,7 @@ func TestDetailsList_FilterMapsSelectionToSourceItem(t *testing.T) {
 
 func TestDetailsList_FilterWithNoMatchesHasNoCurrentItem(t *testing.T) {
 	list := NewDetailsList()
-	list.setItems([]*item{{status: Modified, name: "file.txt", fileName: "file.txt"}})
+	list.setItems([]*item{{status: Modified, name: "file.txt", fileName: jj.NewFileName("file.txt")}})
 
 	list.setFilter("missing", true)
 

--- a/internal/ui/operations/details/details_test.go
+++ b/internal/ui/operations/details/details_test.go
@@ -42,8 +42,8 @@ func TestOperation_InitLoadsStatus(t *testing.T) {
 	operation := loadOperation(t, commandRunner, statusOutput)
 
 	require.Len(t, operation.files, 2)
-	assert.Equal(t, "file.txt", operation.files[0].fileName)
-	assert.Equal(t, "newfile.txt", operation.files[1].fileName)
+	assert.Equal(t, "file.txt", operation.files[0].fileName.Path())
+	assert.Equal(t, "newfile.txt", operation.files[1].fileName.Path())
 }
 
 func TestOperation_Restore(t *testing.T) {
@@ -59,7 +59,7 @@ func TestOperation_Restore(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			commandRunner := test.NewTestCommandRunner(t)
 			t.Cleanup(commandRunner.Verify)
-			commandRunner.Expect(jj.Restore(revision, []string{"file.txt"}, tt.interactive))
+			commandRunner.Expect(jj.Restore(revision, []jj.FileName{jj.NewFileName("file.txt")}, tt.interactive))
 			operation := loadOperation(t, commandRunner, statusOutput)
 
 			if tt.checkFile {
@@ -84,7 +84,7 @@ func TestOperation_Split(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			commandRunner := test.NewTestCommandRunner(t)
 			t.Cleanup(commandRunner.Verify)
-			commandRunner.Expect(jj.Split(revision, []string{"file.txt"}, tt.isParallel, false))
+			commandRunner.Expect(jj.Split(revision, []jj.FileName{jj.NewFileName("file.txt")}, tt.isParallel, false))
 			operation := loadOperation(t, commandRunner, statusOutput)
 
 			test.SimulateModel(operation, func() tea.Msg { return intents.DetailsToggleSelect{} })
@@ -120,7 +120,7 @@ func TestOperation_HandleIntentUpdatesSelectionAfterNavigation(t *testing.T) {
 
 	selected, ok := operation.Selection().Highlighted.(common.SelectedFile)
 	require.True(t, ok)
-	assert.Equal(t, "file.txt", selected.File)
+	assert.Equal(t, "file.txt", selected.File.Path())
 
 	cmd, handled := operation.HandleIntent(intents.DetailsNavigate{Delta: 1})
 	require.True(t, handled)
@@ -128,7 +128,7 @@ func TestOperation_HandleIntentUpdatesSelectionAfterNavigation(t *testing.T) {
 
 	selected, ok = operation.Selection().Highlighted.(common.SelectedFile)
 	require.True(t, ok)
-	assert.Equal(t, "newfile.txt", selected.File)
+	assert.Equal(t, "newfile.txt", selected.File.Path())
 }
 
 func TestOperation_FilterLifecycle(t *testing.T) {
@@ -145,7 +145,7 @@ func TestOperation_FilterLifecycle(t *testing.T) {
 	operation.Update(tea.PasteMsg{Content: "new"})
 	assert.Equal(t, 1, operation.VisibleLen())
 	require.NotNil(t, operation.current())
-	assert.Equal(t, "newfile.txt", operation.current().fileName)
+	assert.Equal(t, "newfile.txt", operation.current().fileName.Path())
 
 	_, handled = operation.HandleIntent(intents.DetailsApplyFilter{})
 	require.True(t, handled)
@@ -169,12 +169,12 @@ func TestOperation_FilterKeepsHiddenCheckedFilesInActions(t *testing.T) {
 	operation.files[0].selected = true
 	operation.setFilter("new", true)
 
-	assert.Equal(t, []string{"file.txt"}, operation.getSelectedFiles(true))
+	assert.Equal(t, []jj.FileName{jj.NewFileName("file.txt")}, operation.getSelectedFiles(true))
 	selection := operation.Selection()
 	require.Len(t, selection.Checked, 1)
 	checked, ok := selection.Checked[0].(uiContext.SelectedFile)
 	require.True(t, ok)
-	assert.Equal(t, "file.txt", checked.File)
+	assert.Equal(t, "file.txt", checked.File.Path())
 }
 
 func TestOperation_FilterNoMatchesRendersInsideDetails(t *testing.T) {
@@ -206,13 +206,29 @@ M modified.txt
 R src/{old => renamed}.txt
 C copied.txt`
 
-	got := operation.createListItems(content, []string{"deleted.txt"})
+	got := operation.createListItems(content, []jj.FileName{jj.NewFileName("deleted.txt")})
 
 	assert.Equal(t, []*item{
-		{status: Added, name: "added.txt", fileName: "added.txt", conflict: true},
-		{status: Deleted, name: "deleted.txt", fileName: "deleted.txt", selected: true},
-		{status: Modified, name: "modified.txt", fileName: "modified.txt", conflict: true},
-		{status: Renamed, name: "src/{old => renamed}.txt", fileName: "src/renamed.txt"},
-		{status: Copied, name: "copied.txt", fileName: "copied.txt", conflict: true},
+		{status: Added, name: "added.txt", fileName: jj.NewFileName("added.txt"), conflict: true},
+		{status: Deleted, name: "deleted.txt", fileName: jj.NewFileName("deleted.txt"), selected: true},
+		{status: Modified, name: "modified.txt", fileName: jj.NewFileName("modified.txt"), conflict: true},
+		{status: Renamed, name: "src/{ol => rename}d.txt", fileName: jj.NewFileName("src/renamed.txt")},
+		{status: Copied, name: "copied.txt", fileName: jj.NewFileName("copied.txt"), conflict: true},
 	}, got)
+}
+
+func TestOperationDisplaysWorkingDirectoryRelativeNamesButSelectsRepositoryPath(t *testing.T) {
+	ctx := test.NewTestContext(test.NewTestCommandRunner(t))
+	ctx.Location = "/work/repo"
+	ctx.WorkingDirectory = "/work/repo/internal"
+	operation := NewOperation(ctx, commit)
+
+	items := operation.createListItems("false $\nM internal/ui/details.go\n", nil)
+	require.Len(t, items, 1)
+	assert.Equal(t, "ui/details.go", items[0].name)
+	assert.Equal(t, "internal/ui/details.go", items[0].fileName.Path())
+
+	operation.setItems(items)
+	selected := operation.Selection().Highlighted.(common.SelectedFile)
+	assert.Equal(t, "internal/ui/details.go", selected.File.Path())
 }

--- a/internal/ui/operations/details/item.go
+++ b/internal/ui/operations/details/item.go
@@ -2,6 +2,8 @@ package details
 
 import (
 	"fmt"
+
+	"github.com/idursun/jjui/internal/jj"
 )
 
 type status uint8
@@ -17,7 +19,7 @@ const (
 type item struct {
 	status   status
 	name     string
-	fileName string
+	fileName jj.FileName
 	selected bool
 	conflict bool
 }

--- a/internal/ui/operations/evolog/evolog_operation.go
+++ b/internal/ui/operations/evolog/evolog_operation.go
@@ -161,7 +161,7 @@ func (o *Operation) HandleIntent(intent intents.Intent) (tea.Cmd, bool) {
 		}
 		return func() tea.Msg {
 			selectedCommitId := o.getSelectedEvolog().CommitId
-			args := jj.Diff(selectedCommitId, "")
+			args := jj.Diff(selectedCommitId, jj.FileName{})
 			output, _ := o.context.RunCommandImmediate(args)
 			return intents.DiffShow{Content: string(output), Args: args}
 		}, true

--- a/internal/ui/operations/squash/squash_operation.go
+++ b/internal/ui/operations/squash/squash_operation.go
@@ -26,7 +26,7 @@ var (
 type Operation struct {
 	context               *context.MainContext
 	from                  jj.SelectedRevisions
-	files                 []string
+	files                 []jj.FileName
 	current               *jj.Commit
 	targetName            string
 	keepEmptied           bool
@@ -155,7 +155,7 @@ func (s *Operation) targetArg() string {
 
 type Option func(*Operation)
 
-func WithFiles(files []string) Option {
+func WithFiles(files []jj.FileName) Option {
 	return func(op *Operation) {
 		op.files = files
 	}

--- a/internal/ui/operations/target_picker/target_picker.go
+++ b/internal/ui/operations/target_picker/target_picker.go
@@ -27,6 +27,7 @@ const (
 
 type Item struct {
 	Name string
+	File jj.FileName
 	Kind source.Kind
 }
 
@@ -73,6 +74,7 @@ func (m itemScrollMsg) SetDelta(delta int, horizontal bool) tea.Msg {
 
 type TargetSelectedMsg struct {
 	Target  string
+	File    jj.FileName
 	Force   bool
 	Payload any
 }
@@ -286,7 +288,11 @@ func (m *Model) fetchItems() tea.Cmd {
 		sourceItems := source.FetchAll(m.context.RunCommandImmediate, m.sources...)
 		items := make([]Item, len(sourceItems))
 		for i, si := range sourceItems {
-			items[i] = Item{Name: si.Name, Kind: si.Kind}
+			name := si.Name
+			if !si.File.IsEmpty() {
+				name = si.File.Display(m.context.Location, m.context.WorkingDirectory)
+			}
+			items[i] = Item{Name: name, File: si.File, Kind: si.Kind}
 		}
 		return itemsLoadedMsg{items: items}
 	}
@@ -336,7 +342,14 @@ func (m *Model) cursorDown() {
 func (m *Model) accept(force bool) tea.Cmd {
 	if m.cursor >= 0 && m.cursor < len(m.matches) {
 		item := m.items[m.matches[m.cursor].Index]
-		return func() tea.Msg { return TargetSelectedMsg{Target: item.Name, Force: force, Payload: m.payload} }
+		if !item.File.IsEmpty() {
+			return func() tea.Msg {
+				return TargetSelectedMsg{File: item.File, Force: force, Payload: m.payload}
+			}
+		}
+		return func() tea.Msg {
+			return TargetSelectedMsg{Target: item.Name, Force: force, Payload: m.payload}
+		}
 	}
 	if input := strings.TrimSpace(m.input.Value()); input != "" {
 		return func() tea.Msg { return TargetSelectedMsg{Target: input, Force: force, Payload: m.payload} }

--- a/internal/ui/operations/target_picker/target_picker_test.go
+++ b/internal/ui/operations/target_picker/target_picker_test.go
@@ -1,0 +1,30 @@
+package target_picker
+
+import (
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/idursun/jjui/internal/jj"
+	"github.com/idursun/jjui/internal/jj/source"
+	jjuitest "github.com/idursun/jjui/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFileItemUsesDisplayLabelAndTypedSelection(t *testing.T) {
+	ctx := jjuitest.NewTestContext(jjuitest.NewTestCommandRunner(t))
+	ctx.Location = "/work/repo"
+	ctx.WorkingDirectory = "/work/repo/internal"
+	model := NewModel(ctx, nil, source.FileSource{Files: []jj.FileName{jj.NewFileName("internal/ui/ui.go")}})
+
+	loaded, ok := model.Init()().(itemsLoadedMsg)
+	require.True(t, ok)
+	jjuitest.SimulateModel(model, func() tea.Msg { return loaded })
+	require.Len(t, model.items, 1)
+	assert.Equal(t, "ui/ui.go", model.items[0].Name)
+
+	selected, ok := model.accept(false)().(TargetSelectedMsg)
+	require.True(t, ok)
+	assert.Empty(t, selected.Target)
+	assert.Equal(t, "internal/ui/ui.go", selected.File.Path())
+}

--- a/internal/ui/preview/preview.go
+++ b/internal/ui/preview/preview.go
@@ -206,7 +206,7 @@ func (m *Model) refreshPreviewForItem(item common.SelectedItem) tea.Cmd {
 				jj.RevsetPlaceholder:       m.context.CurrentRevset,
 				jj.ChangeIdPlaceholder:     sel.ChangeId,
 				jj.CommitIdPlaceholder:     sel.CommitId,
-				jj.FilePlaceholder:         sel.File,
+				jj.FilePlaceholder:         sel.File.Path(),
 				jj.PreviewWidthPlaceholder: previewWidth,
 			})
 		case common.SelectedRevision:

--- a/internal/ui/revisions/revisions.go
+++ b/internal/ui/revisions/revisions.go
@@ -1136,7 +1136,7 @@ func (m *Model) showDiff(intent intents.ShowDiff) tea.Cmd {
 	}
 	changeId := commit.GetChangeId()
 	return func() tea.Msg {
-		args := jj.Diff(changeId, "")
+		args := jj.Diff(changeId, jj.FileName{})
 		output, _ := m.context.RunCommandImmediate(args)
 		return intents.DiffShow{Content: string(output), Args: args}
 	}

--- a/internal/ui/revisions/revisions_test.go
+++ b/internal/ui/revisions/revisions_test.go
@@ -100,7 +100,7 @@ func (o *viewRectTrackingOp) Selection() common.SelectionSnapshot {
 			Highlighted: common.SelectedFile{
 				ChangeId: o.selectedRevision.GetChangeId(),
 				CommitId: o.selectedRevision.CommitId,
-				File:     o.selectedFile,
+				File:     jj.NewFileName(o.selectedFile),
 			},
 		}
 	}
@@ -357,7 +357,7 @@ func TestModel_UpdateRevisionsRefreshesDetailsSelection(t *testing.T) {
 	assert.True(t, ok, "refresh should keep details selection type while details is active")
 	assert.Equal(t, "a", selected.ChangeId)
 	assert.Equal(t, "10", selected.CommitId)
-	assert.Equal(t, "file.txt", selected.File)
+	assert.Equal(t, "file.txt", selected.File.Path())
 }
 
 func TestModel_UpdateRevisionsPreservesViewportOnKeepSelectionRefresh(t *testing.T) {

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -632,7 +632,7 @@ func (m *Model) HandleIntent(intent intents.Intent) (tea.Cmd, bool) {
 			return nil, true
 		}
 		out, _ := m.context.RunCommandImmediate(jj.FilesInRevision(rev))
-		return common.FileSearch(m.context.CurrentRevset, rev, out), true
+		return common.FileSearch(m.context.CurrentRevset, rev, out, m.context.Location, m.context.WorkingDirectory), true
 
 	// --- Delegated intents ---
 	case intents.DiffShow:

--- a/internal/ui/ui_test.go
+++ b/internal/ui/ui_test.go
@@ -1174,10 +1174,10 @@ func Test_Update_OpenTargetPickerWhileDiffActiveCreatesRootOverlay(t *testing.T)
 
 	ctx := test.NewTestContext(commandRunner)
 	model := NewUI(ctx)
-	model.diff = diff.NewWithContext(ctx, "diff content", jj.Diff("abc123", ""))
+	model.diff = diff.NewWithContext(ctx, "diff content", jj.Diff("abc123", jj.FileName{}))
 
 	cmd := model.Update(common.OpenTargetPickerMsg{
-		Sources: []source.Source{source.FileSource{Files: []string{"a.go"}}},
+		Sources: []source.Source{source.FileSource{Files: []jj.FileName{jj.NewFileName("a.go")}}},
 	})
 	require.NotNil(t, cmd)
 	test.SimulateModel(model, cmd)
@@ -1197,20 +1197,20 @@ func Test_Update_DiffTargetPickerClosesOnSelectionAndCancel(t *testing.T) {
 
 	ctx := test.NewTestContext(commandRunner)
 	model := NewUI(ctx)
-	model.diff = diff.NewWithContext(ctx, "diff content", jj.Diff("abc123", ""))
+	model.diff = diff.NewWithContext(ctx, "diff content", jj.Diff("abc123", jj.FileName{}))
 
 	cmd := model.Update(common.OpenTargetPickerMsg{
-		Sources: []source.Source{source.FileSource{Files: []string{"a.go"}}},
+		Sources: []source.Source{source.FileSource{Files: []jj.FileName{jj.NewFileName("a.go")}}},
 	})
 	require.NotNil(t, cmd)
 	test.SimulateModel(model, cmd)
 	require.NotNil(t, model.stacked)
 
-	model.Update(target_picker.TargetSelectedMsg{Target: "a.go"})
+	model.Update(target_picker.TargetSelectedMsg{File: jj.NewFileName("a.go")})
 	assert.Nil(t, model.stacked)
 
 	cmd = model.Update(common.OpenTargetPickerMsg{
-		Sources: []source.Source{source.FileSource{Files: []string{"a.go"}}},
+		Sources: []source.Source{source.FileSource{Files: []jj.FileName{jj.NewFileName("a.go")}}},
 	})
 	require.NotNil(t, cmd)
 	test.SimulateModel(model, cmd)


### PR DESCRIPTION
Renders files relative to the current working directory as described as requested in the referenced issue.

<img width="621" height="600" alt="image" src="https://github.com/user-attachments/assets/67a7c356-ebba-4d95-9417-7ec7c2cb9402" />


fixes #719