### PR TITLE
Feat: Add config option to show just the basename in title

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -186,7 +186,7 @@ type UIConfig struct {
 	Theme           ThemeConfig           `toml:"theme"`
 	Colors          map[string]Color      `toml:"colors"`
 	BackgroundBlend BackgroundBlendConfig `toml:"background_blend"`
-	SetWindowTitle  bool                  `toml:"set_window_title"`
+	SetWindowTitle  WindowTitleMode       `toml:"set_window_title"`
 	// TODO(ilyagr): It might make sense to rename this to `auto_refresh_period` to match `--period` option
 	// once we have a mechanism to deprecate the old name softly.
 	AutoRefreshInterval        int  `toml:"auto_refresh_interval"`
@@ -196,6 +196,40 @@ type UIConfig struct {
 
 func GetExpiringFlashMessageTimeout(c *Config) time.Duration {
 	return time.Duration(c.UI.FlashMessageDisplaySeconds) * time.Second
+}
+
+// WindowTitleMode controls the terminal window title. It accepts a boolean
+// (true shows the full repo path, false disables the title) or the string
+// "base" to show only the directory name.
+type WindowTitleMode int
+
+const (
+	WindowTitleOff WindowTitleMode = iota
+	WindowTitleFull
+	WindowTitleBase
+)
+
+func (m *WindowTitleMode) UnmarshalTOML(data any) error {
+	switch value := data.(type) {
+	case bool:
+		if value {
+			*m = WindowTitleFull
+		} else {
+			*m = WindowTitleOff
+		}
+	case string:
+		switch value {
+		case "base":
+			*m = WindowTitleBase
+		case "full":
+			*m = WindowTitleFull
+		default:
+			return fmt.Errorf("invalid value for 'set_window_title': %q (expected one of: true, false, 'base', 'full')", value)
+		}
+	default:
+		return fmt.Errorf("invalid type for 'set_window_title': expected boolean or string, got %T", data)
+	}
+	return nil
 }
 
 type RevisionsConfig struct {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,12 +1,43 @@
 package config
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestLoad_SetWindowTitle(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    string
+		expected WindowTitleMode
+		wantErr  bool
+	}{
+		{"true", "true", WindowTitleFull, false},
+		{"false", "false", WindowTitleOff, false},
+		{"base", `"base"`, WindowTitleBase, false},
+		{"full", `"full"`, WindowTitleFull, false},
+		{"invalid", `"bogus"`, WindowTitleOff, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &Config{}
+			err := cfg.Load(fmt.Sprintf(`
+[ui]
+set_window_title = %s
+`, tt.value), "")
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expected, cfg.UI.SetWindowTitle)
+			}
+		})
+	}
+}
 
 func TestLoad_Theme_Simple(t *testing.T) {
 	content := `

--- a/internal/config/default/config.toml
+++ b/internal/config/default/config.toml
@@ -6,6 +6,11 @@ bindings_profile = ":builtin"
   theme = ""
   # background_blend = 0.4 # optional; overrides both variants of the selected theme (0.0 to 1.0)
   # background_blend = { light = 0.2, dark = 0.4 } # optional per-variant overrides
+  # set_window_title controls the terminal window title:
+  #   true    - show the full repo path (default)
+  #   "full"  - same as true
+  #   "base"  - show only the directory name
+  #   false   - disable the title
   set_window_title = true
   auto_refresh_interval = 0
   flash_message_display_seconds = 4 # 0 means display until manually dismissed

--- a/internal/config/loader_test.go
+++ b/internal/config/loader_test.go
@@ -293,7 +293,7 @@ key = "esc"
 func TestLoadDefaultConfig_SetsWindowTitleByDefault(t *testing.T) {
 	cfg := loadDefaultConfig()
 
-	assert.True(t, cfg.UI.SetWindowTitle)
+	assert.Equal(t, WindowTitleFull, cfg.UI.SetWindowTitle)
 }
 
 func TestLoad_UISetWindowTitleCanBeDisabled(t *testing.T) {
@@ -304,7 +304,30 @@ func TestLoad_UISetWindowTitleCanBeDisabled(t *testing.T) {
 set_window_title = false
 `, ""))
 
