### PR TITLE
lua: add footer help and prompt to choose filter

### DIFF
--- a/internal/ui/choose/choose.go
+++ b/internal/ui/choose/choose.go
@@ -61,7 +61,12 @@ func NewWithTitle(options []string, title string) *Model {
 
 func NewWithOptions(options []string, title string, ordered bool) *Model {
 	ti := textinput.New()
-	ti.Prompt = "/"
+	ti.Prompt = "filter: "
+	is := ti.Styles()
+	is.Focused.Prompt = common.DefaultPalette.Get("help", "", "shortcut", false)
+	is.Blurred.Prompt = common.DefaultPalette.Get("help", "", "shortcut", false)
+	ti.SetStyles(is)
+	ti.Placeholder = ""
 	ti.CharLimit = 100
 	ti.SetWidth(20)
 	ti.SetVirtualCursor(false)


### PR DESCRIPTION
minor update on the prompt showing in `choose` menu:

#### before
<img width="526" height="309" alt="image" src="https://github.com/user-attachments/assets/516ea4ce-6cef-4a35-8046-afcf3343108f" />

#### after 
<img width="526" height="309" alt="image" src="https://github.com/user-attachments/assets/63ddf2f2-02c4-45a2-b8e4-6ac182881abb" />