-	assert.False(t, cfg.UI.SetWindowTitle)
+	assert.Equal(t, WindowTitleOff, cfg.UI.SetWindowTitle)
+}
+
+func TestLoad_UISetWindowTitleStringValues(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    string
+		expected WindowTitleMode
+	}{
+		{"base", "base", WindowTitleBase},
+		{"full", "full", WindowTitleFull},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := loadDefaultConfig()
+
+			require.NoError(t, cfg.Load(fmt.Sprintf(`
+[ui]
+set_window_title = %q
+`, tt.value), ""))
+
+			assert.Equal(t, tt.expected, cfg.UI.SetWindowTitle)
+		})
+	}
 }
 
 func TestLoad_SeqBindingDoesNotInheritStaleKey(t *testing.T) {
@@ -348,7 +371,7 @@ scope = "revisions"
 action = "revisions.move_up"
 key = "j"
 `
-	err := os.WriteFile(filepath.Join(dir, "my-profile.toml"), []byte(profileContent), 0600)
+	err := os.WriteFile(filepath.Join(dir, "my-profile.toml"), []byte(profileContent), 0o600)
 	require.NoError(t, err)
 
 	configContent := `bindings_profile = "my-profile.toml"`
@@ -374,7 +397,7 @@ action = "revisions.move_down"
 key = "k"
 `
 	profilePath := filepath.Join(dir, "abs-profile.toml")
-	err := os.WriteFile(profilePath, []byte(profileContent), 0600)
+	err := os.WriteFile(profilePath, []byte(profileContent), 0o600)
 	require.NoError(t, err)
 
 	// Use an absolute path — baseDir should be irrelevant
@@ -431,7 +454,7 @@ limit = 99
 [ui]
 auto_refresh_interval = 30
 `
-	require.NoError(t, os.WriteFile(filepath.Join(envDir, "config.toml"), []byte(envConfig), 0600))
+	require.NoError(t, os.WriteFile(filepath.Join(envDir, "config.toml"), []byte(envConfig), 0o600))
 	t.Setenv("JJUI_CONFIG_DIR", envDir)
 
 	// Simulate what main.go does when JJUI_CONFIG_DIR is set:

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -3,6 +3,7 @@ package ui
 import (
 	"fmt"
 	"log"
+	"path/filepath"
 	"slices"
 	"strings"
 	"time"
@@ -809,8 +810,12 @@ func (w *wrapper) View() tea.View {
 	}
 	v := tea.NewView(w.cachedFrame)
 	v.Cursor = w.cachedCursor
-	if config.Current.UI.SetWindowTitle {
-		v.WindowTitle = fmt.Sprintf("jjui - %s", w.ui.context.Location)
+	if config.Current.UI.SetWindowTitle != config.WindowTitleOff {
+		title := w.ui.context.Location
+		if config.Current.UI.SetWindowTitle == config.WindowTitleBase {
+			title = filepath.Base(title)
+		}
+		v.WindowTitle = fmt.Sprintf("jjui - %s", title)
 	}
 	v.AltScreen = true
 	v.ReportFocus = true

--- a/internal/ui/ui_test.go
+++ b/internal/ui/ui_test.go
@@ -108,21 +108,60 @@ const testLogOutput = "○  _PREFIX:abc123_PREFIX:def456 \x1b[1m\x1b[38;5;5mchil
 func TestWrapperView_SetsWindowTitleWhenEnabled(t *testing.T) {
 	origSetWindowTitle := config.Current.UI.SetWindowTitle
 	t.Cleanup(func() { config.Current.UI.SetWindowTitle = origSetWindowTitle })
-	config.Current.UI.SetWindowTitle = true
+	config.Current.UI.SetWindowTitle = config.WindowTitleFull
 
-	ctx := test.NewTestContext(test.NewTestCommandRunner(t))
-	ctx.Location = "/tmp/repo"
-	w := &wrapper{ui: &Model{context: ctx}, cachedFrame: "frame"}
+	tests := []struct {
+		name     string
+		location string
+		expected string
+	}{
+		{"simple", "/tmp/repo", "jjui - /tmp/repo"},
+		{"nested", "/tmp/foo/bar/repo", "jjui - /tmp/foo/bar/repo"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := test.NewTestContext(test.NewTestCommandRunner(t))
+			ctx.Location = tt.location
+			w := &wrapper{ui: &Model{context: ctx}, cachedFrame: "frame"}
 
-	view := w.View()
+			view := w.View()
 
-	assert.Equal(t, "jjui - /tmp/repo", view.WindowTitle)
+			assert.Equal(t, tt.expected, view.WindowTitle)
+		})
+	}
+}
+
+func TestWrapperView_SetsWindowTitleToBaseNameWhenConfigured(t *testing.T) {
+	origSetWindowTitle := config.Current.UI.SetWindowTitle
+	t.Cleanup(func() { config.Current.UI.SetWindowTitle = origSetWindowTitle })
+	config.Current.UI.SetWindowTitle = config.WindowTitleBase
+
+	tests := []struct {
+		name     string
+		location string
+		expected string
+	}{
+		{"simple", "/tmp/repo", "jjui - repo"},
+		{"nested", "/tmp/foo/bar/repo", "jjui - repo"},
+		{"trailing slash", "/tmp/repo/", "jjui - repo"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := test.NewTestContext(test.NewTestCommandRunner(t))
+			ctx.Location = tt.location
+			w := &wrapper{ui: &Model{context: ctx}, cachedFrame: "frame"}
+
+			view := w.View()
+
+			assert.Equal(t, tt.expected, view.WindowTitle)
+		})
+	}
 }
 
 func TestWrapperView_LeavesWindowTitleEmptyWhenDisabled(t *testing.T) {
 	origSetWindowTitle := config.Current.UI.SetWindowTitle
 	t.Cleanup(func() { config.Current.UI.SetWindowTitle = origSetWindowTitle })
-	config.Current.UI.SetWindowTitle = false
+	config.Current.UI.SetWindowTitle = config.WindowTitleOff
 
 	ctx := test.NewTestContext(test.NewTestCommandRunner(t))
 	ctx.Location = "/tmp/repo"


### PR DESCRIPTION
By default jjui shows `jjui - full/path/to/repo` in the title. You can turn that off by setting `ui.set_window_title`  to `false`, which then just shows `jjui`.

This PR adds the ability to set `ui.set_window_title` to `"base"` or `"full"` (which is the same as `true`). 

This results in a significantly cleaner title, especially when many tabs are open and you therefore cant even see the base dir in the title

Before:
<img width="1254" height="88" alt="Screenshot_2026-09-02_11-23-14" src="https://github.com/user-attachments/assets/64de5379-ec71-4931-ab40-f933ecabca00" />

After:
<img width="1186" height="89" alt="Screenshot_2026-09-02_11-22-49" src="https://github.com/user-attachments/assets/6d49c028-4db6-40e6-ba68-82e04f3543fa" />


Seems like it resolves the now-closed https://github.com/idursun/jjui/issues/68